### PR TITLE
feat: improve unmatched deals handling and parser refinements

### DIFF
--- a/docs/parsers.md
+++ b/docs/parsers.md
@@ -32,9 +32,11 @@ Format: XLSX only. Detects sheet by name containing `"R&H"` or `"White Rabbit"`.
 | merchant_name | Column D (Business Name) |
 | gross | Derived: net / (1 − fee_rate) |
 | fee | Derived: gross × fee_rate |
-| net | Sum of all "Total Paid" columns (detected from headers) |
+| net | Sum of the report's weekly "Total Paid" columns |
 
 fee_rate comes from column Q (Management Fee %).
+
+**Which "Total Paid" weeks are summed:** BIG highlights the report's weeks yellow and sums them in a grand-total formula (e.g. `=BH374+BP374+BX374+CF374+CN374`). The parser reads that additive formula and sums exactly those columns — this stays correct when a report's weeks straddle a calendar-month boundary (the trailing week can end in the prior month). If no such formula is present, it falls back to selecting "Total Paid" columns whose end-date falls in the report month.
 
 No required-columns validation — layout is positional.
 

--- a/src-tauri/src/parsers/big_parser.rs
+++ b/src-tauri/src/parsers/big_parser.rs
@@ -40,6 +40,71 @@ impl BigParser {
         Some((year, month))
     }
 
