### PR TITLE
feat: add Phase 3 one-time workbook import — Rust parser, import RPC, wizard UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@ Excelerate is a desktop application built with Tauri (Rust backend) and React + 
 - `npm run format:check` - Prettier check (CI gate)
 
 ### Tauri Application
-- `npm run tauri dev` - Run Tauri app in development mode
+- `npm run tauri dev` - Run Tauri app in development mode (against the **production** Supabase project via `.env`)
+- `npm run dev:local` - Run against the **local** Supabase stack in Docker (login: `dev@excelerate.local` / `excelerate-dev`; see [`docs/local-dev.md`](docs/local-dev.md))
+- `npm run db:reset:local` - Wipe the local stack DB, re-apply migrations + `supabase/seed.sql`
 - `npm run tauri build` - Build production desktop app
 
 ### Rust

--- a/FABLE_PLAN.md
+++ b/FABLE_PLAN.md
@@ -205,11 +205,14 @@ Two migrations (`20260710131919/20`), pushed live. RPC logic behaviorally tested
 - [x] **Validation RPC**: `SECURITY INVOKER`, two guards — rows-vs-parser-total on entry, matched+unmatched+duplicate = `total_net` (±$0.01) before commit; payments written per-deal with replace-on-re-upload semantics (`source_upload_id` scoped delete + upsert)
 - [x] Reconciliation modal (`pivot-reconciliation-modal.tsx` + `use-cloud-sync.ts`): dry-run first, shows pivot/matched/unmatched/duplicate totals + unmatched rows, then user confirms the real commit. Clear View produces one preview per portfolio from the single upload
 
-### Phase 3 — One-time workbook import (kills the weekly workbook upload)
+### Phase 3 — One-time workbook import (kills the weekly workbook upload) ✅ Completed 2026-07-10
 
-- [ ] Port `scripts/migrate-workbook.py` (618 lines — header quirks, `Net RTR M/D/YY` date inference, batch upserts already solved) into an in-app "Import portfolio workbook" wizard using the existing Rust xlsx reading (calamine). Note: the script has drifted from the live `deals` schema (`sell_rate`/`total_rtr`/`term_months` columns don't exist; live column is `deal_length_months`) — reconcile during the port
-- [ ] Import populates `deals` + `net_rtr_payments` + `funders` (reading each sheet's `B1` fee) per portfolio
-- [ ] Run once per portfolio at onboarding; monthly funder files only from then on
+One migration (`20260710135856_phase3_workbook_import`). Full pipeline verified offline: Rust parse of both real workbooks matches an openpyxl probe cell-for-cell (Alder 1,687 deals / 26,127 payments; WR 1,073 / 26,023), then replayed through the RPC in a scratch Postgres 16 cluster — 2,760 deals, 52,122 payment rows, $13.1M net, all reconciliation guards pass, re-import idempotent.
+
+- [x] Ported `scripts/migrate-workbook.py` into Rust `parse_portfolio_workbook` (calamine, `workbook_import.rs`) + `WorkbookImportService` + wizard modal (`workbook-import-wizard.tsx`) on both portfolio pages. Schema drift reconciled: inputs only (`commission` = rate; sell rate/total RTR/term stay derived in views). Extra inputs the script missed are captured: participation, `New $`/`RTR` flags (non-blank text like `'New  '`), Date Closed, and R'bull (script's sheet list omitted it)
+- [x] **Import identity**: the workbooks have duplicate internal advance ids that are distinct deals (BHB-264 ×2 etc.) and null/dup funder advance ids — upsert key is the composite `(portfolio, funder, advance_id, COALESCE(funder_advance_id,''))`, verified unique across every sheet of both books. `deals.total_amount_funded`/`participation_on_amount` widened integer→numeric (39 PayVa deals have cents)
+- [x] `import_funder_sheet` RPC (SECURITY INVOKER, one call per sheet): upserts portfolio_funders fee from `B1`, merchants (industry/state resolved case-insensitively, unmatched reported), deals, and replaces import-sourced `net_rtr_payments` (`source_upload_id IS NULL`; monthly-flow rows preserved). Gross/fee reconstructed from net via the fee rate so imported rows match monthly-parser rows in the views. Phase 2-style guards: payload-vs-parser net total on entry, inserted+dropped=total before commit. Workbook quirks: literal duplicate week columns (Alder `Net RTR 5/10` ×2) and WR's dual May-2026 grids sum into one `(deal, date)` payment — dollar-preserving, same as the sheet's own row-total `SUM`
+- [x] Run once per portfolio at onboarding; wizard is re-runnable (idempotent) and reports per-sheet counts + unmatched industries/states
 
 ### Phase 4 — Dashboard buildout
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,66 @@
+# Local Development Environment
+
+Run the app against a full local Supabase stack (Postgres, Auth, PostgREST,
+Storage) in Docker instead of the production project. Real login, real RLS,
+real RPCs — no fake-auth code paths, no risk to live data.
+
+## Prerequisites
+
+- Docker Desktop running
+- Supabase CLI (`brew install supabase/tap/supabase`)
+
+## Run the app locally
+
+```bash
+npm run dev:local
+```
+
+That script (`tools/dev-local.sh`):
+
+1. Starts the local Supabase stack if it isn't running (`supabase start` —
+   first run downloads Docker images, applies every migration in
+   `supabase/migrations/`, then runs `supabase/seed.sql`)
+2. Launches `npm run tauri dev` with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`
+   pointed at `http://127.0.0.1:54321`
+
+Because process env beats `.env` in Vite, the plain `npm run tauri dev` still
+targets production. Only `dev:local` switches to the local stack.
+
+**Log in with** `dev@excelerate.local` / `excelerate-dev` — a confirmed admin
+user seeded with access to both portfolios.
+
+## What's in the local database
+
+Migrations seed everything the real project has except data that was created
+via the dashboard before the migration baseline existed:
+
+| Data | Source |
+|---|---|
+| portfolios (Alder, White Rabbit), states, industries, 6 funders, views, RLS, RPCs | `supabase/migrations/` |
+| the 5 pre-baseline funders (BHB, Clear View, BIG, eFin, In Advance) + all 18 portfolio_funders fee rows | `supabase/seed.sql` |
+| dev login + admin role + portfolio_access | `supabase/seed.sql` |
+
+`deals` / `net_rtr_payments` start empty — run the **Import Portfolio
+Workbook** wizard from a portfolio page (workbooks are in `examples/`) to
+populate them, which is also the end-to-end test for Phase 3.
+
+## Useful commands
+
+```bash
+npm run db:reset:local   # wipe local DB, re-apply migrations + seed
+supabase status          # URLs + keys of the running stack
+supabase stop            # shut the stack down (add --no-backup to also wipe)
+```
+
+Supabase Studio runs at <http://127.0.0.1:54323> for poking at local data.
+
+## Notes
+
+- `supabase/seed.sql` only ever runs locally (`db reset` / first `start`);
+  `supabase db push` ignores it, so it can never touch production.
+- The local SQLite/file flow (`~/Excelerate/`) is shared between modes — the
+  Rust side doesn't know about Supabase. If you want a clean slate there too,
+  move `~/Excelerate` aside before testing.
+- Testing an RPC without the app:
+  `curl -s "http://127.0.0.1:54321/auth/v1/token?grant_type=password" -H "apikey: <ANON_KEY>" -H "Content-Type: application/json" -d '{"email":"dev@excelerate.local","password":"excelerate-dev"}'`
+  then call `/rest/v1/rpc/<fn>` with the returned `access_token` as a Bearer token.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:local": "bash tools/dev-local.sh",
+    "db:reset:local": "supabase db reset --local",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod file_handler;
 mod notification;
 pub mod parsers;
 mod validated_file_handler;
