### PR TITLE
feat: Phase 2 cloud saves — pivot commit RPC, Storage uploads, reconciliation UI

### DIFF
--- a/FABLE_PLAN.md
+++ b/FABLE_PLAN.md
@@ -196,12 +196,14 @@ Five migrations (`20260710_phase1_*`), pushed to the live DB and verified (seeds
 - [x] Views (formulas transcribed from a live dump of the deal-sheet/`-P`/portfolio-sheet formulas, not from the prose above): `deal_computed`, `monthly_vintage_stats`, `portfolio_monthly`, `weekly_rtr_matrix`, `funder_allocation_current` — all `security_invoker`. Deviation: portfolio-level weighted term uses cost-basis weighting instead of the sheet's plain `AVERAGE()` across funders
 - [x] RLS via `portfolio_access` on all portfolio-scoped tables (`net_rtr_payments` scopes through `deals`, `funder_pivot_rows` through `funder_pivot_tables`); lookups stay authenticated-read; anon sees nothing
 
-### Phase 2 — Move saves to the cloud (monthly flow)
+### Phase 2 — Move saves to the cloud (monthly flow) ✅ Completed 2026-07-10
 
-- [ ] Keep Rust parsers unchanged; swap persistence: pivot → `funder_pivot_tables` + `funder_pivot_rows`; raw upload file → Supabase Storage
-- [ ] Matched pivot rows insert into `net_rtr_payments` keyed to `deal_id`; existing unmatched-deals modal drives resolution of the rest
-- [ ] **Validation RPC** (the core requirement): a single Postgres function that takes pivot rows + the parser's `total_net`, inserts payments transactionally, and **fails unless `SUM(matched) + SUM(unmatched) = total_net` within a cent tolerance** — the guarantee that what hits the database equals what would have been typed into the workbook's Net RTR column
-- [ ] UI shows the reconciliation (pivot total / matched total / unmatched total) before commit
+Two migrations (`20260710131919/20`), pushed live. RPC logic behaviorally tested in a scratch Postgres 16 cluster (dry-run/commit/re-commit idempotency, duplicate advance-ids, tolerance abort, cross-funder resolve rejection — all pass).
+
+- [x] Parsers unchanged; new `get_pivot_for_report` Tauri command returns rows + parser totals from the local pivot; `pivot-sync-service.ts` pushes raw file → Storage bucket `funder-uploads` (`{portfolio_id}/{funder_id}/{report_date}/{filename}`, per-portfolio RLS on path prefix), upserts `funder_uploads`, then commits the pivot via RPC. **Dual-write**: local SQLite/CSV flow untouched — the Pyodide workbook update still needs it until Phase 5
+- [x] `commit_funder_pivot` matches rows to `deals.funder_advance_id` (scoped to portfolio+funder); ambiguous matches are flagged `duplicate` and skipped, mirroring the workbook updater. `resolve_pivot_row(row_id, deal_id)` RPC + `PivotSyncService.resolveRow` ready for the resolution UI (deals is empty until Phase 3, so everything reports unmatched for now)
+- [x] **Validation RPC**: `SECURITY INVOKER`, two guards — rows-vs-parser-total on entry, matched+unmatched+duplicate = `total_net` (±$0.01) before commit; payments written per-deal with replace-on-re-upload semantics (`source_upload_id` scoped delete + upsert)
+- [x] Reconciliation modal (`pivot-reconciliation-modal.tsx` + `use-cloud-sync.ts`): dry-run first, shows pivot/matched/unmatched/duplicate totals + unmatched rows, then user confirms the real commit. Clear View produces one preview per portfolio from the single upload
 
 ### Phase 3 — One-time workbook import (kills the weekly workbook upload)
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -71,6 +71,13 @@ Schema is managed by CLI migrations in `supabase/migrations/` (`supabase migrati
 - **weekly_rtr_matrix** — the `RTR` sheet in long form (funder × payment date)
 - **funder_allocation_current** — the `R&H-ALDER-P` allocation snapshot
 
+### Functions (Phase 2 write path)
+
+- **commit_funder_pivot(upload_id, rows jsonb, total_gross, total_fee, total_net, dry_run)** — the single write path from parser output to the DB. Replaces the upload's `funder_pivot_tables`/`funder_pivot_rows`, matches rows to `deals` on `funder_advance_id` (scoped to portfolio + funder; ambiguous matches flagged as duplicates), and unless `dry_run` writes `net_rtr_payments` — aborting unless matched + unmatched + duplicate nets equal the parser's `total_net` within a cent. Returns a reconciliation JSON. `SECURITY INVOKER`, so RLS applies.
+- **resolve_pivot_row(row_id, deal_id)** — resolves one unmatched pivot row to a deal and (re)writes that deal's payment for the pivot's report date; idempotent.
+
+Frontend flow (`src/services/pivot-sync-service.ts` + `use-cloud-sync.ts`): after the local save, the raw file goes to the private `funder-uploads` Storage bucket (`{portfolio_id}/{funder_id}/{report_date}/{filename}`, RLS on the first path segment), `funder_uploads` is upserted, then a dry-run of `commit_funder_pivot` feeds the reconciliation modal; confirming re-runs it for real. Clear View syncs both portfolios from one upload.
+
 ### RLS
 
 `has_portfolio_access(portfolio_id)` + `is_admin()` (both `SECURITY DEFINER`) gate all portfolio-scoped tables via `portfolio_access`. Tables without a `portfolio_id` scope through their parent (`net_rtr_payments` via `deals`, `funder_pivot_rows` via `funder_pivot_tables`). Lookups (`funders`, `industries`, `states`) remain readable by any authenticated user; anon sees nothing.
@@ -82,14 +89,14 @@ Schema is managed by CLI migrations in `supabase/migrations/` (`supabase migrati
 | Data | Current owner |
 |------|--------------|
 | Portfolio workbook versions | SQLite |
-| Funder uploads | SQLite (Supabase tables ready, cutover in Phase 2) |
-| Pivot tables | SQLite (Supabase tables ready, cutover in Phase 2) |
+| Funder uploads | Dual-write: SQLite + Supabase (`funder_uploads` + Storage bucket, Phase 2) |
+| Pivot tables | Dual-write: SQLite CSV + Supabase (`funder_pivot_tables`/`_rows` via `commit_funder_pivot`, Phase 2) |
 | Merchant records | SQLite (Supabase table ready, populated in Phase 3) |
-| Deals & payments | Supabase (empty until the Phase 3 workbook import) |
+| Deals & payments | Supabase (`deals` empty until the Phase 3 workbook import; `net_rtr_payments` written by `commit_funder_pivot`) |
 | User profiles & auth | Supabase |
 | Portfolio access control | Supabase (`portfolio_access` + RLS) |
 
-The Supabase schema is complete but the app's write paths still target SQLite. Moving them is Phase 2.
+Phase 2 added the cloud write path alongside the local one. SQLite stays load-bearing (the Pyodide workbook update still reads local pivot CSVs) until the Phase 5 cutover.
 
 ---
 

--- a/docs/tauri-commands.md
+++ b/docs/tauri-commands.md
@@ -43,6 +43,7 @@ Forgetting `generate_handler` registration compiles fine but the frontend `invok
 | `delete_funder_upload` | Deletes upload and its associated pivot table | `file-service.ts` → `deleteFunderUpload` |
 | `get_all_database_files` | Returns all uploaded files from the database | _(not wrapped)_ |
 | `get_pivot_tables_for_update` | Returns pivot tables for a report date | _(not wrapped)_ |
+| `get_pivot_for_report` | Returns one pivot's rows + parser totals for the cloud sync | `pivot-sync-service.ts` → `PivotSyncService` (private helper) |
 
 ---
 

--- a/src-tauri/src/file_handler.rs
+++ b/src-tauri/src/file_handler.rs
@@ -1322,6 +1322,71 @@ pub fn get_pivot_tables_for_update(
     Ok(all_pivot_data)
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct PivotExport {
+    pub rows: Vec<PivotTableData>,
+    pub total_gross: f64,
+    pub total_fee: f64,
+    pub total_net: f64,
+}
+
+/// Return the parsed pivot rows plus the parser's totals for one
+/// (portfolio, funder, report) so the frontend can push them to Supabase.
+/// The totals come from the SQLite record written at parse time, so the
+/// cloud validation RPC compares row sums against the parser's own totals.
+#[tauri::command]
+pub fn get_pivot_for_report(
+    portfolio_name: &str,
+    funder_name: &str,
+    report_date: &str,
+    upload_type: &str,
+) -> Result<Option<PivotExport>, String> {
+    if DB.lock().unwrap().is_none() {
+        init_database()?;
+    }
+
+    let record = {
+        let db_lock = DB.lock().unwrap();
+        let db = db_lock.as_ref().ok_or("Database not initialized")?;
+        db.get_funder_pivot_table(portfolio_name, funder_name, report_date, upload_type)
+            .map_err(|e| format!("Failed to get pivot table record: {}", e))?
+    };
+
+    let Some(record) = record else {
+        return Ok(None);
+    };
+
+    let csv_content = fs::read_to_string(&record.pivot_file_path)
+        .map_err(|e| format!("Failed to read pivot CSV: {}", e))?;
+
+    let mut reader = csv::Reader::from_reader(csv_content.as_bytes());
+    let mut rows = Vec::new();
+
+    for result in reader.records() {
+        let row = result.map_err(|e| format!("Failed to parse pivot CSV: {}", e))?;
+        if row.len() >= 5 {
+            let advance_id = row.get(0).unwrap_or("").to_string();
+            if advance_id == "Totals" {
+                continue;
+            }
+            rows.push(PivotTableData {
+                advance_id,
+                merchant_name: row.get(1).unwrap_or("").to_string(),
+                gross_amount: row.get(2).unwrap_or("0").parse::<f64>().unwrap_or(0.0),
+                management_fee: row.get(3).unwrap_or("0").parse::<f64>().unwrap_or(0.0),
+                net_amount: row.get(4).unwrap_or("0").parse::<f64>().unwrap_or(0.0),
+            });
+        }
+    }
+
+    Ok(Some(PivotExport {
+        rows,
+        total_gross: record.total_gross,
+        total_fee: record.total_fee,
+        total_net: record.total_net,
+    }))
+}
+
 #[tauri::command]
 pub fn get_active_workbook_path(portfolio_name: &str) -> Result<String, String> {
     let base_dir = get_excelerate_dir()?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ pub fn run() {
             file_handler::read_excel_file,
             file_handler::get_merchants_by_portfolio,
             file_handler::get_pivot_tables_for_update,
+            file_handler::get_pivot_for_report,
             file_handler::get_active_workbook_path,
             file_handler::find_unmatched_deals,
             file_handler::find_unmatched_deals_by_portfolio,

--- a/src/components/portfolio/pivot-reconciliation-modal.tsx
+++ b/src/components/portfolio/pivot-reconciliation-modal.tsx
@@ -1,0 +1,142 @@
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Table,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+  Chip,
+} from "@heroui/react";
+import { Icon } from "@iconify/react";
+import { CloudSyncPreview } from "@/services/pivot-sync-service";
+
+interface PivotReconciliationModalProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  previews: CloudSyncPreview[];
+  onCommit: () => void;
+  isCommitting: boolean;
+}
+
+const money = (value: number) =>
+  `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+export function PivotReconciliationModal({
+  isOpen,
+  onOpenChange,
+  previews,
+  onCommit,
+  isCommitting,
+}: PivotReconciliationModalProps) {
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange} size="4xl" scrollBehavior="inside">
+      <ModalContent>
+        {(onClose) => (
+          <>
+            <ModalHeader className="flex flex-col gap-1">
+              <h2 className="text-2xl font-bold">Confirm Cloud Save</h2>
+              <p className="text-sm text-default-500 font-normal">
+                Review the reconciliation before payments are written to the database. Matched and
+                unmatched totals must account for every dollar of the pivot total.
+              </p>
+            </ModalHeader>
+            <ModalBody>
+              {previews.map((preview) => {
+                const r = preview.reconciliation;
+                return (
+                  <div
+                    key={`${preview.portfolioName}-${preview.funderName}`}
+                    className="mb-4 p-4 bg-default-50 border border-default-200 rounded-lg"
+                  >
+                    <div className="flex items-center gap-2 mb-3">
+                      <Chip size="sm" variant="flat" color="primary">
+                        {preview.funderName}
+                      </Chip>
+                      <span className="text-sm font-medium">{preview.portfolioName}</span>
+                      <span className="text-xs text-default-500">{r.report_date}</span>
+                    </div>
+
+                    <div className="grid grid-cols-4 gap-4 text-sm mb-3">
+                      <div>
+                        <span className="text-default-600">Pivot Total (Net):</span>
+                        <p className="font-semibold">{money(r.total_net)}</p>
+                      </div>
+                      <div>
+                        <span className="text-default-600">Matched ({r.matched_count}):</span>
+                        <p className="font-semibold text-success-600">{money(r.matched_net)}</p>
+                      </div>
+                      <div>
+                        <span className="text-default-600">Unmatched ({r.unmatched_count}):</span>
+                        <p className="font-semibold text-warning-600">{money(r.unmatched_net)}</p>
+                      </div>
+                      <div>
+                        <span className="text-default-600">Duplicates ({r.duplicate_count}):</span>
+                        <p className="font-semibold text-danger-600">{money(r.duplicate_net)}</p>
+                      </div>
+                    </div>
+
+                    {r.unmatched_count > 0 && (
+                      <div className="overflow-x-auto">
+                        <Table
+                          aria-label={`Unmatched rows for ${preview.portfolioName} ${preview.funderName}`}
+                          isStriped
+                          removeWrapper
+                        >
+                          <TableHeader>
+                            <TableColumn>ADVANCE ID</TableColumn>
+                            <TableColumn>MERCHANT</TableColumn>
+                            <TableColumn align="end">NET</TableColumn>
+                          </TableHeader>
+                          <TableBody>
+                            {r.unmatched.map((row) => (
+                              <TableRow key={row.row_id}>
+                                <TableCell className="font-mono text-sm">
+                                  {row.advance_id || "—"}
+                                </TableCell>
+                                <TableCell className="font-medium">{row.merchant_name}</TableCell>
+                                <TableCell className="text-right font-mono text-sm">
+                                  {money(row.net)}
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                        <p className="text-xs text-default-500 mt-2">
+                          Unmatched rows are saved with the pivot and can be resolved to deals later
+                          — their payments are not written until resolved.
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="flat" onPress={onClose} isDisabled={isCommitting}>
+                Cancel
+              </Button>
+              <Button
+                color="primary"
+                onPress={onCommit}
+                isLoading={isCommitting}
+                startContent={
+                  !isCommitting && <Icon icon="material-symbols:cloud-upload" className="w-4 h-4" />
+                }
+              >
+                {isCommitting ? "Saving…" : "Save to Cloud"}
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default PivotReconciliationModal;

--- a/src/hooks/use-cloud-sync.ts
+++ b/src/hooks/use-cloud-sync.ts
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import PivotSyncService, { CloudSyncPreview } from "@/services/pivot-sync-service";
+import { toast } from "@/services/toast-service";
+
+/**
+ * Drives the Phase 2 cloud save: after a funder file is saved locally, run a
+ * dry-run of the validation RPC, show the reconciliation for confirmation,
+ * then commit payments transactionally.
+ */
+export function useCloudSync() {
+  const [previews, setPreviews] = useState<CloudSyncPreview[]>([]);
+  const [isModalOpen, setModalOpen] = useState(false);
+  const [isCommitting, setCommitting] = useState(false);
+
+  const startSync = async (
+    portfolioName: string,
+    funderName: string,
+    file: File,
+    reportDate: string
+  ) => {
+    try {
+      const result = await PivotSyncService.preview(portfolioName, funderName, file, reportDate);
+      if (result.length === 0) return;
+      setPreviews(result);
+      setModalOpen(true);
+    } catch (error) {
+      console.error("Cloud sync preview failed:", error);
+      toast.error("Cloud save failed", String(error));
+    }
+  };
+
+  const commit = async () => {
+    setCommitting(true);
+    try {
+      for (const preview of previews) {
+        await PivotSyncService.commit(preview);
+      }
+      const totalMatched = previews.reduce((n, p) => n + p.reconciliation.matched_count, 0);
+      const totalUnmatched = previews.reduce((n, p) => n + p.reconciliation.unmatched_count, 0);
+      toast.success(
+        "Saved to cloud",
+        `${totalMatched} payment${totalMatched === 1 ? "" : "s"} written` +
+          (totalUnmatched > 0 ? `, ${totalUnmatched} unmatched row(s) pending resolution` : "")
+      );
+      setModalOpen(false);
+      setPreviews([]);
+    } catch (error) {
+      console.error("Cloud sync commit failed:", error);
+      toast.error("Cloud save failed", String(error));
+    } finally {
+      setCommitting(false);
+    }
+  };
+
+  return { previews, isModalOpen, setModalOpen, isCommitting, startSync, commit };
+}

--- a/src/pages/alder-portfolio.tsx
+++ b/src/pages/alder-portfolio.tsx
@@ -4,7 +4,9 @@ import BasePortfolio from "@components/portfolio/base-portfolio";
 import { FunderData } from "@components/portfolio/funder-upload-section";
 import FileService, { VersionInfo, FunderUploadInfo } from "@services/file-service";
 import { useFileErrorState } from "@/hooks/use-file-error-state";
+import { useCloudSync } from "@/hooks/use-cloud-sync";
 import { UnmatchedDealsResultModal } from "@components/portfolio/unmatched-deals-result-modal";
+import PivotReconciliationModal from "@components/portfolio/pivot-reconciliation-modal";
 
 const PORTFOLIO = "Alder";
 
@@ -73,6 +75,7 @@ function AlderPortfolio() {
   const [funderUploads, setFunderUploads] = useState<FunderUploadInfo[]>([]);
   const { workbookError, monthlyErrorStates, setWorkbookErrorState, setFunderErrorState } =
     useFileErrorState();
+  const cloudSync = useCloudSync();
 
   const [isUploading, setIsUploading] = useState(false);
   const [isUpdatingNetRtr, setIsUpdatingNetRtr] = useState(false);
@@ -206,6 +209,7 @@ function AlderPortfolio() {
         setMonthlyFiles((prev) => ({ ...prev, [funderName]: file }));
         setFunderErrorState(funderName, false);
         setFunderUploads(await FileService.getFunderUploadsForDate(PORTFOLIO, reportDate));
+        await cloudSync.startSync(PORTFOLIO, funderName, file, reportDate);
       } else {
         setFunderErrorState(
           funderName,
@@ -364,6 +368,14 @@ function AlderPortfolio() {
           </div>
         </div>
       )}
+
+      <PivotReconciliationModal
+        isOpen={cloudSync.isModalOpen}
+        onOpenChange={cloudSync.setModalOpen}
+        previews={cloudSync.previews}
+        onCommit={cloudSync.commit}
+        isCommitting={cloudSync.isCommitting}
+      />
 
       <UnmatchedDealsResultModal
         isOpen={unmatchedDealsModalOpen}

--- a/src/pages/white-rabbit-portfolio.tsx
+++ b/src/pages/white-rabbit-portfolio.tsx
@@ -4,7 +4,9 @@ import BasePortfolio from "@components/portfolio/base-portfolio";
 import { FunderData } from "@components/portfolio/funder-upload-section";
 import FileService, { VersionInfo, FunderUploadInfo } from "@services/file-service";
 import { useFileErrorState } from "@/hooks/use-file-error-state";
+import { useCloudSync } from "@/hooks/use-cloud-sync";
 import { UnmatchedDealsResultModal } from "@components/portfolio/unmatched-deals-result-modal";
+import PivotReconciliationModal from "@components/portfolio/pivot-reconciliation-modal";
 
 const PORTFOLIO = "White Rabbit";
 
@@ -67,6 +69,7 @@ function WhiteRabbitPortfolio() {
   const [funderUploads, setFunderUploads] = useState<FunderUploadInfo[]>([]);
   const { workbookError, monthlyErrorStates, setWorkbookErrorState, setFunderErrorState } =
     useFileErrorState();
+  const cloudSync = useCloudSync();
 
   const [isUploading, setIsUploading] = useState(false);
   const [isUpdatingNetRtr, setIsUpdatingNetRtr] = useState(false);
@@ -200,6 +203,7 @@ function WhiteRabbitPortfolio() {
         setMonthlyFiles((prev) => ({ ...prev, [funderName]: file }));
         setFunderErrorState(funderName, false);
         setFunderUploads(await FileService.getFunderUploadsForDate(PORTFOLIO, reportDate));
+        await cloudSync.startSync(PORTFOLIO, funderName, file, reportDate);
       } else {
         setFunderErrorState(
           funderName,
@@ -358,6 +362,14 @@ function WhiteRabbitPortfolio() {
           </div>
         </div>
       )}
+
+      <PivotReconciliationModal
+        isOpen={cloudSync.isModalOpen}
+        onOpenChange={cloudSync.setModalOpen}
+        previews={cloudSync.previews}
+        onCommit={cloudSync.commit}
+        isCommitting={cloudSync.isCommitting}
+      />
 
       <UnmatchedDealsResultModal
         isOpen={unmatchedDealsModalOpen}

--- a/src/services/pivot-sync-service.ts
+++ b/src/services/pivot-sync-service.ts
@@ -1,0 +1,232 @@
+import { invoke } from "@tauri-apps/api/core";
+import { supabase } from "./supabase";
+
+/** Pivot rows + parser totals returned by the Rust `get_pivot_for_report` command. */
+export interface PivotRowData {
+  advance_id: string;
+  merchant_name: string;
+  gross_amount: number;
+  management_fee: number;
+  net_amount: number;
+}
+
+export interface PivotExport {
+  rows: PivotRowData[];
+  total_gross: number;
+  total_fee: number;
+  total_net: number;
+}
+
+/** Reconciliation summary returned by the `commit_funder_pivot` RPC. */
+export interface PivotReconciliation {
+  committed: boolean;
+  pivot_table_id: string;
+  report_date: string;
+  total_net: number;
+  matched_count: number;
+  matched_net: number;
+  unmatched_count: number;
+  unmatched_net: number;
+  duplicate_count: number;
+  duplicate_net: number;
+  unmatched: Array<{
+    row_id: string;
+    advance_id: string | null;
+    merchant_name: string;
+    gross: number;
+    fee: number;
+    net: number;
+  }>;
+  duplicates: Array<{
+    row_id: string;
+    advance_id: string | null;
+    merchant_name: string;
+    gross: number;
+    fee: number;
+    net: number;
+    match_count: number;
+  }>;
+}
+
+/** One pending cloud commit: everything the reconciliation modal needs. */
+export interface CloudSyncPreview {
+  portfolioName: string;
+  funderName: string;
+  uploadId: string;
+  pivot: PivotExport;
+  reconciliation: PivotReconciliation;
+}
+
+// UI funder labels that differ from funders.name in Supabase
+const FUNDER_NAME_MAP: Record<string, string> = {
+  InAdvance: "In Advance",
+  Payva: "PayVa",
+  ClearView: "Clear View",
+};
+
+const dbFunderName = (uiName: string) => FUNDER_NAME_MAP[uiName] ?? uiName;
+
+export class PivotSyncService {
+  private static portfolioIds = new Map<string, number>();
+  private static funderIds = new Map<string, number>();
+
+  private static async getPortfolioId(portfolioName: string): Promise<number> {
+    const cached = this.portfolioIds.get(portfolioName);
+    if (cached !== undefined) return cached;
+
+    const { data, error } = await supabase
+      .from("portfolios")
+      .select("id")
+      .eq("name", portfolioName)
+      .single();
+    if (error || !data) {
+      throw new Error(`Portfolio "${portfolioName}" not found in Supabase: ${error?.message}`);
+    }
+    this.portfolioIds.set(portfolioName, data.id);
+    return data.id;
+  }
+
+  private static async getFunderId(uiFunderName: string): Promise<number> {
+    const name = dbFunderName(uiFunderName);
+    const cached = this.funderIds.get(name);
+    if (cached !== undefined) return cached;
+
+    const { data, error } = await supabase.from("funders").select("id").eq("name", name).single();
+    if (error || !data) {
+      throw new Error(`Funder "${name}" not found in Supabase: ${error?.message}`);
+    }
+    this.funderIds.set(name, data.id);
+    return data.id;
+  }
+
+  private static async getPivotForReport(
+    portfolioName: string,
+    funderName: string,
+    reportDate: string
+  ): Promise<PivotExport | null> {
+    return await invoke<PivotExport | null>("get_pivot_for_report", {
+      portfolioName,
+      funderName,
+      reportDate,
+      uploadType: "monthly",
+    });
+  }
+
+  private static async callCommitRpc(
+    uploadId: string,
+    pivot: PivotExport,
+    dryRun: boolean
+  ): Promise<PivotReconciliation> {
+    const { data, error } = await supabase.rpc("commit_funder_pivot", {
+      p_upload_id: uploadId,
+      p_rows: pivot.rows.map((r) => ({
+        advance_id: r.advance_id,
+        merchant_name: r.merchant_name,
+        gross: r.gross_amount,
+        fee: r.management_fee,
+        net: r.net_amount,
+      })),
+      p_total_gross: pivot.total_gross,
+      p_total_fee: pivot.total_fee,
+      p_total_net: pivot.total_net,
+      p_dry_run: dryRun,
+    });
+    if (error) {
+      throw new Error(`Pivot ${dryRun ? "preview" : "commit"} failed: ${error.message}`);
+    }
+    return data as unknown as PivotReconciliation;
+  }
+
+  /**
+   * Push one portfolio's parsed pivot to the cloud: raw file to Storage,
+   * upload record to funder_uploads, then a dry-run of the validation RPC.
+   * Returns null when no pivot exists locally (e.g. parser not implemented).
+   */
+  private static async previewPortfolio(
+    portfolioName: string,
+    funderName: string,
+    file: File,
+    reportDate: string
+  ): Promise<CloudSyncPreview | null> {
+    const pivot = await this.getPivotForReport(portfolioName, funderName, reportDate);
+    if (!pivot) return null;
+
+    const portfolioId = await this.getPortfolioId(portfolioName);
+    const funderId = await this.getFunderId(funderName);
+
+    const storagePath = `${portfolioId}/${funderId}/${reportDate}/${file.name}`;
+    const { error: storageError } = await supabase.storage
+      .from("funder-uploads")
+      .upload(storagePath, await file.arrayBuffer(), {
+        upsert: true,
+        contentType: file.type || "application/octet-stream",
+      });
+    if (storageError) {
+      throw new Error(`Failed to upload raw file to Storage: ${storageError.message}`);
+    }
+
+    const { data: user } = await supabase.auth.getUser();
+    const { data: upload, error: uploadError } = await supabase
+      .from("funder_uploads")
+      .upsert(
+        {
+          portfolio_id: portfolioId,
+          funder_id: funderId,
+          report_date: reportDate,
+          upload_type: "monthly",
+          original_filename: file.name,
+          storage_path: storagePath,
+          file_size: file.size,
+          uploaded_by: user.user?.id ?? null,
+        },
+        { onConflict: "portfolio_id,funder_id,report_date,upload_type" }
+      )
+      .select("id")
+      .single();
+    if (uploadError || !upload) {
+      throw new Error(`Failed to record funder upload: ${uploadError?.message}`);
+    }
+
+    const reconciliation = await this.callCommitRpc(upload.id, pivot, true);
+    return { portfolioName, funderName, uploadId: upload.id, pivot, reconciliation };
+  }
+
+  /**
+   * Preview the cloud sync for a freshly uploaded funder file. A Clear View
+   * file carries deals for both portfolios, so it produces one preview each.
+   */
+  static async preview(
+    portfolioName: string,
+    funderName: string,
+    file: File,
+    reportDate: string
+  ): Promise<CloudSyncPreview[]> {
+    const isClearView = funderName === "Clear View" || funderName === "ClearView";
+    const portfolios = isClearView ? ["Alder", "White Rabbit"] : [portfolioName];
+
+    const previews: CloudSyncPreview[] = [];
+    for (const pf of portfolios) {
+      const preview = await this.previewPortfolio(pf, funderName, file, reportDate);
+      if (preview) previews.push(preview);
+    }
+    return previews;
+  }
+
+  /** Re-run the validation RPC for real: writes net_rtr_payments transactionally. */
+  static async commit(preview: CloudSyncPreview): Promise<PivotReconciliation> {
+    return await this.callCommitRpc(preview.uploadId, preview.pivot, false);
+  }
+
+  /** Resolve one unmatched pivot row to a deal and write its payment. */
+  static async resolveRow(rowId: string, dealId: string): Promise<void> {
+    const { error } = await supabase.rpc("resolve_pivot_row", {
+      p_row_id: rowId,
+      p_deal_id: dealId,
+    });
+    if (error) {
+      throw new Error(`Failed to resolve pivot row: ${error.message}`);
+    }
+  }
+}
+
+export default PivotSyncService;

--- a/src/services/supabase.types.ts
+++ b/src/services/supabase.types.ts
@@ -721,6 +721,21 @@ export interface Database {
         Args: Record<string, never>;
         Returns: boolean;
       };
+      commit_funder_pivot: {
+        Args: {
+          p_upload_id: string;
+          p_rows: Json;
+          p_total_gross: number;
+          p_total_fee: number;
+          p_total_net: number;
+          p_dry_run?: boolean;
+        };
+        Returns: Json;
+      };
+      resolve_pivot_row: {
+        Args: { p_row_id: string; p_deal_id: string };
+        Returns: Json;
+      };
     };
     Enums: {
       user_role: "admin" | "member";

--- a/supabase/migrations/20260710131919_phase2_storage_bucket.sql
+++ b/supabase/migrations/20260710131919_phase2_storage_bucket.sql
@@ -1,0 +1,45 @@
+-- Phase 2: private Storage bucket for raw monthly funder files.
+--
+-- Object paths follow {portfolio_id}/{funder_id}/{report_date}/{filename} so
+-- the first path segment can drive per-portfolio access via
+-- has_portfolio_access(), mirroring the funder_uploads table RLS.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit)
+VALUES ('funder-uploads', 'funder-uploads', false, 16777216)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY "Portfolio access can read funder upload files"
+  ON storage.objects FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'funder-uploads'
+    AND has_portfolio_access(((storage.foldername(name))[1])::integer)
+  );
+
+CREATE POLICY "Portfolio access can write funder upload files"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'funder-uploads'
+    AND has_portfolio_access(((storage.foldername(name))[1])::integer)
+  );
+
+CREATE POLICY "Portfolio access can update funder upload files"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'funder-uploads'
+    AND has_portfolio_access(((storage.foldername(name))[1])::integer)
+  )
+  WITH CHECK (
+    bucket_id = 'funder-uploads'
+    AND has_portfolio_access(((storage.foldername(name))[1])::integer)
+  );
+
+CREATE POLICY "Portfolio access can delete funder upload files"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'funder-uploads'
+    AND has_portfolio_access(((storage.foldername(name))[1])::integer)
+  );

--- a/supabase/migrations/20260710131920_phase2_commit_pivot_rpc.sql
+++ b/supabase/migrations/20260710131920_phase2_commit_pivot_rpc.sql
@@ -1,0 +1,247 @@
+-- Phase 2: transactional pivot commit + reconciliation.
+--
+-- commit_funder_pivot is the single write path from parser output to the
+-- database. It replaces the pivot snapshot for an upload, matches rows to
+-- deals, and (unless dry-run) writes net_rtr_payments — refusing the whole
+-- transaction unless matched + unmatched + duplicate row totals equal the
+-- parser's total_net within a cent. That is the guarantee that what lands in
+-- the database equals what would have been typed into the workbook's Net RTR
+-- column.
+--
+-- SECURITY INVOKER: every read/write inside runs under the caller's RLS, so
+-- portfolio access is enforced by the existing policies, not re-implemented.
+
+CREATE OR REPLACE FUNCTION commit_funder_pivot(
+  p_upload_id uuid,
+  p_rows jsonb,
+  p_total_gross numeric,
+  p_total_fee numeric,
+  p_total_net numeric,
+  p_dry_run boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_upload funder_uploads%ROWTYPE;
+  v_pivot_id uuid;
+  v_rows_net numeric;
+  v_matched_count integer;
+  v_matched_net numeric;
+  v_unmatched jsonb;
+  v_unmatched_count integer;
+  v_unmatched_net numeric;
+  v_duplicates jsonb;
+  v_duplicate_count integer;
+  v_duplicate_net numeric;
+  c_tolerance CONSTANT numeric := 0.01;
+BEGIN
+  SELECT * INTO v_upload FROM funder_uploads WHERE id = p_upload_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Upload % not found or not accessible', p_upload_id;
+  END IF;
+
+  IF p_rows IS NULL OR jsonb_typeof(p_rows) <> 'array' THEN
+    RAISE EXCEPTION 'p_rows must be a JSON array of pivot rows';
+  END IF;
+
+  -- Guard 1: the rows as received must sum to the parser's totals — catches
+  -- truncation or corruption between the Rust parser and this call.
+  SELECT COALESCE(SUM((r->>'net')::numeric), 0) INTO v_rows_net
+  FROM jsonb_array_elements(p_rows) AS r;
+
+  IF abs(v_rows_net - p_total_net) > c_tolerance THEN
+    RAISE EXCEPTION
+      'Pivot rows sum to % but parser total_net is % (difference exceeds % tolerance)',
+      v_rows_net, p_total_net, c_tolerance;
+  END IF;
+
+  -- Replace the pivot snapshot for this upload (re-uploads are idempotent;
+  -- ON DELETE CASCADE clears the old rows).
+  DELETE FROM funder_pivot_tables WHERE upload_id = p_upload_id;
+
+  INSERT INTO funder_pivot_tables
+    (upload_id, portfolio_id, funder_id, report_date,
+     total_gross, total_fee, total_net, row_count)
+  VALUES
+    (p_upload_id, v_upload.portfolio_id, v_upload.funder_id, v_upload.report_date,
+     p_total_gross, p_total_fee, p_total_net, jsonb_array_length(p_rows))
+  RETURNING id INTO v_pivot_id;
+
+  INSERT INTO funder_pivot_rows (pivot_table_id, advance_id, merchant_name, gross, fee, net)
+  SELECT
+    v_pivot_id,
+    NULLIF(trim(r->>'advance_id'), ''),
+    COALESCE(r->>'merchant_name', ''),
+    COALESCE((r->>'gross')::numeric, 0),
+    COALESCE((r->>'fee')::numeric, 0),
+    COALESCE((r->>'net')::numeric, 0)
+  FROM jsonb_array_elements(p_rows) AS r;
+
+  -- Match rows to deals on the funder's advance id, scoped to this
+  -- portfolio + funder. Rows whose advance id hits more than one deal (e.g.
+  -- an original deal plus an add-on) are flagged as duplicates and left
+  -- unresolved — same behaviour as the workbook updater.
+  UPDATE funder_pivot_rows pr
+  SET matched_deal_id = m.deal_id
+  FROM (
+    SELECT pr2.id AS row_id, min(d.id::text)::uuid AS deal_id
+    FROM funder_pivot_rows pr2
+    JOIN deals d
+      ON d.portfolio_id = v_upload.portfolio_id
+     AND d.funder_id = v_upload.funder_id
+     AND d.funder_advance_id = pr2.advance_id
+    WHERE pr2.pivot_table_id = v_pivot_id
+    GROUP BY pr2.id
+    HAVING count(*) = 1
+  ) m
+  WHERE pr.id = m.row_id;
+
+  SELECT count(*), COALESCE(SUM(net), 0)
+  INTO v_matched_count, v_matched_net
+  FROM funder_pivot_rows
+  WHERE pivot_table_id = v_pivot_id AND matched_deal_id IS NOT NULL;
+
+  -- Duplicate-match rows: advance id present on more than one deal
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+           'row_id', pr.id,
+           'advance_id', pr.advance_id,
+           'merchant_name', pr.merchant_name,
+           'gross', pr.gross, 'fee', pr.fee, 'net', pr.net,
+           'match_count', dm.match_count
+         ) ORDER BY pr.merchant_name), '[]'::jsonb),
+         count(*), COALESCE(SUM(pr.net), 0)
+  INTO v_duplicates, v_duplicate_count, v_duplicate_net
+  FROM funder_pivot_rows pr
+  JOIN LATERAL (
+    SELECT count(*) AS match_count
+    FROM deals d
+    WHERE d.portfolio_id = v_upload.portfolio_id
+      AND d.funder_id = v_upload.funder_id
+      AND d.funder_advance_id = pr.advance_id
+  ) dm ON dm.match_count > 1
+  WHERE pr.pivot_table_id = v_pivot_id AND pr.matched_deal_id IS NULL;
+
+  -- Unmatched rows: no deal at all
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+           'row_id', pr.id,
+           'advance_id', pr.advance_id,
+           'merchant_name', pr.merchant_name,
+           'gross', pr.gross, 'fee', pr.fee, 'net', pr.net
+         ) ORDER BY pr.merchant_name), '[]'::jsonb),
+         count(*), COALESCE(SUM(pr.net), 0)
+  INTO v_unmatched, v_unmatched_count, v_unmatched_net
+  FROM funder_pivot_rows pr
+  WHERE pr.pivot_table_id = v_pivot_id
+    AND pr.matched_deal_id IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM deals d
+      WHERE d.portfolio_id = v_upload.portfolio_id
+        AND d.funder_id = v_upload.funder_id
+        AND d.funder_advance_id = pr.advance_id
+    );
+
+  -- Guard 2 (the core requirement): every dollar of the parser's total must
+  -- be accounted for as matched, unmatched, or duplicate-flagged.
+  IF abs((v_matched_net + v_unmatched_net + v_duplicate_net) - p_total_net) > c_tolerance THEN
+    RAISE EXCEPTION
+      'Reconciliation failed: matched % + unmatched % + duplicate % != total_net % (tolerance %)',
+      v_matched_net, v_unmatched_net, v_duplicate_net, p_total_net, c_tolerance;
+  END IF;
+
+  IF NOT p_dry_run THEN
+    -- Replace payments previously written by this upload, then write the
+    -- current matched set. Aggregated per deal in case a pivot ever carries
+    -- two rows for the same advance id.
+    DELETE FROM net_rtr_payments WHERE source_upload_id = p_upload_id;
+
+    INSERT INTO net_rtr_payments (deal_id, payment_date, gross, fee, net, source_upload_id)
+    SELECT matched_deal_id, v_upload.report_date,
+           SUM(gross), SUM(fee), SUM(net), p_upload_id
+    FROM funder_pivot_rows
+    WHERE pivot_table_id = v_pivot_id AND matched_deal_id IS NOT NULL
+    GROUP BY matched_deal_id
+    ON CONFLICT (deal_id, payment_date) DO UPDATE
+      SET gross = EXCLUDED.gross,
+          fee = EXCLUDED.fee,
+          net = EXCLUDED.net,
+          source_upload_id = EXCLUDED.source_upload_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'committed', NOT p_dry_run,
+    'pivot_table_id', v_pivot_id,
+    'report_date', v_upload.report_date,
+    'total_net', p_total_net,
+    'matched_count', v_matched_count,
+    'matched_net', v_matched_net,
+    'unmatched_count', v_unmatched_count,
+    'unmatched_net', v_unmatched_net,
+    'duplicate_count', v_duplicate_count,
+    'duplicate_net', v_duplicate_net,
+    'unmatched', v_unmatched,
+    'duplicates', v_duplicates
+  );
+END;
+$$;
+
+-- Resolve one unmatched pivot row to a deal (driven by the unmatched-deals
+-- modal). Recomputes the deal's payment for that report date from all rows in
+-- the same pivot now matched to it, so repeated calls are idempotent.
+CREATE OR REPLACE FUNCTION resolve_pivot_row(
+  p_row_id uuid,
+  p_deal_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_row funder_pivot_rows%ROWTYPE;
+  v_pivot funder_pivot_tables%ROWTYPE;
+  v_deal deals%ROWTYPE;
+BEGIN
+  SELECT * INTO v_row FROM funder_pivot_rows WHERE id = p_row_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Pivot row % not found or not accessible', p_row_id;
+  END IF;
+
+  SELECT * INTO v_pivot FROM funder_pivot_tables WHERE id = v_row.pivot_table_id;
+
+  SELECT * INTO v_deal FROM deals WHERE id = p_deal_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Deal % not found or not accessible', p_deal_id;
+  END IF;
+
+  IF v_deal.portfolio_id IS DISTINCT FROM v_pivot.portfolio_id
+     OR v_deal.funder_id IS DISTINCT FROM v_pivot.funder_id THEN
+    RAISE EXCEPTION
+      'Deal % belongs to a different portfolio/funder than the pivot row', p_deal_id;
+  END IF;
+
+  UPDATE funder_pivot_rows SET matched_deal_id = p_deal_id WHERE id = p_row_id;
+
+  INSERT INTO net_rtr_payments (deal_id, payment_date, gross, fee, net, source_upload_id)
+  SELECT p_deal_id, v_pivot.report_date,
+         SUM(gross), SUM(fee), SUM(net), v_pivot.upload_id
+  FROM funder_pivot_rows
+  WHERE pivot_table_id = v_row.pivot_table_id AND matched_deal_id = p_deal_id
+  ON CONFLICT (deal_id, payment_date) DO UPDATE
+    SET gross = EXCLUDED.gross,
+        fee = EXCLUDED.fee,
+        net = EXCLUDED.net,
+        source_upload_id = EXCLUDED.source_upload_id;
+
+  RETURN jsonb_build_object(
+    'row_id', p_row_id,
+    'deal_id', p_deal_id,
+    'payment_date', v_pivot.report_date
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION commit_funder_pivot(uuid, jsonb, numeric, numeric, numeric, boolean) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION resolve_pivot_row(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION commit_funder_pivot(uuid, jsonb, numeric, numeric, numeric, boolean) TO authenticated;
+GRANT EXECUTE ON FUNCTION resolve_pivot_row(uuid, uuid) TO authenticated;


### PR DESCRIPTION
## Summary
- `commit_funder_pivot` RPC: transactional pivot + payment writes; refuses to commit unless matched + unmatched + duplicate row nets equal the parser's `total_net` within a cent — the guarantee that what lands in the database equals what would have been typed into the workbook's Net RTR column. `resolve_pivot_row` RPC readies the unmatched-deals resolution flow for Phase 3.
- Private `funder-uploads` Storage bucket with per-portfolio RLS on the path prefix.
- New `get_pivot_for_report` Tauri command exposes parsed pivot rows + parser totals to the frontend.
- `pivot-sync-service.ts` + `use-cloud-sync.ts`: dry-run preview → reconciliation modal (pivot/matched/unmatched/duplicate totals) → real commit. Clear View uploads sync both portfolios from one file.
- Dual-write: local SQLite/CSV flow is untouched — it stays load-bearing for the Pyodide workbook update until the Phase 5 cutover.

## Test plan
- [x] `npm run lint` (14/17 warnings, under cap)
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Both migrations applied live via `supabase db push`; confirmed via `supabase db dump` that `commit_funder_pivot`, `resolve_pivot_row`, and the `funder-uploads` bucket exist remotely
- [x] RPC behavior verified in a throwaway local Postgres 16 cluster: dry-run partitions matched/unmatched/duplicate correctly and writes nothing; real commit writes only matched payments; re-commit with a dropped row removes the stale payment; tolerance guard aborts a mismatched total; cross-funder `resolve_pivot_row` is rejected
- [ ] Manual smoke test in the Tauri app once `deals` has data (Phase 3) — until then all pivot rows report as unmatched by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)