### PR TITLE
ci: sync Cargo.lock on release-please PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,8 +11,49 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  sync-cargo-lock:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.pr }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release PR branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_JSON: ${{ needs.release-please.outputs.pr }}
+        run: |
+          pr_number=$(jq -r '.number' <<< "$PR_JSON")
+          pr_branch=$(gh pr view "$pr_number" --repo "${{ github.repository }}" --json headRefName -q .headRefName)
+          echo "branch=$pr_branch" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Sync Cargo.lock with bumped Cargo.toml
+        working-directory: src-tauri
+        run: cargo update --workspace --offline || cargo update --workspace
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet src-tauri/Cargo.lock; then
+            echo "Cargo.lock already in sync"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src-tauri/Cargo.lock
+          git commit -m "chore: sync Cargo.lock with release version"
+          git push


### PR DESCRIPTION
## Summary
- Add a `sync-cargo-lock` job to `.github/workflows/release-please.yml` that runs after `release-please-action` and only when a release PR exists.
- The job resolves the PR branch via `gh`, checks it out, runs `cargo update --workspace` in `src-tauri/` to align `Cargo.lock` with the bumped `Cargo.toml`, and pushes the change back to the same release PR.

## Why
The current config bumps `src-tauri/Cargo.toml` via release-please's `extra-files`, but `Cargo.lock` is left at the prior version. After the 0.1.1 release this required a manual `chore: update excelerate version to 0.1.1 in Cargo.lock` commit on `main`. This automates that step.

## Notes
- No infinite loop: pushes via `GITHUB_TOKEN` don't retrigger workflows, and the push targets the release branch (workflow only triggers on `main`).
- `cargo update --workspace --offline` is tried first; falls back to online mode if cargo decides it needs the index.
- Existing open release PRs (if any) will get the lockfile sync on the next `main` push that prompts release-please to update the PR.

## Test plan
- [ ] Merge and wait for the next release-please PR to verify `Cargo.lock` is updated automatically.
- [ ] Confirm no regression: release-please still produces the release PR / release tag as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)