+mod workbook_import;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -46,7 +47,8 @@ pub fn run() {
             file_handler::find_unmatched_deals_by_portfolio,
             file_handler::find_unmatched_deals_by_date,
             validated_file_handler::save_funder_upload_validated,
-            validated_file_handler::save_portfolio_workbook_validated
+            validated_file_handler::save_portfolio_workbook_validated,
+            workbook_import::parse_portfolio_workbook
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/workbook_import.rs
+++ b/src-tauri/src/workbook_import.rs
@@ -1,0 +1,601 @@
+// Phase 3: one-time portfolio workbook import.
+//
+// Parses the client's portfolio workbook (Alder / White Rabbit) into the
+// structures the frontend pushes to Supabase via the import_funder_sheet RPC.
+// Each funder deal sheet has: row 1 = funder label + B1 management fee rate,
+// row 2 = headers, row 3+ = one deal per row, with the weekly Net RTR payment
+// matrix starting around column AW ("Net RTR M/D[/YY]" headers).
+//
+// Header quirks handled here (verified against both real workbooks):
+// - "Commission" appears twice: first occurrence is the rate (col J), second
+//   is the derived dollar amount (col M) — only the first is an input.
+// - PayVa inserts an extra "PAYVA RECORDS" column after "Date Closed", so all
+//   matching is header-based, never positional (except the "DATE" default-date
+//   column, which shares its name with nothing but only appears at index 39+).
+// - "New $" / "RTR" funding-source flags hold text like "New  ", "NEW $",
+//   "RTR" or a lone space — any non-blank trimmed value means the flag is set.
+// - "# of Monthly Payments" (PayVa) is stored as num_weekly_payments, matching
+//   the legacy migration script and the workbook's own term formula.
+// - Net RTR headers may omit the year ("Net RTR 2/9"); the year is inferred
+//   from the previous column's date, wrapping to the next year when the month
+//   decreases. R'bull uses "HIDE" placeholder columns instead (no payments).
+
+use calamine::{open_workbook, Data, Reader, Xlsx};
+use chrono::{Datelike, NaiveDate};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportPayment {
+    pub payment_date: String,
+    pub net: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportDeal {
+    /// 1-based workbook row, for error reporting in the wizard
+    pub row: u32,
+    pub merchant_name: String,
+    pub website: Option<String>,
+    pub advance_id: Option<String>,
+    pub funder_advance_id: Option<String>,
+    pub industry: Option<String>,
+    pub state: Option<String>,
+    pub fico: Option<i64>,
+    pub buy_rate: Option<f64>,
+    pub commission_rate: Option<f64>,
+    pub total_funded_amount: Option<f64>,
+    pub num_daily_payments: Option<i64>,
+    pub num_weekly_payments: Option<i64>,
+    pub participation_amount: Option<f64>,
+    pub new_dollars: bool,
+    pub rtr: bool,
+    pub is_default: bool,
+    pub date_funded: Option<String>,
+    pub date_closed: Option<String>,
+    pub default_date: Option<String>,
+    pub payments: Vec<ImportPayment>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SheetImport {
+    pub sheet_name: String,
+    /// B1 cell — the funder's management fee rate for this portfolio
+    pub management_fee_rate: Option<f64>,
+    pub deals: Vec<ImportDeal>,
+    /// Distinct parsed Net RTR column dates (ISO), in column order
+    pub payment_dates: Vec<String>,
+    pub payment_count: u32,
+    pub total_net_payments: f64,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkbookImport {
+    pub sheets: Vec<SheetImport>,
+    /// Requested sheet names not present in the workbook
+    pub missing_sheets: Vec<String>,
+    /// Every sheet name found in the workbook (for diagnostics)
+    pub workbook_sheet_names: Vec<String>,
+}
+
+const EXCEL_EPOCH: (i32, u32, u32) = (1899, 12, 30);
+
+fn excel_serial_to_date(serial: f64) -> Option<NaiveDate> {
+    let days = serial.trunc() as i64;
+    if !(1..=200_000).contains(&days) {
+        return None;
+    }
+    NaiveDate::from_ymd_opt(EXCEL_EPOCH.0, EXCEL_EPOCH.1, EXCEL_EPOCH.2)
+        .and_then(|epoch| epoch.checked_add_signed(chrono::Duration::days(days)))
+}
+
+fn parse_date_string(s: &str) -> Option<NaiveDate> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    for fmt in ["%m/%d/%Y", "%m/%d/%y", "%Y-%m-%d", "%m-%d-%Y"] {
+        if let Ok(d) = NaiveDate::parse_from_str(s, fmt) {
+            return Some(d);
+        }
+    }
+    None
+}
+
+fn cell_date(cell: &Data) -> Option<NaiveDate> {
+    match cell {
+        Data::DateTime(dt) => excel_serial_to_date(dt.as_f64()),
+        Data::Float(f) => excel_serial_to_date(*f),
+        Data::Int(i) => excel_serial_to_date(*i as f64),
+        Data::String(s) => parse_date_string(s),
+        _ => None,
+    }
+}
+
+/// Trimmed non-empty text; integral numbers render without a decimal point
+/// (advance ids like 7948392 arrive as Float cells).
+fn cell_str(cell: &Data) -> Option<String> {
+    let s = match cell {
+        Data::String(s) => s.trim().to_string(),
+        Data::Float(f) => {
+            if f.fract() == 0.0 && f.abs() < 1e15 {
+                format!("{}", *f as i64)
+            } else {
+                f.to_string()
+            }
+        }
+        Data::Int(i) => i.to_string(),
+        Data::Bool(b) => b.to_string(),
+        _ => return None,
+    };
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+fn cell_f64(cell: &Data) -> Option<f64> {
+    match cell {
+        Data::Float(f) => Some(*f),
+        Data::Int(i) => Some(*i as f64),
+        Data::String(s) => {
+            let cleaned = s.replace(['$', ',', ' '], "");
+            if cleaned.is_empty() || cleaned == "-" {
+                None
+            } else {
+                cleaned.parse().ok()
+            }
+        }
+        _ => None,
+    }
+}
+
+fn cell_i64(cell: &Data) -> Option<i64> {
+    cell_f64(cell).map(|f| f.round() as i64)
+}
+
+/// Funding-source flag columns ("New $" / "RTR"): any non-blank value counts.
+fn cell_flag(cell: &Data) -> bool {
+    match cell {
+        Data::Empty => false,
+        Data::String(s) => !s.trim().is_empty(),
+        Data::Float(f) => *f != 0.0,
+        Data::Int(i) => *i != 0,
+        Data::Bool(b) => *b,
+        _ => false,
+    }
+}
+
+/// "Default" column: Yes/yes/YES in the real workbooks; accept common truthy
+/// spellings but treat anything else (e.g. "No") as false.
+fn cell_yes(cell: &Data) -> bool {
+    match cell {
+        Data::String(s) => matches!(
+            s.trim().to_lowercase().as_str(),
+            "yes" | "y" | "true" | "x" | "1"
+        ),
+        Data::Float(f) => *f != 0.0,
+        Data::Int(i) => *i != 0,
+        Data::Bool(b) => *b,
+        _ => false,
+    }
+}
+
+/// Parse "Net RTR M/D", "Net RTR M/D/YY", or "Net RTR M/D/YYYY". Without a
+/// year, infer from the previous column's date (same year, or next year when
+/// the month wraps); the matrix started in 2025.
+fn parse_net_rtr_header(header: &str, prev: Option<NaiveDate>) -> Option<NaiveDate> {
+    let rest = header.strip_prefix("Net RTR")?.trim();
+    let mut parts = rest.split('/');
+    let month: u32 = parts.next()?.trim().parse().ok()?;
+    let day: u32 = parts.next()?.trim().parse().ok()?;
+    let year = match parts.next() {
+        Some(y) => {
+            let y: i32 = y.trim().parse().ok()?;
+            if y < 100 {
+                y + 2000
+            } else {
+                y
+            }
+        }
+        None => match prev {
+            Some(p) if month < p.month0() + 1 => p.year() + 1,
+            Some(p) => p.year(),
+            None => 2025,
+        },
+    };
+    NaiveDate::from_ymd_opt(year, month, day)
+}
+
+/// Semantic column indices resolved from the header row.
+#[derive(Default)]
+struct ColumnMap {
+    merchant_name: Option<usize>,
+    website: Option<usize>,
+    advance_id: Option<usize>,
+    funder_advance_id: Option<usize>,
+    industry: Option<usize>,
+    state: Option<usize>,
+    fico: Option<usize>,
+    buy_rate: Option<usize>,
+    commission_rate: Option<usize>,
+    total_funded_amount: Option<usize>,
+    num_daily_payments: Option<usize>,
+    num_weekly_payments: Option<usize>,
+    participation_amount: Option<usize>,
+    new_dollars: Option<usize>,
+    rtr: Option<usize>,
+    is_default: Option<usize>,
+    date_funded: Option<usize>,
+    date_closed: Option<usize>,
+    default_date: Option<usize>,
+    /// (column index, parsed week-ending date)
+    net_rtr: Vec<(usize, NaiveDate)>,
+}
+
+fn build_column_map(header_row: &[Data], warnings: &mut Vec<String>) -> ColumnMap {
+    let mut map = ColumnMap::default();
+    let mut prev_net_rtr_date: Option<NaiveDate> = None;
+
+    for (idx, cell) in header_row.iter().enumerate() {
+        let Some(raw) = cell_str(cell) else { continue };
+        let norm = raw.to_lowercase();
+
+        if raw.starts_with("Net RTR") {
+            if raw.to_uppercase().contains("EMPTY") {
+                continue;
+            }
+            match parse_net_rtr_header(&raw, prev_net_rtr_date) {
+                Some(date) => {
+                    map.net_rtr.push((idx, date));
+                    prev_net_rtr_date = Some(date);
+                }
+                None => warnings.push(format!("Unparseable Net RTR header: '{}'", raw)),
+            }
+            continue;
+        }
+
+        let slot = match norm.as_str() {
+            "date funded" => &mut map.date_funded,
+            "merchant name" => &mut map.merchant_name,
+            "website" => &mut map.website,
+            "advance id" | "advanceid" => &mut map.advance_id,
+            "funder advance id" => &mut map.funder_advance_id,
+            "state" => &mut map.state,
+            "fico" => &mut map.fico,
+            "buy rate" => &mut map.buy_rate,
+            // first "Commission" is the rate; the second is the derived $
+            "commission" => &mut map.commission_rate,
+            "total funded amount" => &mut map.total_funded_amount,
+            "# of daily payments" => &mut map.num_daily_payments,
+            "# of weekly payments" | "# of monthly payments" => &mut map.num_weekly_payments,
+            "r&h participation amount" => &mut map.participation_amount,
+            "new $" => &mut map.new_dollars,
+            "rtr" => &mut map.rtr,
+            "default" => &mut map.is_default,
+            "date closed" => &mut map.date_closed,
+            _ if norm.starts_with("industry") => &mut map.industry,
+            // lone "DATE"/"Date" header in the default-flags block (idx 39+)
+            "date" if idx >= 39 => &mut map.default_date,
+            _ => continue,
+        };
+        if slot.is_none() {
+            *slot = Some(idx);
+        }
+    }
+
+    map
+}
+
+fn get(row: &[Data], idx: Option<usize>) -> Option<&Data> {
+    idx.and_then(|i| row.get(i))
+}
+
+fn parse_sheet(range: &calamine::Range<Data>, sheet_name: &str) -> SheetImport {
+    let mut warnings = Vec::new();
+    let mut rows = range.rows();
+
+    // Row 1: funder label in A1, management fee rate in B1
+    let management_fee_rate = rows.next().and_then(|r| r.get(1)).and_then(cell_f64);
+
+    let Some(header_row) = rows.next() else {
+        return SheetImport {
+            sheet_name: sheet_name.to_string(),
+            management_fee_rate,
+            deals: Vec::new(),
+            payment_dates: Vec::new(),
+            payment_count: 0,
+            total_net_payments: 0.0,
+            warnings: vec!["Sheet has no header row".to_string()],
+        };
+    };
+    let map = build_column_map(header_row, &mut warnings);
+
+    if map.merchant_name.is_none() {
+        return SheetImport {
+            sheet_name: sheet_name.to_string(),
+            management_fee_rate,
+            deals: Vec::new(),
+            payment_dates: Vec::new(),
+            payment_count: 0,
+            total_net_payments: 0.0,
+            warnings: vec!["No 'Merchant Name' header found".to_string()],
+        };
+    }
+
+    let mut deals = Vec::new();
+    let mut payment_count: u32 = 0;
+    let mut total_net_payments = 0.0;
+
+    for (i, row) in rows.enumerate() {
+        let workbook_row = (i + 3) as u32; // rows 1-2 are label + headers
+        let Some(merchant_name) = get(row, map.merchant_name).and_then(cell_str) else {
+            continue;
+        };
+
+        let advance_id = get(row, map.advance_id).and_then(cell_str);
+        if advance_id.is_none() {
+            warnings.push(format!(
+                "Row {}: '{}' has no Advance ID — skipped",
+                workbook_row, merchant_name
+            ));
+            continue;
+        }
+
+        let mut payments = Vec::new();
+        for &(col, date) in &map.net_rtr {
+            let Some(net) = row.get(col).and_then(cell_f64) else {
+                continue;
+            };
+            if net == 0.0 {
+                continue;
+            }
+            payments.push(ImportPayment {
+                payment_date: date.format("%Y-%m-%d").to_string(),
+                net,
+            });
+            payment_count += 1;
+            total_net_payments += net;
+        }
+
+        let iso = |idx| {
+            get(row, idx)
+                .and_then(cell_date)
+                .map(|d: NaiveDate| d.format("%Y-%m-%d").to_string())
+        };
+
+        deals.push(ImportDeal {
+            row: workbook_row,
+            merchant_name,
+            website: get(row, map.website).and_then(cell_str),
+            advance_id,
+            funder_advance_id: get(row, map.funder_advance_id).and_then(cell_str),
+            industry: get(row, map.industry).and_then(cell_str),
+            state: get(row, map.state).and_then(cell_str),
+            fico: get(row, map.fico).and_then(cell_i64),
+            buy_rate: get(row, map.buy_rate).and_then(cell_f64),
+            commission_rate: get(row, map.commission_rate).and_then(cell_f64),
+            total_funded_amount: get(row, map.total_funded_amount).and_then(cell_f64),
+            num_daily_payments: get(row, map.num_daily_payments).and_then(cell_i64),
+            num_weekly_payments: get(row, map.num_weekly_payments).and_then(cell_i64),
+            participation_amount: get(row, map.participation_amount).and_then(cell_f64),
+            new_dollars: get(row, map.new_dollars).map(cell_flag).unwrap_or(false),
+            rtr: get(row, map.rtr).map(cell_flag).unwrap_or(false),
+            is_default: get(row, map.is_default).map(cell_yes).unwrap_or(false),
+            date_funded: iso(map.date_funded),
+            date_closed: iso(map.date_closed),
+            default_date: iso(map.default_date),
+            payments,
+        });
+    }
+
+    SheetImport {
+        sheet_name: sheet_name.to_string(),
+        management_fee_rate,
+        deals,
+        payment_dates: map
+            .net_rtr
+            .iter()
+            .map(|(_, d)| d.format("%Y-%m-%d").to_string())
+            .collect(),
+        payment_count,
+        total_net_payments,
+        warnings,
+    }
+}
+
+/// Parse a portfolio workbook: for each requested funder sheet, extract the
+/// B1 management fee, the deal input columns, and the Net RTR payment matrix.
+#[tauri::command]
+pub fn parse_portfolio_workbook(
+    file_path: String,
+    sheet_names: Vec<String>,
+) -> Result<WorkbookImport, String> {
+    let path = Path::new(&file_path);
+    if !path.exists() {
+        return Err(format!("Workbook not found: {}", file_path));
+    }
+
+    let mut workbook: Xlsx<_> = open_workbook(path)
+        .map_err(|e| format!("Failed to open workbook '{}': {}", file_path, e))?;
+    let workbook_sheet_names = workbook.sheet_names().to_vec();
+
+    let mut sheets = Vec::new();
+    let mut missing_sheets = Vec::new();
+
+    for sheet_name in &sheet_names {
+        if !workbook_sheet_names.iter().any(|s| s == sheet_name) {
+            missing_sheets.push(sheet_name.clone());
+            continue;
+        }
+        let range = workbook
+            .worksheet_range(sheet_name)
+            .map_err(|e| format!("Failed to read sheet '{}': {}", sheet_name, e))?;
+        sheets.push(parse_sheet(&range, sheet_name));
+    }
+
+    Ok(WorkbookImport {
+        sheets,
+        missing_sheets,
+        workbook_sheet_names,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn d(y: i32, m: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, day).unwrap()
+    }
+
+    #[test]
+    fn net_rtr_header_explicit_years() {
+        assert_eq!(
+            parse_net_rtr_header("Net RTR 6/30/26", None),
+            Some(d(2026, 6, 30))
+        );
+        assert_eq!(
+            parse_net_rtr_header("Net RTR 4/30/2026", None),
+            Some(d(2026, 4, 30))
+        );
+        assert_eq!(
+            parse_net_rtr_header("Net RTR 8/29/25", None),
+            Some(d(2025, 8, 29))
+        );
+    }
+
+    #[test]
+    fn net_rtr_header_inferred_years() {
+        // No context: default 2025
+        assert_eq!(
+            parse_net_rtr_header("Net RTR 2/9", None),
+            Some(d(2025, 2, 9))
+        );
+        // Same year while months ascend
+        assert_eq!(
+            parse_net_rtr_header("Net RTR 9/5", Some(d(2025, 8, 29))),
+            Some(d(2025, 9, 5))
+        );
+        // Month wraps -> next year
+        assert_eq!(
+            parse_net_rtr_header("Net RTR 1/3", Some(d(2025, 12, 27))),
+            Some(d(2026, 1, 3))
+        );
+    }
+
+    #[test]
+    fn net_rtr_header_rejects_non_matches() {
+        assert_eq!(parse_net_rtr_header("HIDE", None), None);
+        assert_eq!(parse_net_rtr_header("Net RTR", None), None);
+        assert_eq!(parse_net_rtr_header("Total RTR 2/9", None), None);
+    }
+
+    #[test]
+    fn excel_serial_dates() {
+        // 2024-02-08 = serial 45330
+        assert_eq!(excel_serial_to_date(45330.0), Some(d(2024, 2, 8)));
+        assert_eq!(excel_serial_to_date(0.0), None);
+        assert_eq!(excel_serial_to_date(300000.0), None);
+    }
+
+    #[test]
+    fn numeric_ids_render_without_decimal() {
+        assert_eq!(
+            cell_str(&Data::Float(7948392.0)),
+            Some("7948392".to_string())
+        );
+        assert_eq!(
+            cell_str(&Data::String("  BHB-001 ".to_string())),
+            Some("BHB-001".to_string())
+        );
+        assert_eq!(cell_str(&Data::String("   ".to_string())), None);
+    }
+
+    #[test]
+    fn funding_source_flags() {
+        assert!(cell_flag(&Data::String("New  ".to_string())));
+        assert!(cell_flag(&Data::String("RTR".to_string())));
+        assert!(!cell_flag(&Data::String(" ".to_string())));
+        assert!(!cell_flag(&Data::Empty));
+    }
+
+    /// Baseline counts from a Python/openpyxl probe of the real workbook
+    /// (2026-07-10). Requires the gitignored examples/ directory:
+    /// `cargo test parses_real_alder_workbook -- --ignored`
+    #[test]
+    #[ignore]
+    fn parses_real_alder_workbook() {
+        let result = parse_portfolio_workbook(
+            "../examples/Alder_Portfolio_Updated_2026-06-30.xlsx".to_string(),
+            vec![
+                "BHB", "BIG", "CV", "EFin", "InAd", "PayVa", "R'bull", "ACS", "Boom", "Kings",
+                "VSPR",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        )
+        .expect("workbook should parse");
+
+        assert!(result.missing_sheets.is_empty());
+
+        // (sheet, fee, deals, payments)
+        let expected = [
+            ("BHB", 0.03, 400, 8164),
+            ("BIG", 0.04, 383, 4070),
+            ("CV", 0.03, 235, 4359),
+            ("EFin", 0.03, 244, 5369),
+            ("InAd", 0.035, 62, 541),
+            ("PayVa", 0.05, 206, 556),
+            ("R'bull", 0.03, 18, 0),
+            ("ACS", 0.03, 46, 993),
+            ("Boom", 0.04, 31, 789),
+            ("Kings", 0.03, 38, 738),
+            ("VSPR", 0.03, 24, 548),
+        ];
+        assert_eq!(result.sheets.len(), expected.len());
+        for (sheet, (name, fee, deals, payments)) in result.sheets.iter().zip(expected) {
+            assert_eq!(sheet.sheet_name, name);
+            assert_eq!(sheet.management_fee_rate, Some(fee), "{} fee", name);
+            assert_eq!(sheet.deals.len(), deals, "{} deal count", name);
+            assert_eq!(sheet.payment_count, payments, "{} payment count", name);
+            // No real row lacks an advance id, so nothing may be skipped
+            assert!(
+                sheet.warnings.iter().all(|w| !w.contains("skipped")),
+                "{}: {:?}",
+                name,
+                sheet.warnings
+            );
+        }
+
+        // Spot-check the first BHB deal against the raw sheet values
+        let bhb = &result.sheets[0].deals[0];
+        assert_eq!(bhb.advance_id.as_deref(), Some("BHB-001"));
+        assert_eq!(bhb.funder_advance_id.as_deref(), Some("40538"));
+        assert_eq!(bhb.merchant_name, "MARCUS TRAILERS LLC");
+        assert_eq!(bhb.date_funded.as_deref(), Some("2024-02-08"));
+        assert_eq!(bhb.date_closed.as_deref(), Some("2026-03-31"));
+        assert_eq!(bhb.fico, Some(675));
+        assert_eq!(bhb.buy_rate, Some(1.29));
+        assert_eq!(bhb.commission_rate, Some(0.14));
+        assert_eq!(bhb.total_funded_amount, Some(15000.0));
+        assert_eq!(bhb.num_weekly_payments, Some(32));
+        assert_eq!(bhb.participation_amount, Some(2000.0));
+        assert!(bhb.new_dollars); // "New"
+        assert!(!bhb.rtr);
+        assert!(!bhb.is_default);
+        assert_eq!(bhb.state.as_deref(), Some("NE"));
+        assert_eq!(bhb.industry.as_deref(), Some("Automotive: Trailer Sales"));
+    }
+
+    #[test]
+    fn default_column_truthiness() {
+        assert!(cell_yes(&Data::String("Yes".to_string())));
+        assert!(cell_yes(&Data::String("YES ".to_string())));
+        assert!(!cell_yes(&Data::String("No".to_string())));
+        assert!(!cell_yes(&Data::Empty));
+    }
+}

--- a/src/components/portfolio/workbook-import-wizard.tsx
+++ b/src/components/portfolio/workbook-import-wizard.tsx
@@ -1,0 +1,369 @@
+import { useState } from "react";
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Table,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+  Progress,
+} from "@heroui/react";
+import { Icon } from "@iconify/react";
+import { open } from "@tauri-apps/plugin-dialog";
+import WorkbookImportService, {
+  WorkbookImportPreview,
+  SheetImportResult,
+} from "@services/workbook-import-service";
+
+interface WorkbookImportWizardProps {
+  portfolioName: string;
+}
+
+type WizardStep = "idle" | "parsing" | "preview" | "importing" | "summary";
+
+const money = (value: number) =>
+  `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const pct = (value: number | null) => (value === null ? "—" : `${(value * 100).toFixed(1)}%`);
+
+/**
+ * Phase 3 one-time onboarding: parse a portfolio workbook locally (Rust),
+ * preview per-sheet deal/payment counts, then import each funder sheet into
+ * Supabase via the import_funder_sheet RPC. Safe to re-run — imports are
+ * idempotent per (advance id, funder advance id).
+ */
+export function WorkbookImportWizard({ portfolioName }: WorkbookImportWizardProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [step, setStep] = useState<WizardStep>("idle");
+  const [preview, setPreview] = useState<WorkbookImportPreview | null>(null);
+  const [results, setResults] = useState<Map<string, SheetImportResult>>(new Map());
+  const [currentSheet, setCurrentSheet] = useState<string | null>(null);
+  const [completedSheets, setCompletedSheets] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setStep("idle");
+    setPreview(null);
+    setResults(new Map());
+    setCurrentSheet(null);
+    setCompletedSheets(0);
+    setError(null);
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    // Don't allow closing mid-import; a per-sheet transaction is running
+    if (!open && step === "importing") return;
+    setIsOpen(open);
+    if (!open) reset();
+  };
+
+  const pickAndParse = async () => {
+    setError(null);
+    try {
+      const filePath = await open({
+        multiple: false,
+        directory: false,
+        filters: [{ name: "Excel Workbook", extensions: ["xlsx", "xlsm"] }],
+      });
+      if (typeof filePath !== "string") return; // cancelled
+      setStep("parsing");
+      setPreview(await WorkbookImportService.preview(portfolioName, filePath));
+      setStep("preview");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setStep("idle");
+    }
+  };
+
+  const runImport = async () => {
+    if (!preview) return;
+    setStep("importing");
+    setError(null);
+    setCompletedSheets(0);
+    const collected = new Map<string, SheetImportResult>();
+    try {
+      await WorkbookImportService.importAll(preview, (progress) => {
+        setCurrentSheet(progress.sheetName);
+        if (progress.phase === "done") {
+          collected.set(progress.sheetName, progress.result);
+          setResults(new Map(collected));
+          setCompletedSheets(progress.index + 1);
+        }
+      });
+      setStep("summary");
+    } catch (e) {
+      // Per-sheet transactions: completed sheets are saved, re-running skips
+      // nothing but is idempotent. Show what landed alongside the error.
+      setError(e instanceof Error ? e.message : String(e));
+      setResults(new Map(collected));
+      setStep("summary");
+    } finally {
+      setCurrentSheet(null);
+    }
+  };
+
+  const totalDeals = preview?.sheets.reduce((n, s) => n + s.sheet.deals.length, 0) ?? 0;
+  const totalPayments = preview?.sheets.reduce((n, s) => n + s.sheet.payment_count, 0) ?? 0;
+  const totalNet = preview?.sheets.reduce((n, s) => n + s.sheet.total_net_payments, 0) ?? 0;
+  const allWarnings = preview?.sheets.flatMap((s) => s.sheet.warnings) ?? [];
+  const unmatchedIndustries = [
+    ...new Set([...results.values()].flatMap((r) => r.unmatched_industries)),
+  ];
+  const unmatchedStates = [...new Set([...results.values()].flatMap((r) => r.unmatched_states))];
+
+  return (
+    <>
+      <div className="max-w-6xl mx-auto mt-6 p-6 bg-default-50 rounded-lg border border-default-200">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-xl font-semibold text-foreground">Import Portfolio Workbook</h3>
+            <p className="text-sm text-default-500 mt-1">
+              One-time onboarding: load every deal and historical Net RTR payment from the{" "}
+              {portfolioName} workbook into the cloud database.
+            </p>
+          </div>
+          <Button
+            color="primary"
+            variant="flat"
+            onPress={() => setIsOpen(true)}
+            startContent={<Icon icon="material-symbols:database-upload" className="w-5 h-5" />}
+          >
+            Import Workbook
+          </Button>
+        </div>
+      </div>
+
+      <Modal isOpen={isOpen} onOpenChange={handleOpenChange} size="4xl" scrollBehavior="inside">
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader className="flex flex-col gap-1">
+                <h2 className="text-2xl font-bold">Import {portfolioName} Workbook</h2>
+                <p className="text-sm text-default-500 font-normal">
+                  {step === "preview"
+                    ? "Review what was parsed before anything is written to the database."
+                    : step === "summary"
+                      ? "Import results per funder sheet."
+                      : "Select the portfolio workbook (.xlsx) to import deals and payment history."}
+                </p>
+              </ModalHeader>
+              <ModalBody>
+                {error && (
+                  <div className="p-3 bg-danger-50 border border-danger-200 rounded-lg text-sm text-danger-700">
+                    {error}
+                  </div>
+                )}
+
+                {(step === "idle" || step === "parsing") && (
+                  <div className="flex flex-col items-center gap-4 py-10">
+                    <Icon
+                      icon="material-symbols:table-chart-view"
+                      className="w-12 h-12 text-default-400"
+                    />
+                    <Button
+                      color="primary"
+                      onPress={pickAndParse}
+                      isLoading={step === "parsing"}
+                      startContent={
+                        step !== "parsing" && (
+                          <Icon icon="material-symbols:folder-open" className="w-4 h-4" />
+                        )
+                      }
+                    >
+                      {step === "parsing" ? "Parsing workbook…" : "Choose Workbook File"}
+                    </Button>
+                  </div>
+                )}
+
+                {step === "preview" && preview && (
+                  <>
+                    <Table aria-label="Parsed funder sheets" isStriped removeWrapper>
+                      <TableHeader>
+                        <TableColumn>SHEET</TableColumn>
+                        <TableColumn>FUNDER</TableColumn>
+                        <TableColumn align="end">MGMT FEE</TableColumn>
+                        <TableColumn align="end">DEALS</TableColumn>
+                        <TableColumn align="end">PAYMENTS</TableColumn>
+                        <TableColumn align="end">NET RTR TOTAL</TableColumn>
+                      </TableHeader>
+                      <TableBody>
+                        {preview.sheets.map((s) => (
+                          <TableRow key={s.sheet.sheet_name}>
+                            <TableCell className="font-mono text-sm">
+                              {s.sheet.sheet_name}
+                            </TableCell>
+                            <TableCell className="font-medium">{s.funderName}</TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              {pct(s.sheet.management_fee_rate)}
+                              {s.currentFeeRate !== null &&
+                                s.sheet.management_fee_rate !== null &&
+                                s.currentFeeRate !== s.sheet.management_fee_rate && (
+                                  <span className="text-warning-600">
+                                    {" "}
+                                    (was {pct(s.currentFeeRate)})
+                                  </span>
+                                )}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              {s.sheet.deals.length}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              {s.sheet.payment_count}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              {money(s.sheet.total_net_payments)}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+
+                    <div className="flex items-center gap-4 text-sm font-medium px-1">
+                      <span>Total: {totalDeals} deals</span>
+                      <span>{totalPayments} payments</span>
+                      <span>{money(totalNet)} net RTR</span>
+                    </div>
+
+                    {preview.missingSheets.length > 0 && (
+                      <p className="text-xs text-default-500">
+                        Not in this workbook: {preview.missingSheets.join(", ")}
+                      </p>
+                    )}
+                    {allWarnings.length > 0 && (
+                      <div className="p-3 bg-warning-50 border border-warning-200 rounded-lg">
+                        <p className="text-sm font-medium text-warning-700 mb-1">
+                          {allWarnings.length} parser warning{allWarnings.length === 1 ? "" : "s"}
+                        </p>
+                        <ul className="text-xs text-warning-700 list-disc pl-4 max-h-24 overflow-y-auto">
+                          {allWarnings.map((w, i) => (
+                            <li key={i}>{w}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {step === "importing" && preview && (
+                  <div className="flex flex-col gap-3 py-6">
+                    <Progress
+                      aria-label="Import progress"
+                      value={(completedSheets / preview.sheets.length) * 100}
+                      showValueLabel
+                    />
+                    <p className="text-sm text-default-600 text-center">
+                      {currentSheet
+                        ? `Importing ${currentSheet}… (${completedSheets}/${preview.sheets.length} sheets done)`
+                        : `${completedSheets}/${preview.sheets.length} sheets done`}
+                    </p>
+                  </div>
+                )}
+
+                {step === "summary" && (
+                  <>
+                    <Table aria-label="Import results" isStriped removeWrapper>
+                      <TableHeader>
+                        <TableColumn>SHEET</TableColumn>
+                        <TableColumn align="end">DEALS</TableColumn>
+                        <TableColumn align="end">MERCHANTS</TableColumn>
+                        <TableColumn align="end">PAYMENTS</TableColumn>
+                        <TableColumn align="end">NET WRITTEN</TableColumn>
+                        <TableColumn align="end">SKIPPED</TableColumn>
+                      </TableHeader>
+                      <TableBody>
+                        {[...results.entries()].map(([sheetName, r]) => (
+                          <TableRow key={sheetName}>
+                            <TableCell className="font-mono text-sm">{sheetName}</TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              {r.deals_imported}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              {r.merchants_upserted}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              {r.payments_inserted}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              {money(r.payments_net_inserted)}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              {r.rows_skipped + r.duplicate_rows_dropped || ""}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+
+                    {(unmatchedIndustries.length > 0 || unmatchedStates.length > 0) && (
+                      <div className="p-3 bg-default-100 rounded-lg text-xs text-default-600 space-y-2">
+                        {unmatchedIndustries.length > 0 && (
+                          <p>
+                            <span className="font-medium">
+                              {unmatchedIndustries.length} industries
+                            </span>{" "}
+                            had no match in the lookup table (merchants imported without an
+                            industry): {unmatchedIndustries.slice(0, 12).join(", ")}
+                            {unmatchedIndustries.length > 12 && " …"}
+                          </p>
+                        )}
+                        {unmatchedStates.length > 0 && (
+                          <p>
+                            <span className="font-medium">{unmatchedStates.length} states</span>{" "}
+                            unmatched: {unmatchedStates.slice(0, 12).join(", ")}
+                            {unmatchedStates.length > 12 && " …"}
+                          </p>
+                        )}
+                      </div>
+                    )}
+                    {!error && (
+                      <div className="flex items-center gap-2 text-success-600 text-sm">
+                        <Icon icon="material-symbols:check-circle" className="w-5 h-5" />
+                        Workbook imported. Monthly funder uploads take it from here.
+                      </div>
+                    )}
+                  </>
+                )}
+              </ModalBody>
+              <ModalFooter>
+                {step === "preview" && (
+                  <>
+                    <Button variant="flat" onPress={onClose}>
+                      Cancel
+                    </Button>
+                    <Button
+                      color="primary"
+                      onPress={runImport}
+                      startContent={
+                        <Icon icon="material-symbols:cloud-upload" className="w-4 h-4" />
+                      }
+                    >
+                      Import {preview?.sheets.length ?? 0} Sheets
+                    </Button>
+                  </>
+                )}
+                {step === "summary" && (
+                  <Button color="primary" onPress={onClose}>
+                    Done
+                  </Button>
+                )}
+                {(step === "idle" || step === "parsing") && (
+                  <Button variant="flat" onPress={onClose} isDisabled={step === "parsing"}>
+                    Cancel
+                  </Button>
+                )}
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+export default WorkbookImportWizard;

--- a/src/pages/alder-portfolio.tsx
+++ b/src/pages/alder-portfolio.tsx
@@ -7,6 +7,7 @@ import { useFileErrorState } from "@/hooks/use-file-error-state";
 import { useCloudSync } from "@/hooks/use-cloud-sync";
 import { UnmatchedDealsResultModal } from "@components/portfolio/unmatched-deals-result-modal";
 import PivotReconciliationModal from "@components/portfolio/pivot-reconciliation-modal";
+import WorkbookImportWizard from "@components/portfolio/workbook-import-wizard";
 
 const PORTFOLIO = "Alder";
 
@@ -304,6 +305,8 @@ function AlderPortfolio() {
         canUpdateNetRtr={canUpdateNetRtr}
         isUpdatingNetRtr={isUpdatingNetRtr}
       />
+
+      <WorkbookImportWizard portfolioName={PORTFOLIO} />
 
       {/* Uploaded Files Summary */}
       {selectedDate && funderUploads.length > 0 && (

--- a/src/pages/white-rabbit-portfolio.tsx
+++ b/src/pages/white-rabbit-portfolio.tsx
@@ -7,6 +7,7 @@ import { useFileErrorState } from "@/hooks/use-file-error-state";
 import { useCloudSync } from "@/hooks/use-cloud-sync";
 import { UnmatchedDealsResultModal } from "@components/portfolio/unmatched-deals-result-modal";
 import PivotReconciliationModal from "@components/portfolio/pivot-reconciliation-modal";
+import WorkbookImportWizard from "@components/portfolio/workbook-import-wizard";
 
 const PORTFOLIO = "White Rabbit";
 
@@ -298,6 +299,8 @@ function WhiteRabbitPortfolio() {
         canUpdateNetRtr={canUpdateNetRtr}
         isUpdatingNetRtr={isUpdatingNetRtr}
       />
+
+      <WorkbookImportWizard portfolioName={PORTFOLIO} />
 
       {/* Uploaded Files Summary */}
       {selectedDate && funderUploads.length > 0 && (

--- a/src/services/supabase.types.ts
+++ b/src/services/supabase.types.ts
@@ -736,6 +736,16 @@ export interface Database {
         Args: { p_row_id: string; p_deal_id: string };
         Returns: Json;
       };
+      import_funder_sheet: {
+        Args: {
+          p_portfolio_id: number;
+          p_funder_id: number;
+          p_management_fee_rate: number | null;
+          p_deals: Json;
+          p_total_net_payments: number;
+        };
+        Returns: Json;
+      };
     };
     Enums: {
       user_role: "admin" | "member";

--- a/src/services/workbook-import-service.ts
+++ b/src/services/workbook-import-service.ts
@@ -1,0 +1,202 @@
+import { invoke } from "@tauri-apps/api/core";
+import { supabase } from "./supabase";
+import type { Json } from "./supabase.types";
+
+/** One Net RTR cell from the workbook's weekly payment matrix. */
+export interface ImportPayment {
+  payment_date: string;
+  net: number;
+}
+
+/** One deal row parsed from a funder sheet (Rust `parse_portfolio_workbook`). */
+export interface ImportDeal {
+  row: number;
+  merchant_name: string;
+  website: string | null;
+  advance_id: string | null;
+  funder_advance_id: string | null;
+  industry: string | null;
+  state: string | null;
+  fico: number | null;
+  buy_rate: number | null;
+  commission_rate: number | null;
+  total_funded_amount: number | null;
+  num_daily_payments: number | null;
+  num_weekly_payments: number | null;
+  participation_amount: number | null;
+  new_dollars: boolean;
+  rtr: boolean;
+  is_default: boolean;
+  date_funded: string | null;
+  date_closed: string | null;
+  default_date: string | null;
+  payments: ImportPayment[];
+}
+
+export interface SheetImport {
+  sheet_name: string;
+  management_fee_rate: number | null;
+  deals: ImportDeal[];
+  payment_dates: string[];
+  payment_count: number;
+  total_net_payments: number;
+  warnings: string[];
+}
+
+export interface WorkbookImport {
+  sheets: SheetImport[];
+  missing_sheets: string[];
+  workbook_sheet_names: string[];
+}
+
+/** Summary returned by the `import_funder_sheet` RPC for one sheet. */
+export interface SheetImportResult {
+  deals_in_payload: number;
+  deals_imported: number;
+  rows_skipped: number;
+  duplicate_rows_dropped: number;
+  merchants_upserted: number;
+  payments_deleted: number;
+  payments_inserted: number;
+  payments_net_inserted: number;
+  payments_net_dropped: number;
+  management_fee_rate: number;
+  unmatched_industries: string[];
+  unmatched_states: string[];
+}
+
+/** One funder sheet ready to import: parse result + resolved Supabase funder. */
+export interface SheetPreview {
+  sheet: SheetImport;
+  funderId: number;
+  funderName: string;
+  /** Fee currently stored on portfolio_funders (null when not linked yet) */
+  currentFeeRate: number | null;
+}
+
+export interface WorkbookImportPreview {
+  portfolioId: number;
+  portfolioName: string;
+  filePath: string;
+  sheets: SheetPreview[];
+  /** Funder sheets registered in Supabase but absent from this workbook */
+  missingSheets: string[];
+}
+
+export type ImportProgress =
+  | { phase: "importing"; index: number; total: number; sheetName: string }
+  | {
+      phase: "done";
+      index: number;
+      total: number;
+      sheetName: string;
+      result: SheetImportResult;
+    };
+
+export class WorkbookImportService {
+  /**
+   * Parse the workbook (Rust/calamine) and resolve each funder sheet against
+   * Supabase. Nothing is written yet — the wizard shows this as a preview.
+   */
+  static async preview(portfolioName: string, filePath: string): Promise<WorkbookImportPreview> {
+    const { data: portfolio, error: portfolioError } = await supabase
+      .from("portfolios")
+      .select("id")
+      .eq("name", portfolioName)
+      .single();
+    if (portfolioError || !portfolio) {
+      throw new Error(`Portfolio "${portfolioName}" not found: ${portfolioError?.message}`);
+    }
+
+    const { data: funders, error: fundersError } = await supabase
+      .from("funders")
+      .select("id, name, sheet_name")
+      .not("sheet_name", "is", null);
+    if (fundersError || !funders?.length) {
+      throw new Error(`Failed to load funders: ${fundersError?.message}`);
+    }
+
+    const { data: links, error: linksError } = await supabase
+      .from("portfolio_funders")
+      .select("funder_id, management_fee_rate")
+      .eq("portfolio_id", portfolio.id);
+    if (linksError) {
+      throw new Error(`Failed to load portfolio funders: ${linksError.message}`);
+    }
+    const feeByFunder = new Map(links?.map((l) => [l.funder_id, l.management_fee_rate]) ?? []);
+
+    const parse = await invoke<WorkbookImport>("parse_portfolio_workbook", {
+      filePath,
+      sheetNames: funders.map((f) => f.sheet_name),
+    });
+
+    const bySheet = new Map(funders.map((f) => [f.sheet_name, f]));
+    const sheets: SheetPreview[] = parse.sheets.map((sheet) => {
+      const funder = bySheet.get(sheet.sheet_name);
+      if (!funder) {
+        throw new Error(`No funder registered for sheet "${sheet.sheet_name}"`);
+      }
+      return {
+        sheet,
+        funderId: funder.id,
+        funderName: funder.name,
+        currentFeeRate: feeByFunder.get(funder.id) ?? null,
+      };
+    });
+
+    return {
+      portfolioId: portfolio.id,
+      portfolioName,
+      filePath,
+      sheets,
+      missingSheets: parse.missing_sheets,
+    };
+  }
+
+  /** Import one funder sheet transactionally via the import_funder_sheet RPC. */
+  static async importSheet(portfolioId: number, preview: SheetPreview): Promise<SheetImportResult> {
+    const { data, error } = await supabase.rpc("import_funder_sheet", {
+      p_portfolio_id: portfolioId,
+      p_funder_id: preview.funderId,
+      p_management_fee_rate: preview.sheet.management_fee_rate,
+      p_deals: preview.sheet.deals as unknown as Json,
+      p_total_net_payments: preview.sheet.total_net_payments,
+    });
+    if (error) {
+      throw new Error(`Import failed for ${preview.funderName}: ${error.message}`);
+    }
+    return data as unknown as SheetImportResult;
+  }
+
+  /**
+   * Import every parsed sheet sequentially (one transaction per sheet, so a
+   * failure mid-way leaves earlier sheets imported — safe to re-run).
+   */
+  static async importAll(
+    preview: WorkbookImportPreview,
+    onProgress?: (progress: ImportProgress) => void
+  ): Promise<Map<string, SheetImportResult>> {
+    const results = new Map<string, SheetImportResult>();
+    const total = preview.sheets.length;
+    for (const [index, sheetPreview] of preview.sheets.entries()) {
+      onProgress?.({
+        phase: "importing",
+        index,
+        total,
+        sheetName: sheetPreview.sheet.sheet_name,
+      });
+      const result = await this.importSheet(preview.portfolioId, sheetPreview);
+      results.set(sheetPreview.sheet.sheet_name, result);
+      onProgress?.({
+        phase: "done",
+        index,
+        total,
+        sheetName: sheetPreview.sheet.sheet_name,
+        result,
+      });
+    }
+    return results;
+  }
+}
+
+export default WorkbookImportService;

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,396 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "Excelerate-Desktop"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = false
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./declarative"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260710135856_phase3_workbook_import.sql
+++ b/supabase/migrations/20260710135856_phase3_workbook_import.sql
@@ -1,0 +1,666 @@
+-- Phase 3: one-time workbook import.
+--
+-- import_funder_sheet is the single write path from the parsed workbook
+-- (Rust parse_portfolio_workbook command) into deals + net_rtr_payments,
+-- one call per funder sheet. Like commit_funder_pivot it is SECURITY INVOKER
+-- (caller's RLS applies) and refuses the transaction unless the payload's
+-- payment total matches the parser's total within a cent.
+--
+-- Import identity: the workbooks contain duplicate *internal* advance ids
+-- that are genuinely distinct deals (e.g. Alder BHB-264 covers both CRICKET
+-- MOVES and UNCLOG NYC with different funder advance ids), and a handful of
+-- rows with no funder advance id — so neither column alone is a key. The
+-- composite (advance_id, funder_advance_id) was verified unique across every
+-- sheet of both workbooks (2026-07-10), and becomes the re-import upsert key.
+
+-- The real data has funded/participation amounts with cents (39 PayVa deals,
+-- e.g. $1,346.16); integer columns would corrupt the cost-basis math. The
+-- Phase 1 views depend on these columns, so they are dropped and recreated
+-- verbatim around the ALTER (weekly_rtr_matrix doesn't reference them and
+-- stays put).
+DROP VIEW funder_allocation_current;
+DROP VIEW portfolio_monthly;
+DROP VIEW monthly_vintage_stats;
+DROP VIEW deal_computed;
+
+ALTER TABLE deals
+  ALTER COLUMN total_amount_funded TYPE numeric,
+  ALTER COLUMN participation_on_amount TYPE numeric;
+
+-- Recreated from 20260710013534_phase1_analytics_views.sql, definitions
+-- unchanged (the ::numeric casts on the widened columns are now no-ops).
+-- ---------------------------------------------------------------------------
+-- deal_computed: one row per deal — the derived columns K..AV of a funder
+-- deal sheet.
+-- ---------------------------------------------------------------------------
+CREATE VIEW deal_computed
+WITH (security_invoker = true) AS
+WITH base AS (
+  SELECT
+    d.id,
+    d.portfolio_id,
+    d.funder_id,
+    d.merchant_id,
+    d.advance_id,
+    d.funder_advance_id,
+    d.fico,
+    d.date_funded,
+    d.date_closed,
+    d.is_default,
+    d.new_dollars,
+    d.rtr,
+    d.buy_rate,
+    d.commission,
+    (date_trunc('month', d.date_funded))::date AS vintage_month,
+    d.total_amount_funded::numeric AS total_amount_funded,
+    d.participation_on_amount::numeric AS participation_on_amount,
+    COALESCE(pf.management_fee_rate, 0) AS management_fee_rate,
+    -- K: sell rate = I + J
+    d.buy_rate + d.commission AS sell_rate,
+    -- M: commission $ = L * J
+    d.total_amount_funded * d.commission AS commission_dollars,
+    -- N: total RTR = L * K
+    d.total_amount_funded * (d.buy_rate + d.commission) AS total_rtr,
+    -- Q: term (months) = IF(ISBLANK(O), P/4.3, O/20)
+    CASE WHEN d.num_daily_payments IS NULL
+         THEN d.num_weekly_payments / 4.3
+         ELSE d.num_daily_payments / 20.0
+    END AS term_months,
+    d.num_daily_payments IS NOT NULL AS is_daily,
+    COALESCE(d.num_daily_payments, d.num_weekly_payments)::numeric AS num_payments
+  FROM deals d
+  LEFT JOIN portfolio_funders pf
+    ON pf.portfolio_id = d.portfolio_id AND pf.funder_id = d.funder_id
+),
+rh AS (
+  SELECT
+    b.*,
+    -- W: R&H % of deal = R / L
+    COALESCE(b.participation_on_amount / NULLIF(b.total_amount_funded, 0), 0) AS rh_pct_of_deal
+  FROM base b
+),
+cost AS (
+  SELECT
+    r.*,
+    -- X: pro-rata commission paid = M * W
+    COALESCE(r.commission_dollars * r.rh_pct_of_deal, 0) AS pro_rata_commission,
+    -- Z: R&H pro-rata RTR = N * W
+    COALESCE(r.total_rtr * r.rh_pct_of_deal, 0) AS rh_rtr
+  FROM rh r
+),
+net AS (
+  SELECT
+    c.*,
+    -- Y: R&H cost basis = R + X
+    COALESCE(c.participation_on_amount + c.pro_rata_commission, 0) AS cost_basis,
+    -- AA: net RTR (fee-adjusted) = Z - Z * B$1
+    c.rh_rtr * (1 - c.management_fee_rate) AS net_rtr,
+    -- AD: gross payment expected = Z / (O or P)
+    c.rh_rtr / NULLIF(c.num_payments, 0) AS gross_payment_expected
+  FROM cost c
+),
+received AS (
+  SELECT
+    deal_id,
+    SUM(net) AS total_net_received,
+    SUM(gross) AS total_gross_received,
+    SUM(fee) AS total_fee_paid
+  FROM net_rtr_payments
+  GROUP BY deal_id
+)
+SELECT
+  n.id,
+  n.portfolio_id,
+  n.funder_id,
+  n.merchant_id,
+  n.advance_id,
+  n.funder_advance_id,
+  n.fico,
+  n.date_funded,
+  n.date_closed,
+  n.is_default,
+  n.new_dollars,
+  n.rtr,
+  n.vintage_month,
+  n.buy_rate,
+  n.commission,
+  n.sell_rate,
+  n.total_amount_funded,
+  n.participation_on_amount,
+  n.management_fee_rate,
+  n.commission_dollars,
+  n.total_rtr,
+  n.term_months,
+  n.is_daily,
+  n.rh_pct_of_deal,
+  n.pro_rata_commission,
+  n.rh_rtr,
+  n.cost_basis,
+  n.net_rtr,
+  -- U / V: cost basis at work, split by funding source flag
+  CASE WHEN n.new_dollars THEN n.cost_basis ELSE 0 END AS new_dollars_at_work,
+  CASE WHEN n.rtr THEN n.cost_basis ELSE 0 END AS rtr_dollars_at_work,
+  -- AB: "all in" factor = AA / Y
+  n.net_rtr / NULLIF(n.cost_basis, 0) AS all_in_factor,
+  -- AC: points per month = ((AB - 1) / Q) * 100
+  (n.net_rtr / NULLIF(n.cost_basis, 0) - 1) / NULLIF(n.term_months, 0) * 100 AS points_per_month,
+  n.gross_payment_expected,
+  -- AF: net payment expected = AD - AD * fee
+  n.gross_payment_expected * (1 - n.management_fee_rate) AS net_payment_expected,
+  -- AG: weekly payment expected = IF(ISBLANK(O), AF, AF*5); blank once closed
+  CASE WHEN n.date_closed IS NULL
+       THEN n.gross_payment_expected * (1 - n.management_fee_rate)
+            * CASE WHEN n.is_daily THEN 5 ELSE 1 END
+       ELSE 0
+  END AS weekly_payment_expected,
+  -- AI: total net RTR received = SUM(payment matrix)
+  COALESCE(r.total_net_received, 0) AS total_net_received,
+  COALESCE(r.total_gross_received, 0) AS total_gross_received,
+  COALESCE(r.total_fee_paid, 0) AS total_fee_paid,
+  -- AJ: net RTR balance = AA - AI
+  n.net_rtr - COALESCE(r.total_net_received, 0) AS net_rtr_balance,
+  -- AK: % of RTR paid = AI / AA
+  COALESCE(COALESCE(r.total_net_received, 0) / NULLIF(n.net_rtr, 0), 0) AS pct_rtr_paid,
+  -- AL: return on cost basis = AI / Y
+  COALESCE(COALESCE(r.total_net_received, 0) / NULLIF(n.cost_basis, 0), 0) AS return_on_cost_basis,
+  -- AR: bad debt adjustment = IF(default, AJ, "")
+  CASE WHEN n.is_default THEN n.net_rtr - COALESCE(r.total_net_received, 0) ELSE 0 END AS bad_debt_rtr,
+  -- AT: default $ lost = IF(default, AI - Y, "")
+  CASE WHEN n.is_default THEN COALESCE(r.total_net_received, 0) - n.cost_basis END AS default_dollars_lost
+FROM net n
+LEFT JOIN received r ON r.deal_id = n.id;
+-- ---------------------------------------------------------------------------
+-- monthly_vintage_stats: the per-funder '-P' sheets — one row per
+-- (portfolio, funder, vintage month).
+-- ---------------------------------------------------------------------------
+CREATE VIEW monthly_vintage_stats
+WITH (security_invoker = true) AS
+WITH agg AS (
+  SELECT
+    dc.portfolio_id,
+    dc.funder_id,
+    dc.vintage_month,
+    COUNT(*)::integer AS deal_count,                                -- B
+    SUM(dc.new_dollars_at_work) AS new_invested,                    -- C
+    SUM(dc.rtr_dollars_at_work) AS rtr_invested,                    -- D
+    SUM(dc.participation_on_amount) AS total_participation,         -- E
+    SUM(dc.pro_rata_commission) AS total_commissions,               -- F
+    SUM(dc.cost_basis) AS cost_basis,                               -- G
+    SUM(dc.net_rtr) AS initial_net_rtr,                             -- H
+    SUM(dc.total_net_received) AS rtr_received,                     -- L
+    SUM(dc.net_rtr_balance) AS net_rtr_outstanding,                 -- Q
+    SUM(dc.bad_debt_rtr) AS bad_debt_rtr,                           -- R
+    SUM(dc.weekly_payment_expected) AS expected_weekly_payments,    -- T
+    -- U: workbook sums AP (= per-deal term × share of vintage cost basis),
+    -- i.e. the cost-basis-weighted average term
+    SUM(dc.cost_basis * dc.term_months) / NULLIF(SUM(dc.cost_basis), 0) AS weighted_avg_term_months
+  FROM deal_computed dc
+  GROUP BY dc.portfolio_id, dc.funder_id, dc.vintage_month
+),
+factors AS (
+  SELECT
+    a.*,
+    -- I: weighted avg factor = H / G
+    COALESCE(a.initial_net_rtr / NULLIF(a.cost_basis, 0), 0) AS weighted_avg_factor,
+    -- J: "principal" share = 1 / I
+    COALESCE(a.cost_basis / NULLIF(a.initial_net_rtr, 0), 0) AS principal_pct
+  FROM agg a
+),
+splits AS (
+  SELECT
+    f.*,
+    -- K: "profit" share = 1 - J
+    1 - f.principal_pct AS profit_pct,
+    -- M: principal returned = L * J
+    f.rtr_received * f.principal_pct AS principal_returned,
+    -- N: profit returned = L * K
+    f.rtr_received * (1 - f.principal_pct) AS profit_returned
+  FROM factors f
+)
+SELECT
+  s.portfolio_id,
+  s.funder_id,
+  s.vintage_month,
+  s.deal_count,
+  s.new_invested,
+  s.rtr_invested,
+  s.total_participation,
+  s.total_commissions,
+  s.cost_basis,
+  s.initial_net_rtr,
+  s.weighted_avg_factor,
+  s.principal_pct,
+  s.profit_pct,
+  s.rtr_received,
+  s.principal_returned,
+  s.profit_returned,
+  -- O: cost basis after principal received = G - M
+  s.cost_basis - s.principal_returned AS cost_basis_after_principal,
+  -- P: cost basis final = O - N
+  s.cost_basis - s.principal_returned - s.profit_returned AS cost_basis_final,
+  s.net_rtr_outstanding,
+  s.bad_debt_rtr,
+  -- S: outstanding after bad debt = Q - R
+  s.net_rtr_outstanding - s.bad_debt_rtr AS net_rtr_outstanding_after_bad_debt,
+  s.expected_weekly_payments,
+  s.weighted_avg_term_months,
+  -- V: average cost basis per deal = G / B
+  COALESCE(s.cost_basis / NULLIF(s.deal_count, 0), 0) AS avg_cost_basis_per_deal,
+  -- W: vintage return = (L / G) - 1 (sheet shows "-na-" when negative;
+  -- consumers decide how to render negatives)
+  COALESCE(s.rtr_received / NULLIF(s.cost_basis, 0) - 1, 0) AS vintage_return,
+  -- X: bad debt % per vintage = R / H
+  COALESCE(s.bad_debt_rtr / NULLIF(s.initial_net_rtr, 0), 0) AS bad_debt_pct,
+  -- AA: points per month = (I - 1) / U * 100
+  (s.weighted_avg_factor - 1) / NULLIF(s.weighted_avg_term_months, 0) * 100 AS points_per_month,
+  -- AB: R&H profit share = N * AB$1
+  s.profit_returned * p.profit_share_rate AS profit_share,
+  -- AC: WRC net $ = L - AB
+  s.rtr_received - s.profit_returned * p.profit_share_rate AS wrc_net,
+  -- AD: WRC net vintage return = (AC / G) - 1
+  COALESCE(
+    (s.rtr_received - s.profit_returned * p.profit_share_rate) / NULLIF(s.cost_basis, 0) - 1,
+    0
+  ) AS wrc_net_vintage_return
+FROM splits s
+JOIN portfolios p ON p.id = s.portfolio_id;
+-- ---------------------------------------------------------------------------
+-- portfolio_monthly: the 'ALDER Portfolio' sheet — the '-P' rollups summed
+-- across funders per vintage month. Non-linear ratios (factor, splits) are
+-- recomputed from the portfolio-level sums, exactly as the sheet does
+-- (I3 = H3/G3 over the summed columns).
+-- ---------------------------------------------------------------------------
+CREATE VIEW portfolio_monthly
+WITH (security_invoker = true) AS
+WITH agg AS (
+  SELECT
+    dc.portfolio_id,
+    dc.vintage_month,
+    COUNT(*)::integer AS deal_count,
+    SUM(dc.new_dollars_at_work) AS new_invested,
+    SUM(dc.rtr_dollars_at_work) AS rtr_invested,
+    SUM(dc.participation_on_amount) AS total_participation,
+    SUM(dc.pro_rata_commission) AS total_commissions,
+    SUM(dc.cost_basis) AS cost_basis,
+    SUM(dc.net_rtr) AS initial_net_rtr,
+    SUM(dc.total_net_received) AS rtr_received,
+    SUM(dc.net_rtr_balance) AS net_rtr_outstanding,
+    SUM(dc.bad_debt_rtr) AS bad_debt_rtr,
+    SUM(dc.weekly_payment_expected) AS expected_weekly_payments,
+    -- Sheet U is AVERAGE() of the funder terms; weighting by cost basis is
+    -- used here instead (an unweighted average over-counts small funders)
+    SUM(dc.cost_basis * dc.term_months) / NULLIF(SUM(dc.cost_basis), 0) AS weighted_avg_term_months
+  FROM deal_computed dc
+  GROUP BY dc.portfolio_id, dc.vintage_month
+),
+factors AS (
+  SELECT
+    a.*,
+    COALESCE(a.initial_net_rtr / NULLIF(a.cost_basis, 0), 0) AS weighted_avg_factor,
+    COALESCE(a.cost_basis / NULLIF(a.initial_net_rtr, 0), 0) AS principal_pct
+  FROM agg a
+)
+SELECT
+  f.portfolio_id,
+  f.vintage_month,
+  f.deal_count,
+  f.new_invested,
+  f.rtr_invested,
+  f.total_participation,
+  f.total_commissions,
+  f.cost_basis,
+  f.initial_net_rtr,
+  f.weighted_avg_factor,
+  f.principal_pct,
+  1 - f.principal_pct AS profit_pct,
+  f.rtr_received,
+  f.rtr_received * f.principal_pct AS principal_returned,
+  f.rtr_received * (1 - f.principal_pct) AS profit_returned,
+  f.cost_basis - f.rtr_received * f.principal_pct AS cost_basis_after_principal,
+  f.cost_basis - f.rtr_received AS cost_basis_final,
+  f.net_rtr_outstanding,
+  f.bad_debt_rtr,
+  f.net_rtr_outstanding - f.bad_debt_rtr AS net_rtr_outstanding_after_bad_debt,
+  f.expected_weekly_payments,
+  f.weighted_avg_term_months,
+  COALESCE(f.cost_basis / NULLIF(f.deal_count, 0), 0) AS avg_cost_basis_per_deal,
+  COALESCE(f.rtr_received / NULLIF(f.cost_basis, 0) - 1, 0) AS vintage_return,
+  COALESCE(f.bad_debt_rtr / NULLIF(f.initial_net_rtr, 0), 0) AS bad_debt_pct,
+  (f.weighted_avg_factor - 1) / NULLIF(f.weighted_avg_term_months, 0) * 100 AS points_per_month,
+  f.rtr_received * (1 - f.principal_pct) * p.profit_share_rate AS profit_share,
+  f.rtr_received - f.rtr_received * (1 - f.principal_pct) * p.profit_share_rate AS wrc_net,
+  COALESCE(
+    (f.rtr_received - f.rtr_received * (1 - f.principal_pct) * p.profit_share_rate)
+      / NULLIF(f.cost_basis, 0) - 1,
+    0
+  ) AS wrc_net_vintage_return,
+  p.profit_share_rate,
+  p.dividend_rate
+FROM factors f
+JOIN portfolios p ON p.id = f.portfolio_id;
+-- ---------------------------------------------------------------------------
+-- funder_allocation_current: the 'R&H-ALDER-P' snapshot — current allocation
+-- per funder. Current cost basis is the '-P' P-column total, which reduces to
+-- cost_basis - rtr_received (P = G - M - N and M + N = L).
+-- ---------------------------------------------------------------------------
+CREATE VIEW funder_allocation_current
+WITH (security_invoker = true) AS
+WITH per_funder AS (
+  SELECT
+    dc.portfolio_id,
+    dc.funder_id,
+    SUM(dc.cost_basis) AS initial_cost_basis,
+    SUM(dc.net_rtr) AS initial_net_rtr,
+    SUM(dc.total_net_received) AS rtr_received,
+    SUM(dc.cost_basis * dc.term_months) / NULLIF(SUM(dc.cost_basis), 0) AS weighted_avg_term_months
+  FROM deal_computed dc
+  GROUP BY dc.portfolio_id, dc.funder_id
+),
+calc AS (
+  SELECT
+    pf.*,
+    COALESCE(pf.initial_net_rtr / NULLIF(pf.initial_cost_basis, 0), 0) AS factor,
+    pf.initial_cost_basis - pf.rtr_received AS current_cost_basis
+  FROM per_funder pf
+)
+SELECT
+  c.portfolio_id,
+  c.funder_id,
+  c.initial_cost_basis,
+  c.current_cost_basis,
+  c.rtr_received,
+  c.factor,
+  c.weighted_avg_term_months,
+  -- row 3: % of initial cost basis
+  c.initial_cost_basis
+    / NULLIF(SUM(c.initial_cost_basis) OVER (PARTITION BY c.portfolio_id), 0)
+    AS pct_initial_cost_basis,
+  -- row 5: % of current cost basis
+  c.current_cost_basis
+    / NULLIF(SUM(c.current_cost_basis) OVER (PARTITION BY c.portfolio_id), 0)
+    AS pct_current_cost_basis,
+  -- row 7: term × current allocation share
+  c.weighted_avg_term_months
+    * (c.current_cost_basis
+       / NULLIF(SUM(c.current_cost_basis) OVER (PARTITION BY c.portfolio_id), 0))
+    AS weighted_term_contribution
+FROM calc c;
+
+-- Idempotent re-import keys. Partial on advance_id: the import skips rows
+-- without one, and the monthly flow never inserts deals.
+CREATE UNIQUE INDEX deals_import_key
+  ON deals (portfolio_id, funder_id, advance_id, COALESCE(funder_advance_id, ''))
+  WHERE advance_id IS NOT NULL;
+
+-- merchants is empty live; one merchant row per (portfolio, funder, name).
+CREATE UNIQUE INDEX merchants_import_key
+  ON merchants (portfolio_id, funder_id, lower(name));
+
+CREATE OR REPLACE FUNCTION import_funder_sheet(
+  p_portfolio_id integer,
+  p_funder_id integer,
+  p_management_fee_rate numeric,
+  p_deals jsonb,
+  p_total_net_payments numeric
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_fee numeric;
+  v_payload_net numeric;
+  v_deals_in_payload integer;
+  v_rows_skipped integer;
+  v_net_skipped numeric;
+  v_dupes_dropped integer;
+  v_net_duped numeric;
+  v_deals_imported integer;
+  v_merchants_upserted integer;
+  v_payments_deleted integer;
+  v_payments_inserted integer;
+  v_net_inserted numeric;
+  v_unmatched_industries jsonb;
+  v_unmatched_states jsonb;
+  c_tolerance CONSTANT numeric := 0.01;
+BEGIN
+  IF NOT has_portfolio_access(p_portfolio_id) THEN
+    RAISE EXCEPTION 'No access to portfolio %', p_portfolio_id;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM funders WHERE id = p_funder_id) THEN
+    RAISE EXCEPTION 'Funder % not found', p_funder_id;
+  END IF;
+  IF p_deals IS NULL OR jsonb_typeof(p_deals) <> 'array' THEN
+    RAISE EXCEPTION 'p_deals must be a JSON array of workbook deals';
+  END IF;
+  IF p_management_fee_rate IS NOT NULL
+     AND (p_management_fee_rate < 0 OR p_management_fee_rate >= 1) THEN
+    RAISE EXCEPTION 'Management fee rate % out of range [0, 1)', p_management_fee_rate;
+  END IF;
+
+  v_deals_in_payload := jsonb_array_length(p_deals);
+
+  -- Record the sheet's B1 fee on the portfolio↔funder link (creating the
+  -- link if the funder is new to this portfolio).
+  INSERT INTO portfolio_funders (portfolio_id, funder_id, management_fee_rate)
+  VALUES (p_portfolio_id, p_funder_id, p_management_fee_rate)
+  ON CONFLICT (portfolio_id, funder_id) DO UPDATE
+    SET management_fee_rate = COALESCE(EXCLUDED.management_fee_rate,
+                                       portfolio_funders.management_fee_rate);
+
+  SELECT COALESCE(p_management_fee_rate, management_fee_rate, 0) INTO v_fee
+  FROM portfolio_funders
+  WHERE portfolio_id = p_portfolio_id AND funder_id = p_funder_id;
+
+  -- Guard 1: the payments as received must sum to the parser's total —
+  -- catches truncation or corruption between the Rust parser and this call.
+  SELECT COALESCE(SUM((p->>'net')::numeric), 0)
+  INTO v_payload_net
+  FROM jsonb_array_elements(p_deals) AS d
+  CROSS JOIN LATERAL jsonb_array_elements(COALESCE(d->'payments', '[]'::jsonb)) AS p;
+
+  IF abs(v_payload_net - p_total_net_payments) > c_tolerance THEN
+    RAISE EXCEPTION
+      'Payload payments sum to % but parser total is % (difference exceeds % tolerance)',
+      v_payload_net, p_total_net_payments, c_tolerance;
+  END IF;
+
+  DROP TABLE IF EXISTS _import_rows;
+  CREATE TEMP TABLE _import_rows ON COMMIT DROP AS
+  SELECT
+    t.ord,
+    NULLIF(trim(t.d->>'advance_id'), '')        AS advance_id,
+    NULLIF(trim(t.d->>'funder_advance_id'), '') AS funder_advance_id,
+    NULLIF(trim(t.d->>'merchant_name'), '')     AS merchant_name,
+    NULLIF(trim(t.d->>'website'), '')           AS website,
+    NULLIF(trim(t.d->>'industry'), '')          AS industry,
+    NULLIF(trim(t.d->>'state'), '')             AS state,
+    (t.d->>'fico')::integer                     AS fico,
+    (t.d->>'buy_rate')::numeric                 AS buy_rate,
+    (t.d->>'commission_rate')::numeric          AS commission,
+    (t.d->>'total_funded_amount')::numeric      AS total_amount_funded,
+    (t.d->>'num_daily_payments')::integer       AS num_daily_payments,
+    (t.d->>'num_weekly_payments')::integer      AS num_weekly_payments,
+    (t.d->>'participation_amount')::numeric     AS participation_on_amount,
+    COALESCE((t.d->>'new_dollars')::boolean, false) AS new_dollars,
+    COALESCE((t.d->>'rtr')::boolean, false)         AS rtr,
+    COALESCE((t.d->>'is_default')::boolean, false)  AS is_default,
+    (t.d->>'date_funded')::timestamptz          AS date_funded,
+    (t.d->>'date_closed')::timestamptz          AS date_closed,
+    (t.d->>'default_date')::timestamptz         AS default_date,
+    COALESCE(t.d->'payments', '[]'::jsonb)      AS payments
+  FROM jsonb_array_elements(p_deals) WITH ORDINALITY AS t(d, ord);
+
+  -- Rows the import cannot key (the Rust parser already skips these; belt
+  -- and braces) — drop and account for their payments.
+  SELECT count(*),
+         COALESCE(SUM((SELECT COALESCE(SUM((p->>'net')::numeric), 0)
+                       FROM jsonb_array_elements(r.payments) AS p)), 0)
+  INTO v_rows_skipped, v_net_skipped
+  FROM _import_rows r
+  WHERE r.advance_id IS NULL OR r.merchant_name IS NULL;
+
+  DELETE FROM _import_rows
+  WHERE advance_id IS NULL OR merchant_name IS NULL;
+
+  -- Defensive dedupe on the import key (verified unique in the real
+  -- workbooks; keeps the first occurrence if that ever regresses).
+  WITH dupes AS (
+    DELETE FROM _import_rows a
+    USING _import_rows b
+    WHERE a.advance_id = b.advance_id
+      AND COALESCE(a.funder_advance_id, '') = COALESCE(b.funder_advance_id, '')
+      AND a.ord > b.ord
+    RETURNING a.payments
+  )
+  SELECT count(*),
+         COALESCE(SUM((SELECT COALESCE(SUM((p->>'net')::numeric), 0)
+                       FROM jsonb_array_elements(d.payments) AS p)), 0)
+  INTO v_dupes_dropped, v_net_duped
+  FROM dupes d;
+
+  -- Merchants: one row per name, industry/state resolved against the lookups
+  -- (unmatched names import with NULL and are reported below).
+  INSERT INTO merchants (name, website, industry_id, state_id, funder_id, portfolio_id)
+  SELECT DISTINCT ON (lower(r.merchant_name))
+         r.merchant_name, r.website, i.id, s.id, p_funder_id, p_portfolio_id
+  FROM _import_rows r
+  LEFT JOIN industries i ON lower(i.name) = lower(r.industry)
+  LEFT JOIN states s ON upper(s.code) = upper(r.state) OR lower(s.name) = lower(r.state)
+  ORDER BY lower(r.merchant_name), r.ord
+  ON CONFLICT (portfolio_id, funder_id, lower(name)) DO UPDATE
+    SET website = COALESCE(EXCLUDED.website, merchants.website),
+        industry_id = COALESCE(EXCLUDED.industry_id, merchants.industry_id),
+        state_id = COALESCE(EXCLUDED.state_id, merchants.state_id),
+        updated_at = now();
+  GET DIAGNOSTICS v_merchants_upserted = ROW_COUNT;
+
+  INSERT INTO deals (
+    portfolio_id, funder_id, merchant_id, advance_id, funder_advance_id,
+    fico, buy_rate, commission, total_amount_funded,
+    num_daily_payments, num_weekly_payments, participation_on_amount,
+    new_dollars, rtr, is_default, date_funded, date_closed, default_date
+  )
+  SELECT
+    p_portfolio_id, p_funder_id, m.id, r.advance_id, r.funder_advance_id,
+    r.fico, r.buy_rate, r.commission, r.total_amount_funded,
+    r.num_daily_payments, r.num_weekly_payments, r.participation_on_amount,
+    r.new_dollars, r.rtr, r.is_default, r.date_funded, r.date_closed, r.default_date
+  FROM _import_rows r
+  LEFT JOIN merchants m
+    ON m.portfolio_id = p_portfolio_id
+   AND m.funder_id = p_funder_id
+   AND lower(m.name) = lower(r.merchant_name)
+  ON CONFLICT (portfolio_id, funder_id, advance_id, COALESCE(funder_advance_id, ''))
+    WHERE advance_id IS NOT NULL
+  DO UPDATE SET
+    merchant_id = EXCLUDED.merchant_id,
+    fico = EXCLUDED.fico,
+    buy_rate = EXCLUDED.buy_rate,
+    commission = EXCLUDED.commission,
+    total_amount_funded = EXCLUDED.total_amount_funded,
+    num_daily_payments = EXCLUDED.num_daily_payments,
+    num_weekly_payments = EXCLUDED.num_weekly_payments,
+    participation_on_amount = EXCLUDED.participation_on_amount,
+    new_dollars = EXCLUDED.new_dollars,
+    rtr = EXCLUDED.rtr,
+    is_default = EXCLUDED.is_default,
+    date_funded = EXCLUDED.date_funded,
+    date_closed = EXCLUDED.date_closed,
+    default_date = EXCLUDED.default_date,
+    updated_at = now();
+  GET DIAGNOSTICS v_deals_imported = ROW_COUNT;
+
+  -- Payments: resolve each row's payment list to its deal. Grouped per
+  -- (deal, date) in case two Net RTR columns ever parse to the same date.
+  DROP TABLE IF EXISTS _import_payments;
+  CREATE TEMP TABLE _import_payments ON COMMIT DROP AS
+  SELECT d.id AS deal_id,
+         (p->>'payment_date')::date AS payment_date,
+         SUM((p->>'net')::numeric) AS net
+  FROM _import_rows r
+  JOIN deals d
+    ON d.portfolio_id = p_portfolio_id
+   AND d.funder_id = p_funder_id
+   AND d.advance_id = r.advance_id
+   AND COALESCE(d.funder_advance_id, '') = COALESCE(r.funder_advance_id, '')
+  CROSS JOIN LATERAL jsonb_array_elements(r.payments) AS p
+  GROUP BY d.id, (p->>'payment_date')::date;
+
+  -- The workbook is the source of truth for history: replace all
+  -- import-sourced payments for this portfolio+funder (source_upload_id is
+  -- NULL only for imports; monthly-flow payments keep their upload id).
+  WITH deleted AS (
+    DELETE FROM net_rtr_payments np
+    USING deals d
+    WHERE np.deal_id = d.id
+      AND d.portfolio_id = p_portfolio_id
+      AND d.funder_id = p_funder_id
+      AND np.source_upload_id IS NULL
+    RETURNING np.id
+  )
+  SELECT count(*) INTO v_payments_deleted FROM deleted;
+
+  -- Historical Net RTR is recorded net of the management fee; reconstruct
+  -- gross/fee the same way the monthly parsers compute them (fee = gross ×
+  -- rate), so imported and monthly rows are consistent in the RTR views.
+  INSERT INTO net_rtr_payments (deal_id, payment_date, gross, fee, net, source_upload_id)
+  SELECT
+    ip.deal_id,
+    ip.payment_date,
+    round(ip.net / (1 - v_fee), 2),
+    round(ip.net / (1 - v_fee), 2) - ip.net,
+    ip.net,
+    NULL
+  FROM _import_payments ip
+  ON CONFLICT (deal_id, payment_date) DO UPDATE
+    SET gross = EXCLUDED.gross,
+        fee = EXCLUDED.fee,
+        net = EXCLUDED.net,
+        source_upload_id = NULL;
+  GET DIAGNOSTICS v_payments_inserted = ROW_COUNT;
+
+  SELECT COALESCE(SUM(net), 0) INTO v_net_inserted FROM _import_payments;
+
+  -- Guard 2: every dollar of the parser's payment total must be written or
+  -- explicitly accounted for by a skipped/duplicate row.
+  IF abs((v_net_inserted + v_net_skipped + v_net_duped) - p_total_net_payments) > c_tolerance THEN
+    RAISE EXCEPTION
+      'Import reconciliation failed: inserted % + skipped % + duplicate % != parser total % (tolerance %)',
+      v_net_inserted, v_net_skipped, v_net_duped, p_total_net_payments, c_tolerance;
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(DISTINCT r.industry), '[]'::jsonb)
+  INTO v_unmatched_industries
+  FROM _import_rows r
+  WHERE r.industry IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM industries i WHERE lower(i.name) = lower(r.industry));
+
+  SELECT COALESCE(jsonb_agg(DISTINCT r.state), '[]'::jsonb)
+  INTO v_unmatched_states
+  FROM _import_rows r
+  WHERE r.state IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM states s
+      WHERE upper(s.code) = upper(r.state) OR lower(s.name) = lower(r.state)
+    );
+
+  RETURN jsonb_build_object(
+    'deals_in_payload', v_deals_in_payload,
+    'deals_imported', v_deals_imported,
+    'rows_skipped', v_rows_skipped,
+    'duplicate_rows_dropped', v_dupes_dropped,
+    'merchants_upserted', v_merchants_upserted,
+    'payments_deleted', v_payments_deleted,
+    'payments_inserted', v_payments_inserted,
+    'payments_net_inserted', v_net_inserted,
+    'payments_net_dropped', v_net_skipped + v_net_duped,
+    'management_fee_rate', v_fee,
+    'unmatched_industries', v_unmatched_industries,
+    'unmatched_states', v_unmatched_states
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION import_funder_sheet(integer, integer, numeric, jsonb, numeric) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION import_funder_sheet(integer, integer, numeric, jsonb, numeric) TO authenticated;

--- a/supabase/migrations/20260710195109_phase3_view_null_math_and_pr_state.sql
+++ b/supabase/migrations/20260710195109_phase3_view_null_math_and_pr_state.sql
@@ -1,0 +1,151 @@
+-- Phase 3 polish, found by importing the real Alder workbook locally:
+--
+-- 1. deal_computed treated a NULL buy_rate/commission as NULL where Excel's
+--    =I+J treats blanks as 0 — every R'bull deal (buy rate, no commission)
+--    reported sell_rate/total_rtr/factor as NULL/0 instead of the workbook's
+--    values. CREATE OR REPLACE keeps the dependent views intact.
+--
+-- 2. The states lookup has the 50 states + DC but one Alder merchant is in
+--    Puerto Rico — add it so the import resolves the state.
+
+INSERT INTO states (code, name) VALUES ('PR', 'Puerto Rico')
+ON CONFLICT (code) DO NOTHING;
+
+CREATE OR REPLACE VIEW deal_computed
+WITH (security_invoker = true) AS
+WITH base AS (
+  SELECT
+    d.id,
+    d.portfolio_id,
+    d.funder_id,
+    d.merchant_id,
+    d.advance_id,
+    d.funder_advance_id,
+    d.fico,
+    d.date_funded,
+    d.date_closed,
+    d.is_default,
+    d.new_dollars,
+    d.rtr,
+    d.buy_rate,
+    d.commission,
+    (date_trunc('month', d.date_funded))::date AS vintage_month,
+    d.total_amount_funded::numeric AS total_amount_funded,
+    d.participation_on_amount::numeric AS participation_on_amount,
+    COALESCE(pf.management_fee_rate, 0) AS management_fee_rate,
+    -- K: sell rate = I + J. Excel treats blank cells as 0 here (R'bull rows
+    -- have a buy rate but no commission; PayVa rows have neither) — COALESCE
+    -- to match, otherwise NULL propagates into total RTR and the factor.
+    COALESCE(d.buy_rate, 0) + COALESCE(d.commission, 0) AS sell_rate,
+    -- M: commission $ = L * J
+    d.total_amount_funded * COALESCE(d.commission, 0) AS commission_dollars,
+    -- N: total RTR = L * K
+    d.total_amount_funded * (COALESCE(d.buy_rate, 0) + COALESCE(d.commission, 0)) AS total_rtr,
+    -- Q: term (months) = IF(ISBLANK(O), P/4.3, O/20)
+    CASE WHEN d.num_daily_payments IS NULL
+         THEN d.num_weekly_payments / 4.3
+         ELSE d.num_daily_payments / 20.0
+    END AS term_months,
+    d.num_daily_payments IS NOT NULL AS is_daily,
+    COALESCE(d.num_daily_payments, d.num_weekly_payments)::numeric AS num_payments
+  FROM deals d
+  LEFT JOIN portfolio_funders pf
+    ON pf.portfolio_id = d.portfolio_id AND pf.funder_id = d.funder_id
+),
+rh AS (
+  SELECT
+    b.*,
+    -- W: R&H % of deal = R / L
+    COALESCE(b.participation_on_amount / NULLIF(b.total_amount_funded, 0), 0) AS rh_pct_of_deal
+  FROM base b
+),
+cost AS (
+  SELECT
+    r.*,
+    -- X: pro-rata commission paid = M * W
+    COALESCE(r.commission_dollars * r.rh_pct_of_deal, 0) AS pro_rata_commission,
+    -- Z: R&H pro-rata RTR = N * W
+    COALESCE(r.total_rtr * r.rh_pct_of_deal, 0) AS rh_rtr
+  FROM rh r
+),
+net AS (
+  SELECT
+    c.*,
+    -- Y: R&H cost basis = R + X
+    COALESCE(c.participation_on_amount + c.pro_rata_commission, 0) AS cost_basis,
+    -- AA: net RTR (fee-adjusted) = Z - Z * B$1
+    c.rh_rtr * (1 - c.management_fee_rate) AS net_rtr,
+    -- AD: gross payment expected = Z / (O or P)
+    c.rh_rtr / NULLIF(c.num_payments, 0) AS gross_payment_expected
+  FROM cost c
+),
+received AS (
+  SELECT
+    deal_id,
+    SUM(net) AS total_net_received,
+    SUM(gross) AS total_gross_received,
+    SUM(fee) AS total_fee_paid
+  FROM net_rtr_payments
+  GROUP BY deal_id
+)
+SELECT
+  n.id,
+  n.portfolio_id,
+  n.funder_id,
+  n.merchant_id,
+  n.advance_id,
+  n.funder_advance_id,
+  n.fico,
+  n.date_funded,
+  n.date_closed,
+  n.is_default,
+  n.new_dollars,
+  n.rtr,
+  n.vintage_month,
+  n.buy_rate,
+  n.commission,
+  n.sell_rate,
+  n.total_amount_funded,
+  n.participation_on_amount,
+  n.management_fee_rate,
+  n.commission_dollars,
+  n.total_rtr,
+  n.term_months,
+  n.is_daily,
+  n.rh_pct_of_deal,
+  n.pro_rata_commission,
+  n.rh_rtr,
+  n.cost_basis,
+  n.net_rtr,
+  -- U / V: cost basis at work, split by funding source flag
+  CASE WHEN n.new_dollars THEN n.cost_basis ELSE 0 END AS new_dollars_at_work,
+  CASE WHEN n.rtr THEN n.cost_basis ELSE 0 END AS rtr_dollars_at_work,
+  -- AB: "all in" factor = AA / Y
+  n.net_rtr / NULLIF(n.cost_basis, 0) AS all_in_factor,
+  -- AC: points per month = ((AB - 1) / Q) * 100
+  (n.net_rtr / NULLIF(n.cost_basis, 0) - 1) / NULLIF(n.term_months, 0) * 100 AS points_per_month,
+  n.gross_payment_expected,
+  -- AF: net payment expected = AD - AD * fee
+  n.gross_payment_expected * (1 - n.management_fee_rate) AS net_payment_expected,
+  -- AG: weekly payment expected = IF(ISBLANK(O), AF, AF*5); blank once closed
+  CASE WHEN n.date_closed IS NULL
+       THEN n.gross_payment_expected * (1 - n.management_fee_rate)
+            * CASE WHEN n.is_daily THEN 5 ELSE 1 END
+       ELSE 0
+  END AS weekly_payment_expected,
+  -- AI: total net RTR received = SUM(payment matrix)
+  COALESCE(r.total_net_received, 0) AS total_net_received,
+  COALESCE(r.total_gross_received, 0) AS total_gross_received,
+  COALESCE(r.total_fee_paid, 0) AS total_fee_paid,
+  -- AJ: net RTR balance = AA - AI
+  n.net_rtr - COALESCE(r.total_net_received, 0) AS net_rtr_balance,
+  -- AK: % of RTR paid = AI / AA
+  COALESCE(COALESCE(r.total_net_received, 0) / NULLIF(n.net_rtr, 0), 0) AS pct_rtr_paid,
+  -- AL: return on cost basis = AI / Y
+  COALESCE(COALESCE(r.total_net_received, 0) / NULLIF(n.cost_basis, 0), 0) AS return_on_cost_basis,
+  -- AR: bad debt adjustment = IF(default, AJ, "")
+  CASE WHEN n.is_default THEN n.net_rtr - COALESCE(r.total_net_received, 0) ELSE 0 END AS bad_debt_rtr,
+  -- AT: default $ lost = IF(default, AI - Y, "")
+  CASE WHEN n.is_default THEN COALESCE(r.total_net_received, 0) - n.cost_basis END AS default_dollars_lost
+FROM net n
+LEFT JOIN received r ON r.deal_id = n.id;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,95 @@
+-- Local development seed (applied by `supabase db reset` / first `supabase start`
+-- AFTER migrations; never runs against the linked remote project).
+--
+-- The migrations already seed all reference data (portfolios, funders +
+-- portfolio_funders fees, states, industries). What a fresh local stack lacks
+-- is a user: this creates a confirmed dev login and grants it admin access to
+-- both portfolios, mirroring the live setup.
+--
+--   email:    dev@excelerate.local
+--   password: excelerate-dev
+--
+-- It also backfills the 5 funders that were created via the dashboard on the
+-- live project BEFORE the migration baseline existed — they are data, not
+-- schema, so `db pull` never captured them and the Phase 1 migration's
+-- UPDATE/JOIN seeding silently skips them on a fresh local stack.
+
+INSERT INTO public.funders (name, code, sheet_name) VALUES
+  ('BHB',        'BHB',  'BHB'),
+  ('Clear View', 'CV',   'CV'),
+  ('BIG',        'BIG',  'BIG'),
+  ('eFin',       'EFin', 'EFin'),
+  ('In Advance', 'InAd', 'InAd')
+ON CONFLICT (name) DO UPDATE SET sheet_name = EXCLUDED.sheet_name;
+
+-- Re-run the Phase 1 portfolio↔funder fee seeding now that all 11 funders
+-- exist (same values as 20260710013530_phase1_portfolio_funder_config.sql).
+INSERT INTO public.portfolio_funders (portfolio_id, funder_id, management_fee_rate)
+SELECT p.id, f.id, v.fee
+FROM (VALUES
+  ('Alder', 'BHB',     0.03),
+  ('Alder', 'BIG',     0.04),
+  ('Alder', 'CV',      0.03),
+  ('Alder', 'EFin',    0.03),
+  ('Alder', 'InAd',    0.035),
+  ('Alder', 'PayVa',   0.05),
+  ('Alder', 'R''bull', 0.03),
+  ('Alder', 'ACS',     0.03),
+  ('Alder', 'Boom',    0.04),
+  ('Alder', 'Kings',   0.03),
+  ('Alder', 'VSPR',    0.03),
+  ('White Rabbit', 'BHB',   0.03),
+  ('White Rabbit', 'BIG',   0.03),
+  ('White Rabbit', 'CV',    0.03),
+  ('White Rabbit', 'EFin',  0.03),
+  ('White Rabbit', 'ACS',   0.03),
+  ('White Rabbit', 'Boom',  0.04),
+  ('White Rabbit', 'Kings', 0.03)
+) AS v(portfolio_name, sheet_name, fee)
+JOIN public.portfolios p ON p.name = v.portfolio_name
+JOIN public.funders f ON f.sheet_name = v.sheet_name
+ON CONFLICT (portfolio_id, funder_id) DO UPDATE
+  SET management_fee_rate = EXCLUDED.management_fee_rate;
+
+DO $$
+DECLARE
+  v_user_id uuid := gen_random_uuid();
+BEGIN
+  -- GoTrue reads these columns directly; the token columns must be empty
+  -- strings (not NULL) or its Go scanner errors on login.
+  INSERT INTO auth.users (
+    instance_id, id, aud, role, email,
+    encrypted_password, email_confirmed_at,
+    raw_app_meta_data, raw_user_meta_data,
+    confirmation_token, recovery_token,
+    email_change, email_change_token_new, email_change_token_current,
+    phone_change, phone_change_token, reauthentication_token,
+    created_at, updated_at
+  ) VALUES (
+    '00000000-0000-0000-0000-000000000000', v_user_id, 'authenticated', 'authenticated',
+    'dev@excelerate.local',
+    crypt('excelerate-dev', gen_salt('bf')), now(),
+    '{"provider":"email","providers":["email"]}', '{"full_name":"Local Dev"}',
+    '', '', '', '', '', '', '', '',
+    now(), now()
+  );
+
+  INSERT INTO auth.identities (
+    provider_id, user_id, identity_data, provider,
+    last_sign_in_at, created_at, updated_at
+  ) VALUES (
+    v_user_id::text, v_user_id,
+    jsonb_build_object('sub', v_user_id::text, 'email', 'dev@excelerate.local',
+                       'email_verified', true),
+    'email', now(), now(), now()
+  );
+
+  -- handle_new_user created the profile as 'member'; promote to admin and
+  -- grant both portfolios, like the live admin user.
+  UPDATE public.user_profiles SET role = 'admin' WHERE id = v_user_id;
+
+  INSERT INTO public.portfolio_access (user_id, portfolio_id)
+  SELECT v_user_id, p.id FROM public.portfolios p
+  ON CONFLICT DO NOTHING;
+END;
+$$;

--- a/tools/dev-local.sh
+++ b/tools/dev-local.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Run the Tauri app against the LOCAL Supabase stack (Docker) instead of prod.
+#
+# Starts the stack if it isn't running (first run pulls images and applies
+# supabase/migrations + supabase/seed.sql), then launches `tauri dev` with
+# VITE_SUPABASE_* pointed at localhost. Process env beats .env in Vite, so the
+# plain `npm run tauri dev` keeps using the production values from .env.
+#
+# Local login: dev@excelerate.local / excelerate-dev (see supabase/seed.sql)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if ! supabase status >/dev/null 2>&1; then
+  echo "Starting local Supabase stack (first run downloads Docker images)…"
+  supabase start
+fi
+
+eval "$(supabase status -o env 2>/dev/null | grep -E '^(API_URL|ANON_KEY)=')"
+
+export VITE_SUPABASE_URL="$API_URL"
+export VITE_SUPABASE_ANON_KEY="$ANON_KEY"
+echo "Supabase: $VITE_SUPABASE_URL (local) — login dev@excelerate.local / excelerate-dev"
+
+exec npm run tauri dev


### PR DESCRIPTION
## Summary

Phase 3 of the Supabase migration (see `FABLE_PLAN.md`): the one-time "Import Portfolio Workbook" wizard that populates `deals` + `net_rtr_payments` + per-portfolio management fees from each client workbook, replacing the weekly workbook upload at onboarding.

- **`parse_portfolio_workbook` Tauri command** (calamine, new `workbook_import.rs`): per-sheet B1 management fee, deal input columns, and the weekly Net RTR payment matrix with year inference — handles the real workbooks' header quirks (double "Commission" column, PayVa's extra `PAYVA RECORDS` column, year-less `Net RTR M/D` headers, text funding-source flags like `'New  '`)
- **`import_funder_sheet` RPC** (migration `20260710135856`, SECURITY INVOKER): idempotent set-based upserts keyed on the composite `(advance_id, funder_advance_id)` — both workbooks contain duplicate internal advance ids that are genuinely distinct deals, so the legacy Python script's advance-id-only upsert would have silently dropped deals. Merchants resolve industry/state case-insensitively; historical gross/fee reconstructed from net via the management fee so imported and monthly rows are consistent in the views. Same ±$0.01 reconciliation guards as Phase 2's `commit_funder_pivot`
- **`deals.total_amount_funded` / `participation_on_amount` widened integer → numeric** (real PayVa deals have cents); the four dependent views are dropped/recreated verbatim around the ALTER
- **Import wizard modal** on both portfolio pages: parse preview (per-sheet fees, deal/payment counts, warnings) → per-sheet import progress → summary with unmatched industries/states; safe to re-run
- Import-sourced payments have `source_upload_id IS NULL`; re-imports replace only those, so monthly-flow payments survive

## Verification

- Rust parser validated cell-for-cell against both real workbooks via an `#[ignore]`d baseline test (Alder 1,687 deals / 26,127 payments; WR 1,073 / 26,023), plus 7 unit tests for the date/flag/header edge cases
- Full pipeline replayed in a scratch Postgres 16 cluster mirroring the live schema (tables + Phase 1 views): 2,760 deals, 52,122 payment rows, $13.1M net — reconciliation guards, idempotent re-import, monthly-payment preservation, payload dedupe, and the gross−fee−net identity all asserted
- Migration pushed live and verified via `supabase migration list`; all CI gates green (ESLint 0 errors, Prettier, tsc + Vite build, cargo fmt, clippy `-D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Local dev environment (added after review feedback)

`npm run dev:local` runs the app against a full local Supabase stack in Docker (Postgres + GoTrue + PostgREST + Storage) instead of production — real login page, real RLS, no fake-auth code paths. `supabase/seed.sql` provides a confirmed admin login (`dev@excelerate.local` / `excelerate-dev`) plus the 5 pre-baseline funders and fee rows so local matches live. Plain `npm run tauri dev` still targets production via `.env`. See `docs/local-dev.md`. Verified end-to-end: GoTrue password login + `import_funder_sheet` through PostgREST under the dev JWT; anon rejected.