+    /// Convert spreadsheet column letters (e.g. "BH") to a 0-based column index.
+    fn column_letters_to_index(letters: &str) -> Option<usize> {
+        if letters.is_empty() {
+            return None;
+        }
+        let mut idx: usize = 0;
+        for ch in letters.chars() {
+            if !ch.is_ascii_uppercase() {
+                return None;
+            }
+            idx = idx * 26 + (ch as usize - 'A' as usize + 1);
+        }
+        Some(idx - 1)
+    }
+
+    /// Parse a grand-total formula of the form "BH374+BP374+BX374+CF374+CN374"
+    /// (a leading "=" is optional) into the 0-based column indices it references.
+    /// Returns None unless the text is a pure sum of at least two plain cell
+    /// references, so `=SUM(...)` and single-cell formulas are ignored.
+    fn parse_additive_formula_columns(formula: &str) -> Option<Vec<usize>> {
+        let cleaned: String = formula.chars().filter(|c| !c.is_whitespace()).collect();
+        let body = cleaned.strip_prefix('=').unwrap_or(&cleaned);
+        let terms: Vec<&str> = body.split('+').collect();
+        if terms.len() < 2 {
+            return None;
+        }
+        let mut columns = Vec::new();
+        for term in terms {
+            // Each term must be a plain cell reference: letters then digits,
+            // with no absolute markers, ranges, or function calls.
+            let split_at = term.find(|c: char| c.is_ascii_digit())?;
+            let (letters, digits) = term.split_at(split_at);
+            if digits.chars().any(|c| !c.is_ascii_digit()) {
+                return None;
+            }
+            let col = Self::column_letters_to_index(letters)?;
+            if !columns.contains(&col) {
+                columns.push(col);
+            }
+        }
+        Some(columns)
+    }
+
+    /// Determine the weekly "Total Paid" columns that make up this report by
+    /// reading the sheet's grand-total formula (e.g. "=BH374+BP374+…+CN374").
+    /// BIG highlights those columns yellow and sums them into the reported
+    /// total, so this is the authoritative column set — it stays correct even
+    /// when a report's weeks straddle a calendar-month boundary (the reason a
+    /// pure month filter can drop a trailing week). Returns None when no such
+    /// formula exists, in which case the caller falls back to month detection.
+    fn report_columns_from_formula(
+        &self,
+        file_path: &Path,
+        sheet_name: &str,
+    ) -> Option<Vec<usize>> {
+        let mut workbook: Xlsx<_> = open_workbook(file_path).ok()?;
+        let formulas = workbook.worksheet_formula(sheet_name).ok()?;
+        for (_row, _col, text) in formulas.used_cells() {
+            if let Some(cols) = Self::parse_additive_formula_columns(text) {
+                return Some(cols);
+            }
+        }
+        None
+    }
+
     /// Parse the end-date out of a "Total Paid m/d/yy - m/d/yy" header.
     /// Returns (year, month) of the end date. Two-digit years are mapped to 2000+yy.
     fn parse_total_paid_end_date(header: &str) -> Option<(i32, u32)> {
@@ -140,26 +205,46 @@ impl BigParser {
             .nth(header_row_idx)
             .ok_or_else(|| ParserError::ProcessingError("Header row not found".to_string()))?;
 
-        // Collect all "Total Paid" weekly columns. When a report month is set,
-        // restrict to columns whose end-date falls within that month so we don't
-        // sum every historical week in the workbook.
-        let target_year_month = self.report_year_month();
-        let total_paid_columns: Vec<usize> = header_row
+        // All "Total Paid" weekly columns, paired with their header text.
+        let total_paid_headers: Vec<(usize, String)> = header_row
             .iter()
             .enumerate()
-            .filter(|(_, cell)| {
+            .filter_map(|(idx, cell)| {
                 let text = cell.to_string();
-                if !text.trim().to_lowercase().starts_with("total paid") {
-                    return false;
-                }
-                match (target_year_month, Self::parse_total_paid_end_date(&text)) {
-                    (Some(target), Some(end)) => end == target,
-                    (Some(_), None) => false,
-                    (None, _) => true,
+                if text.trim().to_lowercase().starts_with("total paid") {
+                    Some((idx, text))
+                } else {
+                    None
                 }
             })
-            .map(|(idx, _)| idx)
             .collect();
+
+        // Primary: the columns BIG sums in its own grand-total formula (the
+        // yellow-highlighted weeks), keeping only genuine "Total Paid" columns
+        // so a stray additive formula elsewhere can't leak in. Fall back to the
+        // month-based filter when the report has no such formula.
+        let target_year_month = self.report_year_month();
+        let total_paid_columns: Vec<usize> = self
+            .report_columns_from_formula(file_path, sheet_name)
+            .map(|cols| {
+                cols.into_iter()
+                    .filter(|c| total_paid_headers.iter().any(|(idx, _)| idx == c))
+                    .collect::<Vec<usize>>()
+            })
+            .filter(|cols| !cols.is_empty())
+            .unwrap_or_else(|| {
+                total_paid_headers
+                    .iter()
+                    .filter(|(_, text)| {
+                        match (target_year_month, Self::parse_total_paid_end_date(text)) {
+                            (Some(target), Some(end)) => end == target,
+                            (Some(_), None) => false,
+                            (None, _) => true,
+                        }
+                    })
+                    .map(|(idx, _)| *idx)
+                    .collect()
+            });
 
         if total_paid_columns.is_empty() {
             let msg = match target_year_month {
@@ -378,5 +463,37 @@ mod tests {
     fn report_year_month_none_when_unset() {
         let p = BigParser::new();
         assert_eq!(p.report_year_month(), None);
+    }
+
+    #[test]
+    fn column_letters_convert_to_zero_based_index() {
+        assert_eq!(BigParser::column_letters_to_index("A"), Some(0));
+        assert_eq!(BigParser::column_letters_to_index("Z"), Some(25));
+        assert_eq!(BigParser::column_letters_to_index("AA"), Some(26));
+        assert_eq!(BigParser::column_letters_to_index("BH"), Some(59));
+        assert_eq!(BigParser::column_letters_to_index("CN"), Some(91));
+    }
+
+    #[test]
+    fn grand_total_formula_yields_all_referenced_columns() {
+        // BH=59, BP=67, BX=75, CF=83, CN=91 — the trailing CN week ends in the
+        // prior month yet must still be summed.
+        assert_eq!(
+            BigParser::parse_additive_formula_columns("=BH374+BP374+BX374+CF374+CN374"),
+            Some(vec![59, 67, 75, 83, 91])
+        );
+    }
+
+    #[test]
+    fn additive_formula_parse_ignores_sum_and_single_refs() {
+        assert_eq!(
+            BigParser::parse_additive_formula_columns("=SUM(BH2:BH373)"),
+            None
+        );
+        assert_eq!(BigParser::parse_additive_formula_columns("=BH374"), None);
+        assert_eq!(
+            BigParser::parse_additive_formula_columns("=BH:BH+BP:BP"),
+            None
+        );
     }
 }

--- a/src-tauri/src/parsers/clearview_monthly_parser.rs
+++ b/src-tauri/src/parsers/clearview_monthly_parser.rs
@@ -7,10 +7,10 @@ use std::path::Path;
 ///
 /// The file has 4 sheets with two different schemas:
 ///
-/// LendSaaS sheets ("R&H LendSaaS", "WR LendSaaS"):
+/// LendSaaS sheets ("AL LENDSAAS", "WR LendSaas"):
 ///   key cols: Deal ID, Gross Payable, Management Fee, Net Payment
 ///
-/// Centrex sheets ("R&H Centrex", "WR Centrex"):
+/// Centrex sheets ("AL Centrex", "WR CENTREX"):
 ///   key cols: Advance ID, Payable Amt (Gross), Servicing Fee $, Payable Amt (Net)
 ///
 /// Merchant name is not present in either sheet format.
@@ -26,13 +26,41 @@ impl ClearViewMonthlyParser {
         }
     }
 
-    fn sheet_names(&self) -> (&'static str, &'static str) {
+    /// Lowercase substring patterns identifying which sheets belong to this parser's
+    /// portfolio. ClearView has changed the human-readable naming over time
+    /// (e.g. Alder sheets have been prefixed "R&H", "AL", or "Alder"), so we match
+    /// by substring rather than an exact sheet name. Note the Alder sheet prefix is
+    /// "AL"/"R&H" in the sheet name even though the Syndicator column reads
+    /// "R&H Capital Management LLC".
+    fn portfolio_patterns(&self) -> &'static [&'static str] {
         if self.portfolio_name == "White Rabbit" {
-            ("WR LENDSAAS", "WR CENTREX")
+            &["wr", "white rabbit"]
         } else {
-            // Default to Alder / R&H
-            ("R&H LENDSAAS", "R&H CENTREX")
+            &["al ", "alder", "r&h"]
         }
+    }
+
+    fn find_sheet(
+        &self,
+        workbook: &Xlsx<std::io::BufReader<std::fs::File>>,
+        sheet_type: &str,
+    ) -> ParserResult<String> {
+        let needle = sheet_type.to_lowercase();
+        let patterns = self.portfolio_patterns();
+        let names = workbook.sheet_names();
+        names
+            .iter()
+            .find(|name| {
+                let lower = name.to_lowercase();
+                lower.contains(&needle) && patterns.iter().any(|p| lower.contains(p))
+            })
+            .cloned()
+            .ok_or_else(|| {
+                ParserError::ProcessingError(format!(
+                    "No {} sheet found for {} in ClearView monthly file. Available sheets: {:?}",
+                    sheet_type, self.portfolio_name, names
+                ))
+            })
     }
 
     pub fn validate_file_structure(&self, file_path: &Path) -> bool {
@@ -40,11 +68,8 @@ impl ClearViewMonthlyParser {
             Ok(wb) => wb,
             Err(_) => return false,
         };
-        let names = workbook.sheet_names();
-        let required = ["R&H LENDSAAS", "WR LENDSAAS", "R&H CENTREX", "WR CENTREX"];
-        required
-            .iter()
-            .all(|r| names.iter().any(|n| n.eq_ignore_ascii_case(r)))
+        self.find_sheet(&workbook, "lendsaas").is_ok()
+            && self.find_sheet(&workbook, "centrex").is_ok()
     }
 
     fn parse_lendsaas_sheet(
@@ -142,27 +167,12 @@ impl ClearViewMonthlyParser {
     }
 
     pub fn process(&self, file_path: &Path) -> ParserResult<PivotTable> {
-        let (lendsaas_sheet, centrex_sheet) = self.sheet_names();
-
         let mut workbook: Xlsx<_> = open_workbook(file_path).map_err(|_| {
             ParserError::ProcessingError("Failed to open ClearView monthly Excel file".to_string())
         })?;
 
-        let resolve = |wanted: &str| -> ParserResult<String> {
-            workbook
-                .sheet_names()
-                .iter()
-                .find(|n| n.eq_ignore_ascii_case(wanted))
-                .cloned()
-                .ok_or_else(|| {
-                    ParserError::ProcessingError(format!(
-                        "Sheet '{}' not found in ClearView monthly file",
-                        wanted
-                    ))
-                })
-        };
-        let lendsaas_actual = resolve(lendsaas_sheet)?;
-        let centrex_actual = resolve(centrex_sheet)?;
+        let lendsaas_actual = self.find_sheet(&workbook, "lendsaas")?;
+        let centrex_actual = self.find_sheet(&workbook, "centrex")?;
 
         let mut all_rows: Vec<(String, f64, f64, f64)> = Vec::new();
         all_rows.extend(self.parse_lendsaas_sheet(&mut workbook, &lendsaas_actual)?);

--- a/src/components/portfolio/unmatched-deals-result-modal.tsx
+++ b/src/components/portfolio/unmatched-deals-result-modal.tsx
@@ -28,10 +28,23 @@ interface UnmatchedDealFromUpdate {
   net_amount: number;
 }
 
+interface DuplicateConflictFromUpdate {
+  funder_name: string;
+  sheet_name: string;
+  advance_id: string;
+  internal_advance_id: string;
+  merchant_name: string;
+  date_funded: string;
+  row_index: number;
+  net_amount: number;
+  match_count: number;
+}
+
 interface UnmatchedDealsResultModalProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   unmatchedDeals: UnmatchedDealFromUpdate[];
+  duplicateConflicts?: DuplicateConflictFromUpdate[];
   portfolioName: string;
   reportDate: string;
 }
@@ -40,6 +53,7 @@ export function UnmatchedDealsResultModal({
   isOpen,
   onOpenChange,
   unmatchedDeals,
+  duplicateConflicts = [],
   portfolioName,
   reportDate,
 }: UnmatchedDealsResultModalProps) {
@@ -104,123 +118,200 @@ export function UnmatchedDealsResultModal({
   const totalFees = unmatchedDeals.reduce((sum, deal) => sum + deal.management_fee, 0);
   const totalNet = unmatchedDeals.reduce((sum, deal) => sum + deal.net_amount, 0);
 
+  const hasUnmatched = unmatchedDeals.length > 0;
+  const hasDuplicates = duplicateConflicts.length > 0;
+  const uniqueDuplicateIds = new Set(
+    duplicateConflicts.map((d) => `${d.sheet_name}|${d.advance_id}`)
+  );
+
   return (
     <Modal isOpen={isOpen} onOpenChange={onOpenChange} size="5xl" scrollBehavior="inside">
       <ModalContent>
         {(onClose) => (
           <>
             <ModalHeader className="flex flex-col gap-1">
-              <h2 className="text-2xl font-bold">Unmatched Deals Found</h2>
+              <h2 className="text-2xl font-bold">Reconciliation Required</h2>
               <p className="text-sm text-default-500 font-normal">
-                These deals from funder pivot tables were not found in the portfolio workbook
+                {hasUnmatched && hasDuplicates
+                  ? "Some deals couldn't be matched and some Funder Advance IDs appear on multiple workbook rows."
+                  : hasUnmatched
+                    ? "These deals from funder pivot tables were not found in the portfolio workbook."
+                    : "Some Funder Advance IDs appear on multiple workbook rows and need human reconciliation."}
               </p>
             </ModalHeader>
             <ModalBody>
-              {/* Summary */}
-              <div className="mb-4 p-4 bg-warning-50 dark:bg-warning-100/10 border border-warning-200 dark:border-warning-200/20 rounded-lg">
-                <div className="flex justify-between items-start mb-3">
-                  <div>
-                    <h3 className="text-lg font-semibold mb-2 flex items-center gap-2">
-                      <Icon icon="mdi:alert-circle" className="text-warning" width={24} />
-                      {unmatchedDeals.length} Deal{unmatchedDeals.length !== 1 ? "s" : ""} Not Found
-                      in Workbook
-                    </h3>
-                    <p className="text-sm text-default-600 mb-3">
-                      These deals need to be added to the {portfolioName} portfolio workbook.
-                    </p>
-                    <div className="grid grid-cols-3 gap-4 text-sm">
+              {hasUnmatched && (
+                <>
+                  <div className="mb-4 p-4 bg-warning-50 dark:bg-warning-100/10 border border-warning-200 dark:border-warning-200/20 rounded-lg">
+                    <div className="flex justify-between items-start mb-3">
                       <div>
-                        <span className="text-default-600">Total Gross:</span>
-                        <p className="font-semibold">
-                          $
-                          {totalGross.toLocaleString(undefined, {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          })}
+                        <h3 className="text-lg font-semibold mb-2 flex items-center gap-2">
+                          <Icon icon="mdi:alert-circle" className="text-warning" width={24} />
+                          {unmatchedDeals.length} Deal{unmatchedDeals.length !== 1 ? "s" : ""} Not
+                          Found in Workbook
+                        </h3>
+                        <p className="text-sm text-default-600 mb-3">
+                          These deals need to be added to the {portfolioName} portfolio workbook.
                         </p>
+                        <div className="grid grid-cols-3 gap-4 text-sm">
+                          <div>
+                            <span className="text-default-600">Total Gross:</span>
+                            <p className="font-semibold">
+                              $
+                              {totalGross.toLocaleString(undefined, {
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 2,
+                              })}
+                            </p>
+                          </div>
+                          <div>
+                            <span className="text-default-600">Total Fees:</span>
+                            <p className="font-semibold">
+                              $
+                              {totalFees.toLocaleString(undefined, {
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 2,
+                              })}
+                            </p>
+                          </div>
+                          <div>
+                            <span className="text-default-600">Total Net:</span>
+                            <p className="font-semibold">
+                              $
+                              {totalNet.toLocaleString(undefined, {
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 2,
+                              })}
+                            </p>
+                          </div>
+                        </div>
                       </div>
-                      <div>
-                        <span className="text-default-600">Total Fees:</span>
-                        <p className="font-semibold">
-                          $
-                          {totalFees.toLocaleString(undefined, {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          })}
-                        </p>
-                      </div>
-                      <div>
-                        <span className="text-default-600">Total Net:</span>
-                        <p className="font-semibold">
-                          $
-                          {totalNet.toLocaleString(undefined, {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          })}
-                        </p>
-                      </div>
+                      <Button
+                        color="success"
+                        size="sm"
+                        onPress={exportToCSV}
+                        startContent={<Icon icon="mdi:download" width={18} />}
+                      >
+                        Export CSV
+                      </Button>
                     </div>
                   </div>
-                  <Button
-                    color="success"
-                    size="sm"
-                    onPress={exportToCSV}
-                    startContent={<Icon icon="mdi:download" width={18} />}
-                  >
-                    Export CSV
-                  </Button>
-                </div>
-              </div>
 
-              {/* Results Table */}
-              <div className="overflow-x-auto">
-                <Table aria-label="Unmatched deals table" isStriped>
-                  <TableHeader>
-                    <TableColumn>FUNDER</TableColumn>
-                    <TableColumn>SHEET</TableColumn>
-                    <TableColumn>ADVANCE ID</TableColumn>
-                    <TableColumn>MERCHANT NAME</TableColumn>
-                    <TableColumn align="end">GROSS</TableColumn>
-                    <TableColumn align="end">FEE</TableColumn>
-                    <TableColumn align="end">NET</TableColumn>
-                  </TableHeader>
-                  <TableBody>
-                    {unmatchedDeals.map((deal, index) => (
-                      <TableRow key={index}>
-                        <TableCell>
-                          <Chip size="sm" variant="flat" color="primary">
-                            {deal.funder_name}
-                          </Chip>
-                        </TableCell>
-                        <TableCell className="text-sm">{deal.sheet_name}</TableCell>
-                        <TableCell className="font-mono text-sm">{deal.advance_id}</TableCell>
-                        <TableCell className="font-medium">{deal.merchant_name}</TableCell>
-                        <TableCell className="text-right font-mono text-sm">
-                          $
-                          {deal.gross_amount.toLocaleString(undefined, {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          })}
-                        </TableCell>
-                        <TableCell className="text-right font-mono text-sm">
-                          $
-                          {deal.management_fee.toLocaleString(undefined, {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          })}
-                        </TableCell>
-                        <TableCell className="text-right font-mono text-sm">
-                          $
-                          {deal.net_amount.toLocaleString(undefined, {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          })}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
+                  {/* Results Table */}
+                  <div className="overflow-x-auto">
+                    <Table aria-label="Unmatched deals table" isStriped>
+                      <TableHeader>
+                        <TableColumn>FUNDER</TableColumn>
+                        <TableColumn>SHEET</TableColumn>
+                        <TableColumn>ADVANCE ID</TableColumn>
+                        <TableColumn>MERCHANT NAME</TableColumn>
+                        <TableColumn align="end">GROSS</TableColumn>
+                        <TableColumn align="end">FEE</TableColumn>
+                        <TableColumn align="end">NET</TableColumn>
+                      </TableHeader>
+                      <TableBody>
+                        {unmatchedDeals.map((deal, index) => (
+                          <TableRow key={index}>
+                            <TableCell>
+                              <Chip size="sm" variant="flat" color="primary">
+                                {deal.funder_name}
+                              </Chip>
+                            </TableCell>
+                            <TableCell className="text-sm">{deal.sheet_name}</TableCell>
+                            <TableCell className="font-mono text-sm">{deal.advance_id}</TableCell>
+                            <TableCell className="font-medium">{deal.merchant_name}</TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              $
+                              {deal.gross_amount.toLocaleString(undefined, {
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 2,
+                              })}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              $
+                              {deal.management_fee.toLocaleString(undefined, {
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 2,
+                              })}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              $
+                              {deal.net_amount.toLocaleString(undefined, {
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 2,
+                              })}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </>
+              )}
+
+              {hasDuplicates && (
+                <div className={`${hasUnmatched ? "mt-6" : ""}`}>
+                  <div className="mb-4 p-4 bg-danger-50 dark:bg-danger-100/10 border border-danger-200 dark:border-danger-200/20 rounded-lg">
+                    <h3 className="text-lg font-semibold mb-2 flex items-center gap-2">
+                      <Icon icon="mdi:content-duplicate" className="text-danger" width={24} />
+                      {uniqueDuplicateIds.size} Funder Advance ID
+                      {uniqueDuplicateIds.size !== 1 ? "s" : ""} with Multiple Rows (
+                      {duplicateConflicts.length} rows total)
+                    </h3>
+                    <p className="text-sm text-default-600">
+                      Net RTR was <strong>not written</strong> for these rows because the same
+                      Funder Advance ID maps to multiple positions in the {portfolioName} workbook
+                      (e.g. an original deal plus add-ons). Reconcile manually before re-running.
+                    </p>
+                  </div>
+                  <div className="overflow-x-auto">
+                    <Table aria-label="Duplicate funder advance ids" isStriped>
+                      <TableHeader>
+                        <TableColumn>FUNDER</TableColumn>
+                        <TableColumn>SHEET</TableColumn>
+                        <TableColumn>FUNDER ADV ID</TableColumn>
+                        <TableColumn>WORKBOOK ADV ID</TableColumn>
+                        <TableColumn>MERCHANT</TableColumn>
+                        <TableColumn>DATE FUNDED</TableColumn>
+                        <TableColumn align="end">ROW</TableColumn>
+                        <TableColumn align="end">PIVOT NET</TableColumn>
+                      </TableHeader>
+                      <TableBody>
+                        {duplicateConflicts.map((dup, index) => (
+                          <TableRow key={index}>
+                            <TableCell>
+                              <Chip size="sm" variant="flat" color="primary">
+                                {dup.funder_name}
+                              </Chip>
+                            </TableCell>
+                            <TableCell className="text-sm">{dup.sheet_name}</TableCell>
+                            <TableCell className="font-mono text-sm">{dup.advance_id}</TableCell>
+                            <TableCell className="font-mono text-sm">
+                              {dup.internal_advance_id || "—"}
+                            </TableCell>
+                            <TableCell className="font-medium">
+                              {dup.merchant_name || "—"}
+                            </TableCell>
+                            <TableCell className="text-sm">
+                              {dup.date_funded ? dup.date_funded.split("T")[0] : "—"}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              {dup.row_index}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              $
+                              {dup.net_amount.toLocaleString(undefined, {
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 2,
+                              })}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </div>
+              )}
             </ModalBody>
             <ModalFooter>
               <Button color="primary" onPress={onClose}>

--- a/src/pages/alder-portfolio.tsx
+++ b/src/pages/alder-portfolio.tsx
@@ -88,6 +88,19 @@ function AlderPortfolio() {
       net_amount: number;
     }>
   >([]);
+  const [duplicateConflicts, setDuplicateConflicts] = useState<
+    Array<{
+      funder_name: string;
+      sheet_name: string;
+      advance_id: string;
+      internal_advance_id: string;
+      merchant_name: string;
+      date_funded: string;
+      row_index: number;
+      net_amount: number;
+      match_count: number;
+    }>
+  >([]);
 
   useEffect(() => {
     const loadActiveVersion = async () => {
@@ -238,12 +251,17 @@ function AlderPortfolio() {
         selectedDate.toString()
       );
       if (response.success) {
-        if (response.unmatched_deals && response.unmatched_deals.length > 0) {
-          setUnmatchedDeals(response.unmatched_deals);
+        const unmatched = response.unmatched_deals ?? [];
+        const duplicates = response.duplicate_conflicts ?? [];
+        setUnmatchedDeals(unmatched);
+        setDuplicateConflicts(duplicates);
+        if (unmatched.length > 0 || duplicates.length > 0) {
           setUnmatchedDealsModalOpen(true);
-          alert(
-            `Portfolio updated! ${response.unmatched_count} unmatched deals found. Please review.`
-          );
+          const parts: string[] = [];
+          if (unmatched.length > 0) parts.push(`${unmatched.length} unmatched deals`);
+          if (duplicates.length > 0)
+            parts.push(`${duplicates.length} rows with duplicate Funder Advance IDs`);
+          alert(`Portfolio updated! ${parts.join(" and ")} found. Please review.`);
         } else {
           alert("Portfolio updated successfully with Net RTR values! All deals matched.");
         }
@@ -352,6 +370,7 @@ function AlderPortfolio() {
         isOpen={unmatchedDealsModalOpen}
         onOpenChange={setUnmatchedDealsModalOpen}
         unmatchedDeals={unmatchedDeals}
+        duplicateConflicts={duplicateConflicts}
         portfolioName={PORTFOLIO}
         reportDate={selectedDate?.toString() || ""}
       />

--- a/src/pages/white-rabbit-portfolio.tsx
+++ b/src/pages/white-rabbit-portfolio.tsx
@@ -82,6 +82,19 @@ function WhiteRabbitPortfolio() {
       net_amount: number;
     }>
   >([]);
+  const [duplicateConflicts, setDuplicateConflicts] = useState<
+    Array<{
+      funder_name: string;
+      sheet_name: string;
+      advance_id: string;
+      internal_advance_id: string;
+      merchant_name: string;
+      date_funded: string;
+      row_index: number;
+      net_amount: number;
+      match_count: number;
+    }>
+  >([]);
 
   useEffect(() => {
     const loadActiveVersion = async () => {
@@ -232,12 +245,17 @@ function WhiteRabbitPortfolio() {
         selectedDate.toString()
       );
       if (response.success) {
-        if (response.unmatched_deals && response.unmatched_deals.length > 0) {
-          setUnmatchedDeals(response.unmatched_deals);
+        const unmatched = response.unmatched_deals ?? [];
+        const duplicates = response.duplicate_conflicts ?? [];
+        setUnmatchedDeals(unmatched);
+        setDuplicateConflicts(duplicates);
+        if (unmatched.length > 0 || duplicates.length > 0) {
           setUnmatchedDealsModalOpen(true);
-          alert(
-            `Portfolio updated! ${response.unmatched_count} unmatched deals found. Please review.`
-          );
+          const parts: string[] = [];
+          if (unmatched.length > 0) parts.push(`${unmatched.length} unmatched deals`);
+          if (duplicates.length > 0)
+            parts.push(`${duplicates.length} rows with duplicate Funder Advance IDs`);
+          alert(`Portfolio updated! ${parts.join(" and ")} found. Please review.`);
         } else {
           alert("Portfolio updated successfully with Net RTR values! All deals matched.");
         }
@@ -346,6 +364,7 @@ function WhiteRabbitPortfolio() {
         isOpen={unmatchedDealsModalOpen}
         onOpenChange={setUnmatchedDealsModalOpen}
         unmatchedDeals={unmatchedDeals}
+        duplicateConflicts={duplicateConflicts}
         portfolioName={PORTFOLIO}
         reportDate={selectedDate?.toString() || ""}
       />

--- a/src/services/file-service.ts
+++ b/src/services/file-service.ts
@@ -56,6 +56,18 @@ export interface UpdateWithNetRtrResponse extends UploadResponse {
     net_amount: number;
   }>;
   unmatched_count?: number;
+  duplicate_conflicts?: Array<{
+    funder_name: string;
+    sheet_name: string;
+    advance_id: string;
+    internal_advance_id: string;
+    merchant_name: string;
+    date_funded: string;
+    row_index: number;
+    net_amount: number;
+    match_count: number;
+  }>;
+  duplicate_count?: number;
 }
 
 export class FileService {
@@ -278,21 +290,39 @@ export class FileService {
         reportDate
       );
 
-      // Log unmatched deals if any
       if (result.unmatchedDeals && result.unmatchedDeals.length > 0) {
         console.warn(
           `Found ${result.unmatchedDeals.length} unmatched deals:`,
           result.unmatchedDeals
         );
       }
+      if (result.duplicateConflicts && result.duplicateConflicts.length > 0) {
+        console.warn(
+          `Found ${result.duplicateConflicts.length} duplicate-id rows requiring reconciliation:`,
+          result.duplicateConflicts
+        );
+      }
 
-      // Return success response with unmatched deals info
+      const messageParts = [
+        `Successfully updated portfolio with Net RTR values for ${reportDate}. File saved successfully.`,
+      ];
+      if (result.unmatchedDeals.length > 0) {
+        messageParts.push(`Found ${result.unmatchedDeals.length} unmatched deals.`);
+      }
+      if (result.duplicateConflicts.length > 0) {
+        messageParts.push(
+          `Skipped ${result.duplicateConflicts.length} rows with duplicate Funder Advance IDs (need human reconciliation).`
+        );
+      }
+
       return {
         success: true,
-        message: `Successfully updated portfolio with Net RTR values for ${reportDate}. File saved successfully.${result.unmatchedDeals.length > 0 ? ` Found ${result.unmatchedDeals.length} unmatched deals.` : ""}`,
+        message: messageParts.join(" "),
         file_path: result.filePath,
         unmatched_deals: result.unmatchedDeals,
         unmatched_count: result.unmatchedDeals.length,
+        duplicate_conflicts: result.duplicateConflicts,
+        duplicate_count: result.duplicateConflicts.length,
       };
     } catch (error) {
       console.error("Error updating portfolio with Net RTR:", error);

--- a/src/services/pyodide-service.ts
+++ b/src/services/pyodide-service.ts
@@ -29,9 +29,22 @@ export interface UnmatchedDealFromUpdate {
   net_amount: number;
 }
 
+export interface DuplicateConflictFromUpdate {
+  funder_name: string;
+  sheet_name: string;
+  advance_id: string;
+  internal_advance_id: string;
+  merchant_name: string;
+  date_funded: string;
+  row_index: number;
+  net_amount: number;
+  match_count: number;
+}
+
 export interface UpdateWorkbookResult {
   filePath: string;
   unmatchedDeals: UnmatchedDealFromUpdate[];
+  duplicateConflicts: DuplicateConflictFromUpdate[];
 }
 
 // Singleton instance of Pyodide
@@ -162,8 +175,9 @@ from copy import copy
 # Parse the pivot tables data
 pivot_tables = json.loads(pivot_tables_json)
 
-# Track unmatched deals across all funders
+# Track unmatched deals and duplicate-id conflicts across all funders
 all_unmatched_deals = []
+all_duplicate_conflicts = []
 
 # Convert JavaScript Uint8Array to Python bytes
 workbook_bytes = bytes(workbook_array.to_py())
@@ -273,52 +287,45 @@ for funder_pivot in pivot_tables:
             cell = ws.cell(row=row, column=net_rtr_col)
             cell.value = None
     else:
-        # Column not found - need to find where to place it
-        # Try to find the previous Friday's column to place after it
-        from datetime import datetime, timedelta
-        
-        # Parse the current date
+        # Column not found - place chronologically among existing Net RTR headers,
+        # ignoring stale/unparseable outliers so column order tracks date order.
+        def parse_net_rtr_date(header):
+            if not header.startswith('Net RTR '):
+                return None
+            parts = header[len('Net RTR '):].strip().split('/')
+            if len(parts) != 3:
+                return None
+            try:
+                mm, dd, yy = int(parts[0]), int(parts[1]), int(parts[2])
+                if yy < 100:
+                    yy += 2000
+                return datetime(yy, mm, dd)
+            except (ValueError, TypeError):
+                return None
+
         date_parts = report_date.split('-')
-        if len(date_parts) == 3:
-            current_date = datetime(int(date_parts[0]), int(date_parts[1]), int(date_parts[2]))
+        new_date = datetime(int(date_parts[0]), int(date_parts[1]), int(date_parts[2]))
 
-            # Look for previous Fridays (up to 4 weeks back)
-            found_previous = False
-            for weeks_back in range(1, 5):
-                previous_friday = current_date - timedelta(days=7 * weeks_back)
-                # Generate the column name for the previous Friday using the same format as generate_net_rtr_column
-                prev_year = previous_friday.year
-                if prev_year >= 2000:
-                    two_digit_year = str(prev_year)[-2:]
-                    prev_col_name = f"Net RTR {previous_friday.month}/{previous_friday.day}/{two_digit_year}"
-                else:
-                    prev_col_name = f"Net RTR {previous_friday.month}/{previous_friday.day}/{str(prev_year).zfill(2)}"
+        dated_cols = [(c, parse_net_rtr_date(h)) for c, h in net_rtr_columns]
+        dated_cols = [(c, d) for c, d in dated_cols if d is not None]
+        older = [(c, d) for c, d in dated_cols if d < new_date]
+        newer = [(c, d) for c, d in dated_cols if d > new_date]
 
-                # Search for this column
-                for col, col_name in net_rtr_columns:
-                    if col_name == prev_col_name:
-                        # Found a previous week - place new column right after it
-                        net_rtr_col = col + 1
-                        print(f"Found previous week column '{prev_col_name}' at {col}, placing new column at {net_rtr_col}")
-                        found_previous = True
-                        break
+        if older:
+            anchor_col, anchor_date = max(older, key=lambda x: x[1])
+            net_rtr_col = anchor_col + 1
+            print(f"Placing after latest-older Net RTR col {anchor_col} ({anchor_date.strftime('%m/%d/%Y')}) at {net_rtr_col}")
+        elif newer:
+            anchor_col, anchor_date = min(newer, key=lambda x: x[1])
+            net_rtr_col = anchor_col
+            print(f"Placing before earliest-newer Net RTR col {anchor_col} ({anchor_date.strftime('%m/%d/%Y')}) at {net_rtr_col}")
+        elif last_net_rtr_col > 0:
+            net_rtr_col = last_net_rtr_col + 1
+            print(f"No parseable Net RTR dates; placing after last Net RTR col at {net_rtr_col}")
+        else:
+            net_rtr_col = last_data_col + 1
+            print(f"No Net RTR columns; placing after last data col at {net_rtr_col}")
 
-                if found_previous:
-                    break
-        
-        # If no previous Friday found or date parsing failed, place after last Net RTR column
-        if net_rtr_col is None:
-            if last_net_rtr_col > 0:
-                # Add after the last Net RTR column without any artificial cap
-                net_rtr_col = last_net_rtr_col + 1
-                print(f"Adding new Net RTR column at {net_rtr_col} (after last Net RTR)")
-            else:
-                # No Net RTR columns exist yet, add after last data column
-                net_rtr_col = last_data_col + 1
-                print(f"Adding first Net RTR column at {net_rtr_col} (after last data)")
-
-        # Insert a new column at the calculated position to avoid overwriting
-        # This shifts all columns to the right from this position
         ws.insert_cols(net_rtr_col)
         print(f"Inserted new column at position {net_rtr_col}")
 
@@ -363,45 +370,72 @@ for funder_pivot in pivot_tables:
         funder_advance_col = 5
         print(f"Using default column 5 for Funder Advance ID")
     
-    for row_idx in range(3, min(ws.max_row + 1, 1000)):  # Limit for safety
-        # Read the Funder Advance ID from the identified column
+    # First pass: bucket Funder Advance ID -> [row_idx, ...] so we can detect duplicates
+    # before writing anything. If one funder id maps to multiple workbook rows (e.g. an
+    # original deal + an add-on tracked as a separate position), writing the same Net
+    # RTR to each row would double-count in the column total, so we skip those and
+    # surface them for human reconciliation instead.
+    id_row_map = {}
+    for row_idx in range(3, min(ws.max_row + 1, 1000)):
         funder_advance_id_cell = ws.cell(row=row_idx, column=funder_advance_col)
-        
         if funder_advance_id_cell.value:
             funder_advance_id = str(funder_advance_id_cell.value).strip()
-            
-            # Collect worksheet IDs for analysis
             worksheet_ids.append(funder_advance_id)
-            
-            # Check if we have a net amount for this advance ID
             if funder_advance_id in net_amount_map:
-                net_amount = net_amount_map[funder_advance_id]
-                matched_ids.append(funder_advance_id)
-                
-                # Write the Net RTR value
-                net_rtr_cell = ws.cell(row=row_idx, column=net_rtr_col, value=net_amount)
-                
-                # Apply currency formatting
-                net_rtr_cell.number_format = '$#,##0.00'
-                
-                # Copy formatting from a nearby financial cell if available (without using deprecated .copy())
-                ref_col = max(7, min(net_rtr_col - 1, last_data_col))  # Use a reasonable reference column
-                ref_cell = ws.cell(row=row_idx, column=ref_col)
-                if ref_cell.font:
-                    net_rtr_cell.font = copy(ref_cell.font)
-                if ref_cell.fill:
-                    net_rtr_cell.fill = copy(ref_cell.fill)
-                if ref_cell.border:
-                    net_rtr_cell.border = copy(ref_cell.border)
-                if ref_cell.alignment:
-                    net_rtr_cell.alignment = copy(ref_cell.alignment)
-                
-                updates_count += 1
-    
-    print(f"Updated {updates_count} rows with Net RTR values")
+                id_row_map.setdefault(funder_advance_id, []).append(row_idx)
 
-    # Find unmatched deals - advance IDs from pivot that weren't matched in worksheet
-    unmatched_advance_ids = set(net_amount_map.keys()) - set(matched_ids)
+    duplicate_advance_ids = set()
+    for fid, row_indices in id_row_map.items():
+        net_amount = net_amount_map[fid]
+        if len(row_indices) > 1:
+            duplicate_advance_ids.add(fid)
+            for r_idx in row_indices:
+                date_val = ws.cell(row=r_idx, column=1).value
+                if hasattr(date_val, 'isoformat'):
+                    date_str = date_val.isoformat()
+                elif date_val is None:
+                    date_str = ''
+                else:
+                    date_str = str(date_val)
+                all_duplicate_conflicts.append({
+                    'funder_name': funder_name,
+                    'sheet_name': sheet_name,
+                    'advance_id': fid,
+                    'internal_advance_id': str(ws.cell(row=r_idx, column=4).value or ''),
+                    'merchant_name': str(ws.cell(row=r_idx, column=2).value or ''),
+                    'date_funded': date_str,
+                    'row_index': r_idx,
+                    'net_amount': net_amount,
+                    'match_count': len(row_indices),
+                })
+            continue
+
+        row_idx = row_indices[0]
+        matched_ids.append(fid)
+        net_rtr_cell = ws.cell(row=row_idx, column=net_rtr_col, value=net_amount)
+        net_rtr_cell.number_format = '$#,##0.00'
+        ref_col = max(7, min(net_rtr_col - 1, last_data_col))
+        ref_cell = ws.cell(row=row_idx, column=ref_col)
+        if ref_cell.font:
+            net_rtr_cell.font = copy(ref_cell.font)
+        if ref_cell.fill:
+            net_rtr_cell.fill = copy(ref_cell.fill)
+        if ref_cell.border:
+            net_rtr_cell.border = copy(ref_cell.border)
+        if ref_cell.alignment:
+            net_rtr_cell.alignment = copy(ref_cell.alignment)
+        updates_count += 1
+
+    print(f"Updated {updates_count} rows with Net RTR values")
+    if duplicate_advance_ids:
+        print(f"WARNING: {len(duplicate_advance_ids)} advance IDs appeared on multiple rows; skipped writing and flagged for reconciliation:")
+        for fid in list(duplicate_advance_ids)[:10]:
+            print(f"  - {fid}")
+
+    # Find unmatched deals - advance IDs from pivot that weren't matched in worksheet.
+    # Exclude duplicates: they DID appear in the workbook but were skipped pending reconciliation,
+    # so they belong in the duplicates list, not the unmatched list.
+    unmatched_advance_ids = set(net_amount_map.keys()) - set(matched_ids) - duplicate_advance_ids
 
     if unmatched_advance_ids:
         print(f"WARNING: {len(unmatched_advance_ids)} advance IDs from pivot table were not found in worksheet:")
@@ -468,11 +502,14 @@ debug_info = {
     'updated_size': len(updated_workbook_bytes),
     'test_size': len(test_bytes),
     'unmatched_deals': all_unmatched_deals,
-    'unmatched_count': len(all_unmatched_deals)
+    'unmatched_count': len(all_unmatched_deals),
+    'duplicate_conflicts': all_duplicate_conflicts,
+    'duplicate_count': len(all_duplicate_conflicts)
 }
 print(f"Updated workbook base64 length: {len(debug_info['updated'])}")
 print(f"Test workbook base64 length: {len(debug_info['test'])}")
 print(f"Total unmatched deals across all funders: {len(all_unmatched_deals)}")
+print(f"Total duplicate-id conflicts across all funders: {len(all_duplicate_conflicts)}")
 
 # Return as JSON string
 import json
@@ -487,8 +524,10 @@ json.dumps(debug_info)
       console.warn("Updated workbook size:", result.updated_size);
       console.warn("Test workbook size:", result.test_size);
       console.warn("Unmatched deals found:", result.unmatched_count);
+      console.warn("Duplicate-id conflicts found:", result.duplicate_count);
 
       const unmatchedDeals: UnmatchedDealFromUpdate[] = result.unmatched_deals || [];
+      const duplicateConflicts: DuplicateConflictFromUpdate[] = result.duplicate_conflicts || [];
 
       // Convert base64 string to Uint8Array for the updated workbook
       const binaryString = atob(result.updated);
@@ -588,6 +627,7 @@ json.dumps(debug_info)
         return {
           filePath,
           unmatchedDeals,
+          duplicateConflicts,
         };
       } else {
         console.warn("User cancelled save dialog");


### PR DESCRIPTION
## Summary

- Refines the BIG and ClearView monthly parsers
- Reworks the unmatched deals result modal and related portfolio pages (Alder, White Rabbit)
- Updates `file-service` and `pyodide-service` supporting logic
- Updates parser docs

## Changes
| Area | Files |
| --- | --- |
| Parsers | `big_parser.rs`, `clearview_monthly_parser.rs` |
| Portfolio UI | `unmatched-deals-result-modal.tsx`, `alder-portfolio.tsx`, `white-rabbit-portfolio.tsx` |
| Services | `file-service.ts`, `pyodide-service.ts` |
| Docs | `parsers.md` |

## Test plan
- [ ] `npm run lint && npm run format:check && npm run build`
- [ ] `cd src-tauri && cargo fmt --check && cargo clippy --all-targets -- -D warnings`
- [ ] Manually verify unmatched deals flow and parser output

🤖 Generated with [Claude Code](https://claude.com/claude-code)