### PR TITLE
feat: add combined portfolio view and funder drill-down to dashboard

### DIFF
--- a/src/components/dashboard/charts.tsx
+++ b/src/components/dashboard/charts.tsx
@@ -1,0 +1,854 @@
+import { useState } from "react";
+import { Card, Skeleton, Tab, Tabs } from "@heroui/react";
+import { Icon } from "@iconify/react";
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Tooltip,
+  Cell,
+  Label,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+} from "recharts";
+import {
+  formatMoney,
+  formatMonth,
+  type StackedByFunder,
+  type PieSlice,
+  type RtrSeries,
+  type CommissionsMonthRow,
+  type VintagePerformanceRow,
+} from "@services/analytics-service";
+
+// Enough distinct colors for the 11 workbook funders.
+const CHART_COLORS = [
+  "hsl(var(--heroui-primary-500))",
+  "hsl(var(--heroui-secondary-500))",
+  "hsl(var(--heroui-success-500))",
+  "hsl(var(--heroui-warning-500))",
+  "hsl(var(--heroui-danger-500))",
+  "hsl(var(--heroui-primary-300))",
+  "hsl(var(--heroui-secondary-300))",
+  "hsl(var(--heroui-success-600))",
+  "hsl(var(--heroui-warning-600))",
+  "hsl(var(--heroui-danger-300))",
+  "hsl(var(--heroui-default-500))",
+  "hsl(var(--heroui-default-300))",
+];
+
+export const funderColor = (index: number) => CHART_COLORS[index % CHART_COLORS.length];
+
+/** Fired with the funder's display name when a legend entry / slice / bar is clicked. */
+export type FunderClickHandler = (funderName: string) => void;
+
+export const ChartSkeleton = ({ height = 250 }: { height?: number }) => (
+  <div className="p-4">
+    <Skeleton className="rounded-lg mb-4">
+      <div className="h-4 w-48 bg-default-200"></div>
+    </Skeleton>
+    <Skeleton className="rounded-lg">
+      <div style={{ height }} className="w-full bg-default-200"></div>
+    </Skeleton>
+  </div>
+);
+
+export const EmptyChart = ({ height = 250 }: { height?: number }) => (
+  <div style={{ height }} className="flex items-center justify-center">
+    <span className="text-default-400">No data available</span>
+  </div>
+);
+
+export const KpiCard = ({
+  title,
+  value,
+  subtitle,
+  icon,
+  tone,
+  loading,
+}: {
+  title: string;
+  value: string;
+  subtitle?: string;
+  icon: string;
+  tone?: "success" | "danger";
+  loading: boolean;
+}) => {
+  if (loading) {
+    return (
+      <Card className="dark:border-default-100 border border-transparent">
+        <div className="p-4">
+          <Skeleton className="rounded-lg mb-2">
+            <div className="h-4 w-24 bg-default-200"></div>
+          </Skeleton>
+          <Skeleton className="rounded-lg">
+            <div className="h-8 w-32 bg-default-200"></div>
+          </Skeleton>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="dark:border-default-100 border border-transparent">
+      <div className="flex flex-col gap-y-1 p-4">
+        <dt className="text-small text-default-500 font-medium flex items-center gap-2">
+          <Icon icon={icon} width={16} />
+          {title}
+        </dt>
+        <dd
+          className={
+            tone === "success"
+              ? "text-success text-2xl font-semibold"
+              : tone === "danger"
+                ? "text-danger text-2xl font-semibold"
+                : "text-default-700 text-2xl font-semibold"
+          }
+        >
+          {value}
+        </dd>
+        {subtitle && <span className="text-tiny text-default-400">{subtitle}</span>}
+      </div>
+    </Card>
+  );
+};
+
+export const FunderLegend = ({
+  funders,
+  onFunderClick,
+}: {
+  funders: string[];
+  onFunderClick?: FunderClickHandler;
+}) => (
+  <div className="text-tiny text-default-500 flex w-full flex-wrap justify-center gap-x-4 gap-y-1 px-4 pb-4">
+    {funders.map((funder, index) => {
+      const swatch = (
+        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: funderColor(index) }} />
+      );
+      return onFunderClick ? (
+        <button
+          key={funder}
+          type="button"
+          onClick={() => onFunderClick(funder)}
+          className="flex items-center gap-2 rounded-small hover:text-primary transition-colors cursor-pointer"
+        >
+          {swatch}
+          <span className="underline decoration-dotted underline-offset-2">{funder}</span>
+        </button>
+      ) : (
+        <div key={funder} className="flex items-center gap-2">
+          {swatch}
+          <span>{funder}</span>
+        </div>
+      );
+    })}
+  </div>
+);
+
+export const StackedTooltip = ({
+  active,
+  label,
+  payload,
+  formatter,
+}: {
+  active?: boolean;
+  label?: string;
+  payload?: Array<{ name: string; value: number; color?: string }>;
+  formatter: (value: number) => string;
+}) => {
+  if (!active || !payload || payload.length === 0) return null;
+  const shown = [...payload].reverse().filter((p) => p.value !== 0);
+  return (
+    <div className="rounded-medium bg-background text-tiny shadow-small p-2 max-h-[260px] overflow-y-auto">
+      <p className="font-medium mb-1">{label}</p>
+      {shown.map((entry) => (
+        <div key={entry.name} className="flex items-center gap-x-2">
+          <span className="h-2 w-2 rounded-full" style={{ backgroundColor: entry.color }} />
+          <span className="text-default-500">{entry.name}:</span>
+          <span className="text-default-700 font-medium">{formatter(entry.value)}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const AllocationsByMonthCard = ({
+  title = "Allocations by Month (vintage cost basis)",
+  dollars,
+  percents,
+  loading,
+  onFunderClick,
+}: {
+  title?: string;
+  dollars: StackedByFunder;
+  percents: StackedByFunder;
+  loading: boolean;
+  onFunderClick?: FunderClickHandler;
+}) => {
+  const [mode, setMode] = useState<"dollars" | "percent">("dollars");
+
+  if (loading) {
+    return (
+      <Card className="dark:border-default-100 border border-transparent mb-6">
+        <ChartSkeleton height={300} />
+      </Card>
+    );
+  }
+
+  // With a single funder the % view is a flat 100% — not worth a tab.
+  const showModeTabs = dollars.funders.length > 1;
+  const stacked = mode === "dollars" || !showModeTabs ? dollars : percents;
+  const format =
+    mode === "dollars" || !showModeTabs ? formatMoney : (v: number) => `${v.toFixed(1)}%`;
+
+  return (
+    <Card className="dark:border-default-100 border border-transparent mb-6">
+      <div className="flex items-center justify-between p-4 pb-0">
+        <h3 className="text-small text-default-500 font-medium">{title}</h3>
+        {showModeTabs && (
+          <Tabs
+            size="sm"
+            selectedKey={mode}
+            onSelectionChange={(key) => setMode(key as typeof mode)}
+          >
+            <Tab key="dollars" title="$" />
+            <Tab key="percent" title="%" />
+          </Tabs>
+        )}
+      </div>
+
+      {stacked.rows.length > 0 ? (
+        <>
+          <ResponsiveContainer
+            className="[&_.recharts-surface]:outline-hidden"
+            height={300}
+            width="100%"
+          >
+            <BarChart
+              accessibilityLayer
+              data={stacked.rows}
+              margin={{ top: 20, right: 14, left: 8, bottom: 5 }}
+            >
+              <CartesianGrid
+                stroke="hsl(var(--heroui-default-200))"
+                strokeDasharray="3 3"
+                vertical={false}
+              />
+              <XAxis
+                dataKey="month"
+                strokeOpacity={0.25}
+                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
+                tickLine={false}
+                minTickGap={16}
+              />
+              <YAxis
+                axisLine={false}
+                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
+                tickLine={false}
+                tickFormatter={(value) =>
+                  mode === "dollars" || !showModeTabs ? formatMoney(value) : `${value.toFixed(0)}%`
+                }
+                domain={mode === "percent" && showModeTabs ? [0, 100] : undefined}
+              />
+              <Tooltip
+                content={<StackedTooltip formatter={format} />}
+                cursor={{ fill: "hsl(var(--heroui-default-100))", opacity: 0.4 }}
+              />
+              {stacked.funders.map((funder, index) => (
+                <Bar
+                  key={funder}
+                  animationDuration={450}
+                  animationEasing="ease"
+                  dataKey={funder}
+                  stackId="allocations"
+                  fill={funderColor(index)}
+                  cursor={onFunderClick ? "pointer" : undefined}
+                  onClick={onFunderClick ? () => onFunderClick(funder) : undefined}
+                />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+          <FunderLegend funders={stacked.funders} onFunderClick={onFunderClick} />
+        </>
+      ) : (
+        <EmptyChart height={300} />
+      )}
+    </Card>
+  );
+};
+
+export const AllocationPieCard = ({
+  title,
+  slices,
+  loading,
+  onFunderClick,
+}: {
+  title: string;
+  slices: PieSlice[];
+  loading: boolean;
+  onFunderClick?: FunderClickHandler;
+}) => {
+  if (loading) {
+    return (
+      <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
+        <ChartSkeleton height={220} />
+      </Card>
+    );
+  }
+
+  const total = slices.reduce((sum, s) => sum + s.value, 0);
+
+  return (
+    <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
+      <div className="flex flex-col gap-y-2 p-4 pb-0">
+        <h3 className="text-small text-default-500 font-medium">{title}</h3>
+        <dd className="flex items-baseline gap-x-1">
+          <span className="text-default-900 text-3xl font-semibold">{formatMoney(total)}</span>
+          <span className="text-medium text-default-500 font-medium">total</span>
+        </dd>
+      </div>
+
+      {slices.length > 0 ? (
+        <>
+          <ResponsiveContainer
+            className="[&_.recharts-surface]:outline-hidden"
+            height={200}
+            width="100%"
+          >
+            <PieChart accessibilityLayer margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
+              <Tooltip
+                content={({ payload }) => {
+                  if (!payload || payload.length === 0) return null;
+                  return (
+                    <div className="rounded-medium bg-background text-tiny shadow-small p-2">
+                      {payload.map((entry, index) => (
+                        <div key={index} className="flex items-center gap-x-2">
+                          <div
+                            className="h-2 w-2 rounded-full"
+                            style={{ backgroundColor: entry.payload.fill }}
+                          />
+                          <span className="text-default-500">{entry.name}:</span>
+                          <span className="text-default-700 font-medium">
+                            {formatMoney(entry.value as number)}
+                            {total > 0 &&
+                              ` (${(((entry.value as number) / total) * 100).toFixed(1)}%)`}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  );
+                }}
+                cursor={false}
+              />
+              <Pie
+                animationDuration={1000}
+                animationEasing="ease"
+                cornerRadius={6}
+                data={slices}
+                dataKey="value"
+                innerRadius="60%"
+                nameKey="name"
+                paddingAngle={2}
+                strokeWidth={0}
+              >
+                {slices.map((slice, index) => (
+                  <Cell
+                    key={slice.name}
+                    fill={funderColor(index)}
+                    cursor={onFunderClick ? "pointer" : undefined}
+                    onClick={onFunderClick ? () => onFunderClick(slice.name) : undefined}
+                  />
+                ))}
+                <Label
+                  content={({ viewBox }) => {
+                    if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                      return (
+                        <text
+                          x={viewBox.cx}
+                          y={viewBox.cy}
+                          textAnchor="middle"
+                          dominantBaseline="middle"
+                        >
+                          <tspan
+                            x={viewBox.cx}
+                            y={viewBox.cy! - 10}
+                            className="fill-default-700 text-2xl font-bold"
+                          >
+                            {slices.length}
+                          </tspan>
+                          <tspan
+                            x={viewBox.cx}
+                            y={viewBox.cy! + 10}
+                            className="fill-default-500 text-sm"
+                          >
+                            Funders
+                          </tspan>
+                        </text>
+                      );
+                    }
+                    return null;
+                  }}
+                  position="center"
+                />
+              </Pie>
+            </PieChart>
+          </ResponsiveContainer>
+          <FunderLegend funders={slices.map((s) => s.name)} onFunderClick={onFunderClick} />
+        </>
+      ) : (
+        <EmptyChart />
+      )}
+    </Card>
+  );
+};
+
+const rtrDateLabel = (date: string) => formatMonth(date.slice(0, 7));
+
+export const RtrCard = ({
+  series,
+  loading,
+  onFunderClick,
+}: {
+  series: RtrSeries;
+  loading: boolean;
+  onFunderClick?: FunderClickHandler;
+}) => {
+  const [mode, setMode] = useState<"growth" | "by-funder">("growth");
+
+  if (loading) {
+    return (
+      <Card className="dark:border-default-100 border border-transparent mb-6">
+        <ChartSkeleton height={300} />
+      </Card>
+    );
+  }
+
+  const totalReceived =
+    series.points.length > 0 ? series.points[series.points.length - 1].cumulative : 0;
+  const showModeTabs = series.funders.length > 1;
+  const effectiveMode = showModeTabs ? mode : "growth";
+
+  return (
+    <Card className="dark:border-default-100 border border-transparent mb-6">
+      <div className="flex items-center justify-between p-4 pb-0">
+        <div className="flex flex-col gap-y-1">
+          <h3 className="text-small text-default-500 font-medium">Net RTR Received</h3>
+          <dd className="flex items-baseline gap-x-1">
+            <span className="text-default-900 text-3xl font-semibold">
+              {formatMoney(totalReceived)}
+            </span>
+            <span className="text-medium text-default-500 font-medium">to date</span>
+          </dd>
+        </div>
+        {showModeTabs && (
+          <Tabs
+            size="sm"
+            selectedKey={mode}
+            onSelectionChange={(key) => setMode(key as typeof mode)}
+          >
+            <Tab key="growth" title="Growth" />
+            <Tab key="by-funder" title="By Funder" />
+          </Tabs>
+        )}
+      </div>
+
+      {series.points.length > 0 ? (
+        <>
+          <ResponsiveContainer
+            className="[&_.recharts-surface]:outline-hidden"
+            height={300}
+            width="100%"
+          >
+            <AreaChart
+              accessibilityLayer
+              data={series.points}
+              margin={{ top: 20, right: 14, left: 8, bottom: 5 }}
+            >
+              <defs>
+                <linearGradient id="rtrGradient" x1="0" x2="0" y1="0" y2="1">
+                  <stop offset="10%" stopColor="hsl(var(--heroui-primary-500))" stopOpacity={0.3} />
+                  <stop
+                    offset="100%"
+                    stopColor="hsl(var(--heroui-primary-100))"
+                    stopOpacity={0.1}
+                  />
+                </linearGradient>
+              </defs>
+              <CartesianGrid
+                stroke="hsl(var(--heroui-default-200))"
+                strokeDasharray="3 3"
+                vertical={false}
+              />
+              <XAxis
+                dataKey="date"
+                strokeOpacity={0.25}
+                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
+                tickLine={false}
+                tickFormatter={rtrDateLabel}
+                minTickGap={24}
+              />
+              <YAxis
+                axisLine={false}
+                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
+                tickLine={false}
+                tickFormatter={formatMoney}
+              />
+              <Tooltip
+                content={({ active, label, payload }) => {
+                  if (!active || !payload || payload.length === 0) return null;
+                  return (
+                    <StackedTooltip
+                      active
+                      label={String(label)}
+                      payload={payload as Array<{ name: string; value: number; color?: string }>}
+                      formatter={formatMoney}
+                    />
+                  );
+                }}
+                cursor={{ strokeWidth: 0 }}
+              />
+              {effectiveMode === "growth" ? (
+                <Area
+                  animationDuration={800}
+                  animationEasing="ease"
+                  dataKey="cumulative"
+                  name="Cumulative Net RTR"
+                  fill="url(#rtrGradient)"
+                  stroke="hsl(var(--heroui-primary-500))"
+                  strokeWidth={2}
+                  type="monotone"
+                />
+              ) : (
+                series.funders.map((funder, index) => (
+                  <Area
+                    key={funder}
+                    animationDuration={800}
+                    animationEasing="ease"
+                    dataKey={funder}
+                    stackId="rtr"
+                    fill={funderColor(index)}
+                    fillOpacity={0.7}
+                    stroke={funderColor(index)}
+                    strokeWidth={1}
+                    type="monotone"
+                  />
+                ))
+              )}
+            </AreaChart>
+          </ResponsiveContainer>
+          {effectiveMode === "by-funder" && (
+            <FunderLegend funders={series.funders} onFunderClick={onFunderClick} />
+          )}
+        </>
+      ) : (
+        <EmptyChart height={300} />
+      )}
+    </Card>
+  );
+};
+
+export const CommissionsCard = ({
+  data,
+  loading,
+}: {
+  data: CommissionsMonthRow[];
+  loading: boolean;
+}) => {
+  if (loading) {
+    return (
+      <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
+        <ChartSkeleton />
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
+      <div className="flex flex-col gap-y-4 p-4">
+        <h3 className="text-small text-default-500 font-medium">
+          Participation &amp; Commissions by Month
+        </h3>
+        {data.length > 0 ? (
+          <>
+            <ResponsiveContainer
+              className="[&_.recharts-surface]:outline-hidden"
+              height={250}
+              width="100%"
+            >
+              <BarChart accessibilityLayer data={data} margin={{ top: 10, right: 14, left: 8 }}>
+                <CartesianGrid
+                  stroke="hsl(var(--heroui-default-200))"
+                  strokeDasharray="3 3"
+                  vertical={false}
+                />
+                <XAxis
+                  dataKey="month"
+                  strokeOpacity={0.25}
+                  style={{ fontSize: "var(--heroui-font-size-tiny)" }}
+                  tickLine={false}
+                  minTickGap={16}
+                />
+                <YAxis
+                  axisLine={false}
+                  style={{ fontSize: "var(--heroui-font-size-tiny)" }}
+                  tickLine={false}
+                  tickFormatter={formatMoney}
+                />
+                <Tooltip
+                  content={<StackedTooltip formatter={formatMoney} />}
+                  cursor={{ fill: "hsl(var(--heroui-default-100))", opacity: 0.4 }}
+                />
+                <Bar
+                  animationDuration={450}
+                  dataKey="participation"
+                  name="Participation $"
+                  fill="hsl(var(--heroui-default-400))"
+                  radius={[3, 3, 0, 0]}
+                />
+                <Bar
+                  animationDuration={450}
+                  dataKey="commissions"
+                  name="Commissions $"
+                  fill="hsl(var(--heroui-warning-500))"
+                  radius={[3, 3, 0, 0]}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+            <div className="text-tiny text-default-500 flex justify-center gap-4">
+              <div className="flex items-center gap-2">
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: "hsl(var(--heroui-default-400))" }}
+                />
+                Participation $
+              </div>
+              <div className="flex items-center gap-2">
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: "hsl(var(--heroui-warning-500))" }}
+                />
+                Commissions $
+              </div>
+            </div>
+          </>
+        ) : (
+          <EmptyChart />
+        )}
+      </div>
+    </Card>
+  );
+};
+
+export const PointsPerMonthCard = ({
+  data,
+  loading,
+}: {
+  data: VintagePerformanceRow[];
+  loading: boolean;
+}) => {
+  if (loading) {
+    return (
+      <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
+        <ChartSkeleton />
+      </Card>
+    );
+  }
+
+  const rows = data.filter((d) => d.pointsPerMonth != null);
+
+  return (
+    <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
+      <div className="flex flex-col gap-y-4 p-4">
+        <h3 className="text-small text-default-500 font-medium">Points per Month by Vintage</h3>
+        {rows.length > 0 ? (
+          <ResponsiveContainer
+            className="[&_.recharts-surface]:outline-hidden"
+            height={250}
+            width="100%"
+          >
+            <BarChart accessibilityLayer data={rows} margin={{ top: 10, right: 14, left: 8 }}>
+              <CartesianGrid
+                stroke="hsl(var(--heroui-default-200))"
+                strokeDasharray="3 3"
+                vertical={false}
+              />
+              <XAxis
+                dataKey="month"
+                strokeOpacity={0.25}
+                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
+                tickLine={false}
+                minTickGap={16}
+              />
+              <YAxis
+                axisLine={false}
+                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
+                tickLine={false}
+                tickFormatter={(value) => value.toFixed(1)}
+              />
+              <Tooltip
+                content={({ active, label, payload }) => {
+                  if (!active || !payload || payload.length === 0) return null;
+                  return (
+                    <div className="rounded-medium bg-background text-tiny shadow-small p-2">
+                      <p className="font-medium">{label}</p>
+                      <p className="text-default-500">
+                        {(payload[0].value as number).toFixed(2)} points / month
+                      </p>
+                    </div>
+                  );
+                }}
+                cursor={{ fill: "hsl(var(--heroui-default-100))", opacity: 0.4 }}
+              />
+              <Bar
+                animationDuration={450}
+                dataKey="pointsPerMonth"
+                name="Points per Month"
+                fill="hsl(var(--heroui-secondary-500))"
+                radius={[3, 3, 0, 0]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <EmptyChart />
+        )}
+      </div>
+    </Card>
+  );
+};
+
+export const TermVsFactorCard = ({
+  data,
+  loading,
+}: {
+  data: VintagePerformanceRow[];
+  loading: boolean;
+}) => {
+  if (loading) {
+    return (
+      <Card className="dark:border-default-100 border border-transparent mb-6">
+        <ChartSkeleton height={280} />
+      </Card>
+    );
+  }
+
+  const rows = data.filter((d) => d.termMonths != null || d.weightedAvgFactor != null);
+
+  return (
+    <Card className="dark:border-default-100 border border-transparent mb-6">
+      <div className="flex items-center justify-between p-4 pb-0">
+        <h3 className="text-small text-default-500 font-medium">
+          Term vs Weighted Avg Net Factor by Vintage
+        </h3>
+        <div className="text-tiny text-default-500 flex gap-4">
+          <div className="flex items-center gap-2">
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: "hsl(var(--heroui-default-400))" }}
+            />
+            Term (months)
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: "hsl(var(--heroui-primary-500))" }}
+            />
+            Net Factor
+          </div>
+        </div>
+      </div>
+
+      {rows.length > 0 ? (
+        <ResponsiveContainer
+          className="[&_.recharts-surface]:outline-hidden"
+          height={280}
+          width="100%"
+        >
+          <ComposedChart
+            accessibilityLayer
+            data={rows}
+            margin={{ top: 20, right: 14, left: 8, bottom: 5 }}
+          >
+            <CartesianGrid
+              stroke="hsl(var(--heroui-default-200))"
+              strokeDasharray="3 3"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="month"
+              strokeOpacity={0.25}
+              style={{ fontSize: "var(--heroui-font-size-tiny)" }}
+              tickLine={false}
+              minTickGap={16}
+            />
+            <YAxis
+              yAxisId="term"
+              axisLine={false}
+              style={{ fontSize: "var(--heroui-font-size-tiny)" }}
+              tickLine={false}
+              tickFormatter={(value) => `${value.toFixed(0)}mo`}
+            />
+            <YAxis
+              yAxisId="factor"
+              orientation="right"
+              axisLine={false}
+              style={{ fontSize: "var(--heroui-font-size-tiny)" }}
+              tickLine={false}
+              domain={["auto", "auto"]}
+              tickFormatter={(value) => value.toFixed(2)}
+            />
+            <Tooltip
+              content={({ active, label, payload }) => {
+                if (!active || !payload || payload.length === 0) return null;
+                const term = payload.find((p) => p.dataKey === "termMonths");
+                const factor = payload.find((p) => p.dataKey === "weightedAvgFactor");
+                return (
+                  <div className="rounded-medium bg-background text-tiny shadow-small p-2">
+                    <p className="font-medium">{label}</p>
+                    {term?.value != null && (
+                      <p className="text-default-500">
+                        Term: {(term.value as number).toFixed(1)} months
+                      </p>
+                    )}
+                    {factor?.value != null && (
+                      <p className="text-default-500">
+                        Net factor: {(factor.value as number).toFixed(3)}
+                      </p>
+                    )}
+                  </div>
+                );
+              }}
+              cursor={{ fill: "hsl(var(--heroui-default-100))", opacity: 0.4 }}
+            />
+            <Bar
+              yAxisId="term"
+              animationDuration={450}
+              dataKey="termMonths"
+              name="Term (months)"
+              fill="hsl(var(--heroui-default-300))"
+              radius={[3, 3, 0, 0]}
+            />
+            <Line
+              yAxisId="factor"
+              animationDuration={800}
+              dataKey="weightedAvgFactor"
+              name="Weighted Avg Net Factor"
+              stroke="hsl(var(--heroui-primary-500))"
+              strokeWidth={2}
+              dot={false}
+              type="monotone"
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      ) : (
+        <EmptyChart height={280} />
+      )}
+    </Card>
+  );
+};

--- a/src/components/dashboard/funder-deals-table.tsx
+++ b/src/components/dashboard/funder-deals-table.tsx
@@ -1,0 +1,170 @@
+import { useMemo, useState } from "react";
+import {
+  Card,
+  Chip,
+  Input,
+  Pagination,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+} from "@heroui/react";
+import { Icon } from "@iconify/react";
+import { formatMoney, formatPct, type FunderDealRow } from "@services/analytics-service";
+
+const ROWS_PER_PAGE = 15;
+
+const money = (value: number | null) => (value != null ? formatMoney(value) : "—");
+
+const dealStatus = (deal: FunderDealRow) => {
+  if (deal.is_default) return { label: "Defaulted", color: "danger" as const };
+  if (deal.date_closed != null) return { label: "Closed", color: "default" as const };
+  return { label: "Active", color: "success" as const };
+};
+
+const FunderDealsTable = ({
+  deals,
+  loading,
+  error,
+}: {
+  deals: FunderDealRow[];
+  loading: boolean;
+  error: string | null;
+}) => {
+  const [filter, setFilter] = useState("");
+  const [page, setPage] = useState(1);
+
+  const filtered = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    // Newest vintages first — the service returns date_funded ascending.
+    const sorted = [...deals].reverse();
+    if (!needle) return sorted;
+    return sorted.filter(
+      (d) =>
+        (d.merchant_name ?? "").toLowerCase().includes(needle) ||
+        (d.funder_advance_id ?? "").toLowerCase().includes(needle) ||
+        (d.advance_id ?? "").toLowerCase().includes(needle)
+    );
+  }, [deals, filter]);
+
+  const pages = Math.max(1, Math.ceil(filtered.length / ROWS_PER_PAGE));
+  const currentPage = Math.min(page, pages);
+  const pageRows = filtered.slice((currentPage - 1) * ROWS_PER_PAGE, currentPage * ROWS_PER_PAGE);
+
+  if (loading) {
+    return (
+      <Card className="dark:border-default-100 border border-transparent mb-6">
+        <div className="p-4">
+          <Skeleton className="rounded-lg mb-4">
+            <div className="h-4 w-48 bg-default-200"></div>
+          </Skeleton>
+          <Skeleton className="rounded-lg">
+            <div className="h-[300px] w-full bg-default-200"></div>
+          </Skeleton>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="dark:border-default-100 border border-transparent mb-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 p-4 pb-0">
+        <div className="flex flex-col gap-y-1">
+          <h3 className="text-small text-default-500 font-medium">Deals</h3>
+          <span className="text-tiny text-default-400">
+            {filtered.length.toLocaleString()} of {deals.length.toLocaleString()} deals
+          </span>
+        </div>
+        <Input
+          aria-label="Filter deals"
+          className="max-w-[260px]"
+          size="sm"
+          placeholder="Filter by merchant or advance ID"
+          startContent={<Icon icon="solar:magnifer-linear" width={16} />}
+          value={filter}
+          onValueChange={(value) => {
+            setFilter(value);
+            setPage(1);
+          }}
+          isClearable
+        />
+      </div>
+
+      {error ? (
+        <div className="p-4 flex items-center gap-2">
+          <Icon icon="solar:danger-triangle-bold" className="text-danger" width={20} />
+          <span className="text-danger">{error}</span>
+        </div>
+      ) : (
+        <div className="p-4">
+          <Table
+            aria-label="Funder deals"
+            removeWrapper
+            bottomContent={
+              pages > 1 ? (
+                <div className="flex justify-center">
+                  <Pagination
+                    size="sm"
+                    showControls
+                    page={currentPage}
+                    total={pages}
+                    onChange={setPage}
+                  />
+                </div>
+              ) : null
+            }
+          >
+            <TableHeader>
+              <TableColumn>ADVANCE ID</TableColumn>
+              <TableColumn>MERCHANT</TableColumn>
+              <TableColumn>FUNDED</TableColumn>
+              <TableColumn align="end">AMOUNT FUNDED</TableColumn>
+              <TableColumn align="end">PARTICIPATION</TableColumn>
+              <TableColumn align="end">COST BASIS</TableColumn>
+              <TableColumn align="end">NET RTR</TableColumn>
+              <TableColumn align="end">RECEIVED</TableColumn>
+              <TableColumn align="end">% RTR PAID</TableColumn>
+              <TableColumn align="end">BALANCE</TableColumn>
+              <TableColumn>STATUS</TableColumn>
+            </TableHeader>
+            <TableBody emptyContent="No deals found">
+              {pageRows.map((deal) => {
+                const status = dealStatus(deal);
+                return (
+                  <TableRow key={deal.id}>
+                    <TableCell className="text-tiny">
+                      {deal.funder_advance_id ?? deal.advance_id ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-tiny">{deal.merchant_name ?? "—"}</TableCell>
+                    <TableCell className="text-tiny whitespace-nowrap">
+                      {deal.date_funded ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-tiny">{money(deal.total_amount_funded)}</TableCell>
+                    <TableCell className="text-tiny">
+                      {money(deal.participation_on_amount)}
+                    </TableCell>
+                    <TableCell className="text-tiny">{money(deal.cost_basis)}</TableCell>
+                    <TableCell className="text-tiny">{money(deal.net_rtr)}</TableCell>
+                    <TableCell className="text-tiny">{money(deal.total_net_received)}</TableCell>
+                    <TableCell className="text-tiny">{formatPct(deal.pct_rtr_paid)}</TableCell>
+                    <TableCell className="text-tiny">{money(deal.net_rtr_balance)}</TableCell>
+                    <TableCell>
+                      <Chip size="sm" variant="flat" color={status.color}>
+                        {status.label}
+                      </Chip>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default FunderDealsTable;

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,29 +1,14 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { Card, Select, SelectItem, Skeleton, Tab, Tabs } from "@heroui/react";
+import { Button, Card, Chip, Select, SelectItem } from "@heroui/react";
 import { Icon } from "@iconify/react";
-import {
-  ResponsiveContainer,
-  PieChart,
-  Pie,
-  Tooltip,
-  Cell,
-  Label,
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Area,
-  AreaChart,
-  CartesianGrid,
-  ComposedChart,
-  Line,
-} from "recharts";
 import {
   listPortfolios,
   getPortfolioAnalytics,
+  getFunderDeals,
   computeKpis,
+  aggregateMonthlyByVintage,
   buildAllocationsByMonth,
   normalizeStacked,
   latestMonthAllocation,
@@ -33,43 +18,43 @@ import {
   buildVintagePerformance,
   formatMoney,
   formatPct,
-  formatMonth,
   type PortfolioOption,
+  type PortfolioSelection,
   type PortfolioAnalytics,
-  type StackedByFunder,
-  type PieSlice,
+  type MonthlyStatsRow,
+  type FunderDealRow,
 } from "@services/analytics-service";
+import {
+  KpiCard,
+  AllocationsByMonthCard,
+  AllocationPieCard,
+  RtrCard,
+  CommissionsCard,
+  PointsPerMonthCard,
+  TermVsFactorCard,
+} from "@components/dashboard/charts";
+import FunderDealsTable from "@components/dashboard/funder-deals-table";
 
-// Enough distinct colors for the 11 workbook funders.
-const CHART_COLORS = [
-  "hsl(var(--heroui-primary-500))",
-  "hsl(var(--heroui-secondary-500))",
-  "hsl(var(--heroui-success-500))",
-  "hsl(var(--heroui-warning-500))",
-  "hsl(var(--heroui-danger-500))",
-  "hsl(var(--heroui-primary-300))",
-  "hsl(var(--heroui-secondary-300))",
-  "hsl(var(--heroui-success-600))",
-  "hsl(var(--heroui-warning-600))",
-  "hsl(var(--heroui-danger-300))",
-  "hsl(var(--heroui-default-500))",
-  "hsl(var(--heroui-default-300))",
-];
-
-const funderColor = (index: number) => CHART_COLORS[index % CHART_COLORS.length];
+const ALL_PORTFOLIOS_KEY = "all";
 
 function Dashboard() {
   const [portfolios, setPortfolios] = useState<PortfolioOption[]>([]);
-  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [selection, setSelection] = useState<PortfolioSelection | null>(null);
   const [analytics, setAnalytics] = useState<PortfolioAnalytics | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Funder drill-down (set by clicking a funder in a legend / pie / bar)
+  const [funderId, setFunderId] = useState<number | null>(null);
+  const [deals, setDeals] = useState<FunderDealRow[]>([]);
+  const [dealsLoading, setDealsLoading] = useState(false);
+  const [dealsError, setDealsError] = useState<string | null>(null);
 
   useEffect(() => {
     listPortfolios()
       .then((list) => {
         setPortfolios(list);
-        setSelectedId((current) => current ?? list[0]?.id ?? null);
+        setSelection((current) => current ?? (list.length > 0 ? "all" : null));
         if (list.length === 0) {
           setLoading(false);
           setError("No portfolios are shared with your account.");
@@ -82,11 +67,11 @@ function Dashboard() {
   }, []);
 
   useEffect(() => {
-    if (selectedId == null) return;
+    if (selection == null) return;
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getPortfolioAnalytics(selectedId)
+    getPortfolioAnalytics(selection)
       .then((data) => {
         if (!cancelled) setAnalytics(data);
       })
@@ -99,30 +84,113 @@ function Dashboard() {
     return () => {
       cancelled = true;
     };
-  }, [selectedId]);
+  }, [selection]);
 
-  const kpis = useMemo(() => computeKpis(analytics?.monthly ?? []), [analytics]);
-  const allocations = useMemo(
-    () => buildAllocationsByMonth(analytics?.vintages ?? [], analytics?.funderNames ?? {}),
+  useEffect(() => {
+    if (funderId == null || selection == null) {
+      setDeals([]);
+      setDealsError(null);
+      return;
+    }
+    let cancelled = false;
+    setDealsLoading(true);
+    setDealsError(null);
+    getFunderDeals(selection, funderId)
+      .then((rows) => {
+        if (!cancelled) setDeals(rows);
+      })
+      .catch((err) => {
+        if (!cancelled) setDealsError(err instanceof Error ? err.message : "Failed to load deals");
+      })
+      .finally(() => {
+        if (!cancelled) setDealsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [funderId, selection]);
+
+  const funderIdsByName = useMemo(
+    () =>
+      new Map(Object.entries(analytics?.funderNames ?? {}).map(([id, name]) => [name, Number(id)])),
     [analytics]
+  );
+
+  const handleFunderClick = (funderName: string) => {
+    const id = funderIdsByName.get(funderName);
+    if (id != null) setFunderId(id);
+  };
+
+  const funderName = funderId != null ? (analytics?.funderNames[funderId] ?? null) : null;
+  const scopeLabel =
+    selection === "all"
+      ? "All Portfolios"
+      : (portfolios.find((p) => p.id === selection)?.name ?? "");
+
+  // Vintage-month rows for the current scope. The combined view and the funder
+  // view can both have several source rows per month, so collapse them first.
+  const monthlyRows = useMemo<MonthlyStatsRow[]>(() => {
+    if (!analytics) return [];
+    if (funderId != null)
+      return aggregateMonthlyByVintage(analytics.vintages.filter((v) => v.funder_id === funderId));
+    if (selection === "all") return aggregateMonthlyByVintage(analytics.monthly);
+    return analytics.monthly;
+  }, [analytics, selection, funderId]);
+
+  const vintagesInScope = useMemo(() => {
+    if (!analytics) return [];
+    return funderId != null
+      ? analytics.vintages.filter((v) => v.funder_id === funderId)
+      : analytics.vintages;
+  }, [analytics, funderId]);
+
+  const rtrInScope = useMemo(() => {
+    if (!analytics) return [];
+    return funderId != null ? analytics.rtr.filter((r) => r.funder_id === funderId) : analytics.rtr;
+  }, [analytics, funderId]);
+
+  const kpis = useMemo(() => computeKpis(monthlyRows), [monthlyRows]);
+  const allocations = useMemo(
+    () => buildAllocationsByMonth(vintagesInScope, analytics?.funderNames ?? {}),
+    [vintagesInScope, analytics]
   );
   const allocationsPct = useMemo(() => normalizeStacked(allocations), [allocations]);
   const latestVintage = useMemo(
-    () => latestMonthAllocation(analytics?.vintages ?? [], analytics?.funderNames ?? {}),
-    [analytics]
+    () => latestMonthAllocation(vintagesInScope, analytics?.funderNames ?? {}),
+    [vintagesInScope, analytics]
   );
   const currentAlloc = useMemo(
     () => currentAllocation(analytics?.allocations ?? [], analytics?.funderNames ?? {}),
     [analytics]
   );
-  const commissions = useMemo(() => buildCommissionsByMonth(analytics?.monthly ?? []), [analytics]);
+  const commissions = useMemo(() => buildCommissionsByMonth(monthlyRows), [monthlyRows]);
   const rtrSeries = useMemo(
-    () => buildRtrSeries(analytics?.rtr ?? [], analytics?.funderNames ?? {}),
-    [analytics]
+    () => buildRtrSeries(rtrInScope, analytics?.funderNames ?? {}),
+    [rtrInScope, analytics]
   );
-  const performance = useMemo(() => buildVintagePerformance(analytics?.monthly ?? []), [analytics]);
+  const performance = useMemo(() => buildVintagePerformance(monthlyRows), [monthlyRows]);
 
-  const hasData = (analytics?.monthly.length ?? 0) > 0;
+  // Snapshot cards for the funder drill-down, from funder_allocation_current.
+  // In the "all" scope a funder has one row per portfolio, so sum / re-weight.
+  const funderSnapshot = useMemo(() => {
+    if (funderId == null || !analytics) return null;
+    const rows = analytics.allocations.filter((a) => a.funder_id === funderId);
+    const initial = rows.reduce((acc, r) => acc + (r.initial_cost_basis ?? 0), 0);
+    const current = rows.reduce((acc, r) => acc + (r.current_cost_basis ?? 0), 0);
+    const received = rows.reduce((acc, r) => acc + (r.rtr_received ?? 0), 0);
+    const totalCurrent = analytics.allocations.reduce(
+      (acc, r) => acc + Math.max(r.current_cost_basis ?? 0, 0),
+      0
+    );
+    return {
+      initial,
+      current,
+      received,
+      share: totalCurrent > 0 ? Math.max(current, 0) / totalCurrent : 0,
+    };
+  }, [analytics, funderId]);
+
+  const hasData = monthlyRows.length > 0;
 
   const kpiCards = [
     {
@@ -163,25 +231,77 @@ function Dashboard() {
       icon: "solar:danger-triangle-bold",
       tone: kpis.badDebtPct > 0.05 ? ("danger" as const) : ("success" as const),
     },
+    ...(funderSnapshot
+      ? [
+          {
+            title: "Current Cost Basis",
+            value: formatMoney(funderSnapshot.current),
+            subtitle: `of ${formatMoney(funderSnapshot.initial)} initial`,
+            icon: "solar:money-bag-bold",
+          },
+          {
+            title: "RTR Received (snapshot)",
+            value: formatMoney(funderSnapshot.received),
+            subtitle: "current allocation view",
+            icon: "solar:round-double-alt-arrow-down-bold",
+          },
+          {
+            title: "Share of Current Allocation",
+            value: formatPct(funderSnapshot.share),
+            subtitle: `within ${scopeLabel.toLowerCase()}`,
+            icon: "solar:pie-chart-2-bold",
+          },
+        ]
+      : []),
   ];
+
+  const onFunderClick = funderId == null ? handleFunderClick : undefined;
 
   return (
     <div className="p-6">
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold">Portfolio Dashboard</h1>
+      <div className="flex justify-between items-center mb-6 gap-4">
+        {funderName ? (
+          <div className="flex items-center gap-3 min-w-0">
+            <Button
+              isIconOnly
+              size="sm"
+              variant="light"
+              aria-label={`Back to ${scopeLabel}`}
+              onPress={() => setFunderId(null)}
+            >
+              <Icon icon="solar:arrow-left-linear" width={20} />
+            </Button>
+            <h1 className="text-3xl font-bold truncate">{funderName}</h1>
+            <Chip size="sm" variant="flat">
+              {scopeLabel}
+            </Chip>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1">
+            <h1 className="text-3xl font-bold">Portfolio Dashboard</h1>
+            <p className="text-small text-default-400">
+              Click a funder in any legend or chart to drill into funder-level detail.
+            </p>
+          </div>
+        )}
         <Select
           aria-label="Select Portfolio"
           className="max-w-[220px]"
           isDisabled={portfolios.length === 0}
-          selectedKeys={selectedId != null ? [String(selectedId)] : []}
+          selectedKeys={
+            selection != null ? [selection === "all" ? ALL_PORTFOLIOS_KEY : String(selection)] : []
+          }
           onSelectionChange={(keys) => {
             const key = Array.from(keys)[0];
-            if (key != null) setSelectedId(Number(key));
+            if (key == null) return;
+            setFunderId(null);
+            setSelection(key === ALL_PORTFOLIOS_KEY ? "all" : Number(key));
           }}
         >
-          {portfolios.map((p) => (
-            <SelectItem key={String(p.id)}>{p.name}</SelectItem>
-          ))}
+          {[
+            <SelectItem key={ALL_PORTFOLIOS_KEY}>All Portfolios</SelectItem>,
+            ...portfolios.map((p) => <SelectItem key={String(p.id)}>{p.name}</SelectItem>),
+          ]}
         </Select>
       </div>
 
@@ -198,44 +318,64 @@ function Dashboard() {
         <Card className="mb-6 dark:border-default-100 border border-transparent">
           <div className="p-8 flex flex-col items-center gap-2 text-center">
             <Icon icon="solar:database-bold" className="text-default-400" width={32} />
-            <p className="text-default-600 font-medium">No deal data in this portfolio yet</p>
-            <p className="text-default-400 text-small">
-              Run the one-time workbook import from the portfolio page to populate the dashboard.
+            <p className="text-default-600 font-medium">
+              {funderName
+                ? `No deal data for ${funderName} in this scope yet`
+                : "No deal data in this portfolio yet"}
             </p>
+            {!funderName && (
+              <p className="text-default-400 text-small">
+                Run the one-time workbook import from the portfolio page to populate the dashboard.
+              </p>
+            )}
           </div>
         </Card>
       )}
 
-      {/* KPI cards from portfolio_monthly */}
+      {/* KPI cards from portfolio_monthly / monthly_vintage_stats */}
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 mb-6">
         {kpiCards.map((item) => (
           <KpiCard key={item.title} {...item} loading={loading} />
         ))}
       </div>
 
-      {/* Allocations by vintage month, stacked by funder */}
-      <AllocationsByMonthCard dollars={allocations} percents={allocationsPct} loading={loading} />
+      {/* Allocations / cost basis by vintage month */}
+      <AllocationsByMonthCard
+        title={
+          funderName
+            ? `${funderName} — Cost Basis by Vintage Month`
+            : "Allocations by Month (vintage cost basis)"
+        }
+        dollars={allocations}
+        percents={allocationsPct}
+        loading={loading}
+        onFunderClick={onFunderClick}
+      />
 
-      {/* Allocation snapshots */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-        <AllocationPieCard
-          title={
-            latestVintage.month
-              ? `Allocation — ${latestVintage.month} Vintage`
-              : "Latest Vintage Allocation"
-          }
-          slices={latestVintage.slices}
-          loading={loading}
-        />
-        <AllocationPieCard
-          title="Current Allocation — Cost Basis"
-          slices={currentAlloc}
-          loading={loading}
-        />
-      </div>
+      {/* Allocation snapshots — portfolio scope only; a one-funder pie says nothing */}
+      {funderId == null && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+          <AllocationPieCard
+            title={
+              latestVintage.month
+                ? `Allocation — ${latestVintage.month} Vintage`
+                : "Latest Vintage Allocation"
+            }
+            slices={latestVintage.slices}
+            loading={loading}
+            onFunderClick={onFunderClick}
+          />
+          <AllocationPieCard
+            title="Current Allocation — Cost Basis"
+            slices={currentAlloc}
+            loading={loading}
+            onFunderClick={onFunderClick}
+          />
+        </div>
+      )}
 
       {/* RTR received over time */}
-      <RtrCard series={rtrSeries} loading={loading} />
+      <RtrCard series={rtrSeries} loading={loading} onFunderClick={onFunderClick} />
 
       {/* Vintage performance */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
@@ -244,759 +384,13 @@ function Dashboard() {
       </div>
 
       <TermVsFactorCard data={performance} loading={loading} />
+
+      {/* Funder drill-down: the funder's deals */}
+      {funderId != null && (
+        <FunderDealsTable deals={deals} loading={dealsLoading} error={dealsError} />
+      )}
     </div>
   );
 }
-
-const ChartSkeleton = ({ height = 250 }: { height?: number }) => (
-  <div className="p-4">
-    <Skeleton className="rounded-lg mb-4">
-      <div className="h-4 w-48 bg-default-200"></div>
-    </Skeleton>
-    <Skeleton className="rounded-lg">
-      <div style={{ height }} className="w-full bg-default-200"></div>
-    </Skeleton>
-  </div>
-);
-
-const EmptyChart = ({ height = 250 }: { height?: number }) => (
-  <div style={{ height }} className="flex items-center justify-center">
-    <span className="text-default-400">No data available</span>
-  </div>
-);
-
-const KpiCard = ({
-  title,
-  value,
-  subtitle,
-  icon,
-  tone,
-  loading,
-}: {
-  title: string;
-  value: string;
-  subtitle?: string;
-  icon: string;
-  tone?: "success" | "danger";
-  loading: boolean;
-}) => {
-  if (loading) {
-    return (
-      <Card className="dark:border-default-100 border border-transparent">
-        <div className="p-4">
-          <Skeleton className="rounded-lg mb-2">
-            <div className="h-4 w-24 bg-default-200"></div>
-          </Skeleton>
-          <Skeleton className="rounded-lg">
-            <div className="h-8 w-32 bg-default-200"></div>
-          </Skeleton>
-        </div>
-      </Card>
-    );
-  }
-
-  return (
-    <Card className="dark:border-default-100 border border-transparent">
-      <div className="flex flex-col gap-y-1 p-4">
-        <dt className="text-small text-default-500 font-medium flex items-center gap-2">
-          <Icon icon={icon} width={16} />
-          {title}
-        </dt>
-        <dd
-          className={
-            tone === "success"
-              ? "text-success text-2xl font-semibold"
-              : tone === "danger"
-                ? "text-danger text-2xl font-semibold"
-                : "text-default-700 text-2xl font-semibold"
-          }
-        >
-          {value}
-        </dd>
-        {subtitle && <span className="text-tiny text-default-400">{subtitle}</span>}
-      </div>
-    </Card>
-  );
-};
-
-const FunderLegend = ({ funders }: { funders: string[] }) => (
-  <div className="text-tiny text-default-500 flex w-full flex-wrap justify-center gap-x-4 gap-y-1 px-4 pb-4">
-    {funders.map((funder, index) => (
-      <div key={funder} className="flex items-center gap-2">
-        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: funderColor(index) }} />
-        <span>{funder}</span>
-      </div>
-    ))}
-  </div>
-);
-
-const StackedTooltip = ({
-  active,
-  label,
-  payload,
-  formatter,
-}: {
-  active?: boolean;
-  label?: string;
-  payload?: Array<{ name: string; value: number; color?: string }>;
-  formatter: (value: number) => string;
-}) => {
-  if (!active || !payload || payload.length === 0) return null;
-  const shown = [...payload].reverse().filter((p) => p.value !== 0);
-  return (
-    <div className="rounded-medium bg-background text-tiny shadow-small p-2 max-h-[260px] overflow-y-auto">
-      <p className="font-medium mb-1">{label}</p>
-      {shown.map((entry) => (
-        <div key={entry.name} className="flex items-center gap-x-2">
-          <span className="h-2 w-2 rounded-full" style={{ backgroundColor: entry.color }} />
-          <span className="text-default-500">{entry.name}:</span>
-          <span className="text-default-700 font-medium">{formatter(entry.value)}</span>
-        </div>
-      ))}
-    </div>
-  );
-};
-
-const AllocationsByMonthCard = ({
-  dollars,
-  percents,
-  loading,
-}: {
-  dollars: StackedByFunder;
-  percents: StackedByFunder;
-  loading: boolean;
-}) => {
-  const [mode, setMode] = useState<"dollars" | "percent">("dollars");
-
-  if (loading) {
-    return (
-      <Card className="dark:border-default-100 border border-transparent mb-6">
-        <ChartSkeleton height={300} />
-      </Card>
-    );
-  }
-
-  const stacked = mode === "dollars" ? dollars : percents;
-  const format = mode === "dollars" ? formatMoney : (v: number) => `${v.toFixed(1)}%`;
-
-  return (
-    <Card className="dark:border-default-100 border border-transparent mb-6">
-      <div className="flex items-center justify-between p-4 pb-0">
-        <h3 className="text-small text-default-500 font-medium">
-          Allocations by Month (vintage cost basis)
-        </h3>
-        <Tabs size="sm" selectedKey={mode} onSelectionChange={(key) => setMode(key as typeof mode)}>
-          <Tab key="dollars" title="$" />
-          <Tab key="percent" title="%" />
-        </Tabs>
-      </div>
-
-      {stacked.rows.length > 0 ? (
-        <>
-          <ResponsiveContainer
-            className="[&_.recharts-surface]:outline-hidden"
-            height={300}
-            width="100%"
-          >
-            <BarChart
-              accessibilityLayer
-              data={stacked.rows}
-              margin={{ top: 20, right: 14, left: 8, bottom: 5 }}
-            >
-              <CartesianGrid
-                stroke="hsl(var(--heroui-default-200))"
-                strokeDasharray="3 3"
-                vertical={false}
-              />
-              <XAxis
-                dataKey="month"
-                strokeOpacity={0.25}
-                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
-                tickLine={false}
-                minTickGap={16}
-              />
-              <YAxis
-                axisLine={false}
-                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
-                tickLine={false}
-                tickFormatter={(value) =>
-                  mode === "dollars" ? formatMoney(value) : `${value.toFixed(0)}%`
-                }
-                domain={mode === "percent" ? [0, 100] : undefined}
-              />
-              <Tooltip
-                content={<StackedTooltip formatter={format} />}
-                cursor={{ fill: "hsl(var(--heroui-default-100))", opacity: 0.4 }}
-              />
-              {stacked.funders.map((funder, index) => (
-                <Bar
-                  key={funder}
-                  animationDuration={450}
-                  animationEasing="ease"
-                  dataKey={funder}
-                  stackId="allocations"
-                  fill={funderColor(index)}
-                />
-              ))}
-            </BarChart>
-          </ResponsiveContainer>
-          <FunderLegend funders={stacked.funders} />
-        </>
-      ) : (
-        <EmptyChart height={300} />
-      )}
-    </Card>
-  );
-};
-
-const AllocationPieCard = ({
-  title,
-  slices,
-  loading,
-}: {
-  title: string;
-  slices: PieSlice[];
-  loading: boolean;
-}) => {
-  if (loading) {
-    return (
-      <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
-        <ChartSkeleton height={220} />
-      </Card>
-    );
-  }
-
-  const total = slices.reduce((sum, s) => sum + s.value, 0);
-
-  return (
-    <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
-      <div className="flex flex-col gap-y-2 p-4 pb-0">
-        <h3 className="text-small text-default-500 font-medium">{title}</h3>
-        <dd className="flex items-baseline gap-x-1">
-          <span className="text-default-900 text-3xl font-semibold">{formatMoney(total)}</span>
-          <span className="text-medium text-default-500 font-medium">total</span>
-        </dd>
-      </div>
-
-      {slices.length > 0 ? (
-        <>
-          <ResponsiveContainer
-            className="[&_.recharts-surface]:outline-hidden"
-            height={200}
-            width="100%"
-          >
-            <PieChart accessibilityLayer margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
-              <Tooltip
-                content={({ payload }) => {
-                  if (!payload || payload.length === 0) return null;
-                  return (
-                    <div className="rounded-medium bg-background text-tiny shadow-small p-2">
-                      {payload.map((entry, index) => (
-                        <div key={index} className="flex items-center gap-x-2">
-                          <div
-                            className="h-2 w-2 rounded-full"
-                            style={{ backgroundColor: entry.payload.fill }}
-                          />
-                          <span className="text-default-500">{entry.name}:</span>
-                          <span className="text-default-700 font-medium">
-                            {formatMoney(entry.value as number)}
-                            {total > 0 &&
-                              ` (${(((entry.value as number) / total) * 100).toFixed(1)}%)`}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  );
-                }}
-                cursor={false}
-              />
-              <Pie
-                animationDuration={1000}
-                animationEasing="ease"
-                cornerRadius={6}
-                data={slices}
-                dataKey="value"
-                innerRadius="60%"
-                nameKey="name"
-                paddingAngle={2}
-                strokeWidth={0}
-              >
-                {slices.map((slice, index) => (
-                  <Cell key={slice.name} fill={funderColor(index)} />
-                ))}
-                <Label
-                  content={({ viewBox }) => {
-                    if (viewBox && "cx" in viewBox && "cy" in viewBox) {
-                      return (
-                        <text
-                          x={viewBox.cx}
-                          y={viewBox.cy}
-                          textAnchor="middle"
-                          dominantBaseline="middle"
-                        >
-                          <tspan
-                            x={viewBox.cx}
-                            y={viewBox.cy! - 10}
-                            className="fill-default-700 text-2xl font-bold"
-                          >
-                            {slices.length}
-                          </tspan>
-                          <tspan
-                            x={viewBox.cx}
-                            y={viewBox.cy! + 10}
-                            className="fill-default-500 text-sm"
-                          >
-                            Funders
-                          </tspan>
-                        </text>
-                      );
-                    }
-                    return null;
-                  }}
-                  position="center"
-                />
-              </Pie>
-            </PieChart>
-          </ResponsiveContainer>
-          <FunderLegend funders={slices.map((s) => s.name)} />
-        </>
-      ) : (
-        <EmptyChart />
-      )}
-    </Card>
-  );
-};
-
-const rtrDateLabel = (date: string) => formatMonth(date.slice(0, 7));
-
-const RtrCard = ({
-  series,
-  loading,
-}: {
-  series: ReturnType<typeof buildRtrSeries>;
-  loading: boolean;
-}) => {
-  const [mode, setMode] = useState<"growth" | "by-funder">("growth");
-
-  if (loading) {
-    return (
-      <Card className="dark:border-default-100 border border-transparent mb-6">
-        <ChartSkeleton height={300} />
-      </Card>
-    );
-  }
-
-  const totalReceived =
-    series.points.length > 0 ? series.points[series.points.length - 1].cumulative : 0;
-
-  return (
-    <Card className="dark:border-default-100 border border-transparent mb-6">
-      <div className="flex items-center justify-between p-4 pb-0">
-        <div className="flex flex-col gap-y-1">
-          <h3 className="text-small text-default-500 font-medium">Net RTR Received</h3>
-          <dd className="flex items-baseline gap-x-1">
-            <span className="text-default-900 text-3xl font-semibold">
-              {formatMoney(totalReceived)}
-            </span>
-            <span className="text-medium text-default-500 font-medium">to date</span>
-          </dd>
-        </div>
-        <Tabs size="sm" selectedKey={mode} onSelectionChange={(key) => setMode(key as typeof mode)}>
-          <Tab key="growth" title="Growth" />
-          <Tab key="by-funder" title="By Funder" />
-        </Tabs>
-      </div>
-
-      {series.points.length > 0 ? (
-        <>
-          <ResponsiveContainer
-            className="[&_.recharts-surface]:outline-hidden"
-            height={300}
-            width="100%"
-          >
-            <AreaChart
-              accessibilityLayer
-              data={series.points}
-              margin={{ top: 20, right: 14, left: 8, bottom: 5 }}
-            >
-              <defs>
-                <linearGradient id="rtrGradient" x1="0" x2="0" y1="0" y2="1">
-                  <stop offset="10%" stopColor="hsl(var(--heroui-primary-500))" stopOpacity={0.3} />
-                  <stop
-                    offset="100%"
-                    stopColor="hsl(var(--heroui-primary-100))"
-                    stopOpacity={0.1}
-                  />
-                </linearGradient>
-              </defs>
-              <CartesianGrid
-                stroke="hsl(var(--heroui-default-200))"
-                strokeDasharray="3 3"
-                vertical={false}
-              />
-              <XAxis
-                dataKey="date"
-                strokeOpacity={0.25}
-                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
-                tickLine={false}
-                tickFormatter={rtrDateLabel}
-                minTickGap={24}
-              />
-              <YAxis
-                axisLine={false}
-                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
-                tickLine={false}
-                tickFormatter={formatMoney}
-              />
-              <Tooltip
-                content={({ active, label, payload }) => {
-                  if (!active || !payload || payload.length === 0) return null;
-                  return (
-                    <StackedTooltip
-                      active
-                      label={String(label)}
-                      payload={payload as Array<{ name: string; value: number; color?: string }>}
-                      formatter={formatMoney}
-                    />
-                  );
-                }}
-                cursor={{ strokeWidth: 0 }}
-              />
-              {mode === "growth" ? (
-                <Area
-                  animationDuration={800}
-                  animationEasing="ease"
-                  dataKey="cumulative"
-                  name="Cumulative Net RTR"
-                  fill="url(#rtrGradient)"
-                  stroke="hsl(var(--heroui-primary-500))"
-                  strokeWidth={2}
-                  type="monotone"
-                />
-              ) : (
-                series.funders.map((funder, index) => (
-                  <Area
-                    key={funder}
-                    animationDuration={800}
-                    animationEasing="ease"
-                    dataKey={funder}
-                    stackId="rtr"
-                    fill={funderColor(index)}
-                    fillOpacity={0.7}
-                    stroke={funderColor(index)}
-                    strokeWidth={1}
-                    type="monotone"
-                  />
-                ))
-              )}
-            </AreaChart>
-          </ResponsiveContainer>
-          {mode === "by-funder" && <FunderLegend funders={series.funders} />}
-        </>
-      ) : (
-        <EmptyChart height={300} />
-      )}
-    </Card>
-  );
-};
-
-const CommissionsCard = ({
-  data,
-  loading,
-}: {
-  data: ReturnType<typeof buildCommissionsByMonth>;
-  loading: boolean;
-}) => {
-  if (loading) {
-    return (
-      <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
-        <ChartSkeleton />
-      </Card>
-    );
-  }
-
-  return (
-    <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
-      <div className="flex flex-col gap-y-4 p-4">
-        <h3 className="text-small text-default-500 font-medium">
-          Participation &amp; Commissions by Month
-        </h3>
-        {data.length > 0 ? (
-          <>
-            <ResponsiveContainer
-              className="[&_.recharts-surface]:outline-hidden"
-              height={250}
-              width="100%"
-            >
-              <BarChart accessibilityLayer data={data} margin={{ top: 10, right: 14, left: 8 }}>
-                <CartesianGrid
-                  stroke="hsl(var(--heroui-default-200))"
-                  strokeDasharray="3 3"
-                  vertical={false}
-                />
-                <XAxis
-                  dataKey="month"
-                  strokeOpacity={0.25}
-                  style={{ fontSize: "var(--heroui-font-size-tiny)" }}
-                  tickLine={false}
-                  minTickGap={16}
-                />
-                <YAxis
-                  axisLine={false}
-                  style={{ fontSize: "var(--heroui-font-size-tiny)" }}
-                  tickLine={false}
-                  tickFormatter={formatMoney}
-                />
-                <Tooltip
-                  content={<StackedTooltip formatter={formatMoney} />}
-                  cursor={{ fill: "hsl(var(--heroui-default-100))", opacity: 0.4 }}
-                />
-                <Bar
-                  animationDuration={450}
-                  dataKey="participation"
-                  name="Participation $"
-                  fill="hsl(var(--heroui-default-400))"
-                  radius={[3, 3, 0, 0]}
-                />
-                <Bar
-                  animationDuration={450}
-                  dataKey="commissions"
-                  name="Commissions $"
-                  fill="hsl(var(--heroui-warning-500))"
-                  radius={[3, 3, 0, 0]}
-                />
-              </BarChart>
-            </ResponsiveContainer>
-            <div className="text-tiny text-default-500 flex justify-center gap-4">
-              <div className="flex items-center gap-2">
-                <span
-                  className="h-2 w-2 rounded-full"
-                  style={{ backgroundColor: "hsl(var(--heroui-default-400))" }}
-                />
-                Participation $
-              </div>
-              <div className="flex items-center gap-2">
-                <span
-                  className="h-2 w-2 rounded-full"
-                  style={{ backgroundColor: "hsl(var(--heroui-warning-500))" }}
-                />
-                Commissions $
-              </div>
-            </div>
-          </>
-        ) : (
-          <EmptyChart />
-        )}
-      </div>
-    </Card>
-  );
-};
-
-const PointsPerMonthCard = ({
-  data,
-  loading,
-}: {
-  data: ReturnType<typeof buildVintagePerformance>;
-  loading: boolean;
-}) => {
-  if (loading) {
-    return (
-      <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
-        <ChartSkeleton />
-      </Card>
-    );
-  }
-
-  const rows = data.filter((d) => d.pointsPerMonth != null);
-
-  return (
-    <Card className="dark:border-default-100 min-h-[340px] border border-transparent">
-      <div className="flex flex-col gap-y-4 p-4">
-        <h3 className="text-small text-default-500 font-medium">Points per Month by Vintage</h3>
-        {rows.length > 0 ? (
-          <ResponsiveContainer
-            className="[&_.recharts-surface]:outline-hidden"
-            height={250}
-            width="100%"
-          >
-            <BarChart accessibilityLayer data={rows} margin={{ top: 10, right: 14, left: 8 }}>
-              <CartesianGrid
-                stroke="hsl(var(--heroui-default-200))"
-                strokeDasharray="3 3"
-                vertical={false}
-              />
-              <XAxis
-                dataKey="month"
-                strokeOpacity={0.25}
-                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
-                tickLine={false}
-                minTickGap={16}
-              />
-              <YAxis
-                axisLine={false}
-                style={{ fontSize: "var(--heroui-font-size-tiny)" }}
-                tickLine={false}
-                tickFormatter={(value) => value.toFixed(1)}
-              />
-              <Tooltip
-                content={({ active, label, payload }) => {
-                  if (!active || !payload || payload.length === 0) return null;
-                  return (
-                    <div className="rounded-medium bg-background text-tiny shadow-small p-2">
-                      <p className="font-medium">{label}</p>
-                      <p className="text-default-500">
-                        {(payload[0].value as number).toFixed(2)} points / month
-                      </p>
-                    </div>
-                  );
-                }}
-                cursor={{ fill: "hsl(var(--heroui-default-100))", opacity: 0.4 }}
-              />
-              <Bar
-                animationDuration={450}
-                dataKey="pointsPerMonth"
-                name="Points per Month"
-                fill="hsl(var(--heroui-secondary-500))"
-                radius={[3, 3, 0, 0]}
-              />
-            </BarChart>
-          </ResponsiveContainer>
-        ) : (
-          <EmptyChart />
-        )}
-      </div>
-    </Card>
-  );
-};
-
-const TermVsFactorCard = ({
-  data,
-  loading,
-}: {
-  data: ReturnType<typeof buildVintagePerformance>;
-  loading: boolean;
-}) => {
-  if (loading) {
-    return (
-      <Card className="dark:border-default-100 border border-transparent mb-6">
-        <ChartSkeleton height={280} />
-      </Card>
-    );
-  }
-
-  const rows = data.filter((d) => d.termMonths != null || d.weightedAvgFactor != null);
-
-  return (
-    <Card className="dark:border-default-100 border border-transparent mb-6">
-      <div className="flex items-center justify-between p-4 pb-0">
-        <h3 className="text-small text-default-500 font-medium">
-          Term vs Weighted Avg Net Factor by Vintage
-        </h3>
-        <div className="text-tiny text-default-500 flex gap-4">
-          <div className="flex items-center gap-2">
-            <span
-              className="h-2 w-2 rounded-full"
-              style={{ backgroundColor: "hsl(var(--heroui-default-400))" }}
-            />
-            Term (months)
-          </div>
-          <div className="flex items-center gap-2">
-            <span
-              className="h-2 w-2 rounded-full"
-              style={{ backgroundColor: "hsl(var(--heroui-primary-500))" }}
-            />
-            Net Factor
-          </div>
-        </div>
-      </div>
-
-      {rows.length > 0 ? (
-        <ResponsiveContainer
-          className="[&_.recharts-surface]:outline-hidden"
-          height={280}
-          width="100%"
-        >
-          <ComposedChart
-            accessibilityLayer
-            data={rows}
-            margin={{ top: 20, right: 14, left: 8, bottom: 5 }}
-          >
-            <CartesianGrid
-              stroke="hsl(var(--heroui-default-200))"
-              strokeDasharray="3 3"
-              vertical={false}
-            />
-            <XAxis
-              dataKey="month"
-              strokeOpacity={0.25}
-              style={{ fontSize: "var(--heroui-font-size-tiny)" }}
-              tickLine={false}
-              minTickGap={16}
-            />
-            <YAxis
-              yAxisId="term"
-              axisLine={false}
-              style={{ fontSize: "var(--heroui-font-size-tiny)" }}
-              tickLine={false}
-              tickFormatter={(value) => `${value.toFixed(0)}mo`}
-            />
-            <YAxis
-              yAxisId="factor"
-              orientation="right"
-              axisLine={false}
-              style={{ fontSize: "var(--heroui-font-size-tiny)" }}
-              tickLine={false}
-              domain={["auto", "auto"]}
-              tickFormatter={(value) => value.toFixed(2)}
-            />
-            <Tooltip
-              content={({ active, label, payload }) => {
-                if (!active || !payload || payload.length === 0) return null;
-                const term = payload.find((p) => p.dataKey === "termMonths");
-                const factor = payload.find((p) => p.dataKey === "weightedAvgFactor");
-                return (
-                  <div className="rounded-medium bg-background text-tiny shadow-small p-2">
-                    <p className="font-medium">{label}</p>
-                    {term?.value != null && (
-                      <p className="text-default-500">
-                        Term: {(term.value as number).toFixed(1)} months
-                      </p>
-                    )}
-                    {factor?.value != null && (
-                      <p className="text-default-500">
-                        Net factor: {(factor.value as number).toFixed(3)}
-                      </p>
-                    )}
-                  </div>
-                );
-              }}
-              cursor={{ fill: "hsl(var(--heroui-default-100))", opacity: 0.4 }}
-            />
-            <Bar
-              yAxisId="term"
-              animationDuration={450}
-              dataKey="termMonths"
-              name="Term (months)"
-              fill="hsl(var(--heroui-default-300))"
-              radius={[3, 3, 0, 0]}
-            />
-            <Line
-              yAxisId="factor"
-              animationDuration={800}
-              dataKey="weightedAvgFactor"
-              name="Weighted Avg Net Factor"
-              stroke="hsl(var(--heroui-primary-500))"
-              strokeWidth={2}
-              dot={false}
-              type="monotone"
-            />
-          </ComposedChart>
-        </ResponsiveContainer>
-      ) : (
-        <EmptyChart height={280} />
-      )}
-    </Card>
-  );
-};
 
 export default Dashboard;

--- a/src/services/analytics-service.ts
+++ b/src/services/analytics-service.ts
@@ -6,10 +6,38 @@ export type PortfolioMonthlyRow = Views["portfolio_monthly"]["Row"];
 export type MonthlyVintageRow = Views["monthly_vintage_stats"]["Row"];
 export type FunderAllocationRow = Views["funder_allocation_current"]["Row"];
 export type WeeklyRtrRow = Views["weekly_rtr_matrix"]["Row"];
+export type DealComputedRow = Views["deal_computed"]["Row"];
 
 export interface PortfolioOption {
   id: number;
   name: string;
+}
+
+/** "all" aggregates every portfolio the user can see (RLS scopes the reads). */
+export type PortfolioSelection = number | "all";
+
+/**
+ * The per-vintage columns shared by portfolio_monthly and
+ * monthly_vintage_stats, so the KPI/chart transforms work on either a
+ * portfolio's months or a single funder's months.
+ */
+export interface MonthlyStatsRow {
+  vintage_month: string | null;
+  deal_count: number;
+  new_invested: number | null;
+  rtr_invested: number | null;
+  total_participation: number | null;
+  total_commissions: number | null;
+  cost_basis: number | null;
+  initial_net_rtr: number | null;
+  weighted_avg_factor: number;
+  rtr_received: number | null;
+  principal_returned: number | null;
+  profit_returned: number | null;
+  net_rtr_outstanding_after_bad_debt: number | null;
+  bad_debt_rtr: number | null;
+  weighted_avg_term_months: number | null;
+  points_per_month: number | null;
 }
 
 /** Everything the dashboard needs for one portfolio, fetched in parallel. */
@@ -55,38 +83,31 @@ async function getFunderNames(): Promise<Record<number, string>> {
   return Object.fromEntries((data ?? []).map((f) => [f.id, f.name]));
 }
 
-export async function getPortfolioAnalytics(portfolioId: number): Promise<PortfolioAnalytics> {
+export async function getPortfolioAnalytics(
+  selection: PortfolioSelection
+): Promise<PortfolioAnalytics> {
+  // For "all", omit the portfolio filter — RLS already limits rows to
+  // portfolios shared with the signed-in user.
+  const scope = <T extends { eq: (col: string, v: number) => T }>(query: T): T =>
+    selection === "all" ? query : query.eq("portfolio_id", selection);
+
   const [monthly, vintages, allocations, rtr, funderNames] = await Promise.all([
     fetchAllPages<PortfolioMonthlyRow>((from, to) =>
-      supabase
-        .from("portfolio_monthly")
-        .select("*")
-        .eq("portfolio_id", portfolioId)
-        .order("vintage_month")
-        .range(from, to)
+      scope(supabase.from("portfolio_monthly").select("*")).order("vintage_month").range(from, to)
     ),
     fetchAllPages<MonthlyVintageRow>((from, to) =>
-      supabase
-        .from("monthly_vintage_stats")
-        .select("*")
-        .eq("portfolio_id", portfolioId)
+      scope(supabase.from("monthly_vintage_stats").select("*"))
         .order("vintage_month")
         .order("funder_id")
         .range(from, to)
     ),
     fetchAllPages<FunderAllocationRow>((from, to) =>
-      supabase
-        .from("funder_allocation_current")
-        .select("*")
-        .eq("portfolio_id", portfolioId)
+      scope(supabase.from("funder_allocation_current").select("*"))
         .order("funder_id")
         .range(from, to)
     ),
     fetchAllPages<WeeklyRtrRow>((from, to) =>
-      supabase
-        .from("weekly_rtr_matrix")
-        .select("*")
-        .eq("portfolio_id", portfolioId)
+      scope(supabase.from("weekly_rtr_matrix").select("*"))
         .order("payment_date")
         .order("funder_id")
         .range(from, to)
@@ -95,6 +116,40 @@ export async function getPortfolioAnalytics(portfolioId: number): Promise<Portfo
   ]);
 
   return { monthly, vintages, allocations, rtr, funderNames };
+}
+
+/** A funder's deals with the merchant name resolved, for the drill-down table. */
+export interface FunderDealRow extends DealComputedRow {
+  merchant_name: string | null;
+}
+
+export async function getFunderDeals(
+  portfolioId: PortfolioSelection,
+  funderId: number
+): Promise<FunderDealRow[]> {
+  const scope = <T extends { eq: (col: string, v: number) => T }>(query: T): T =>
+    portfolioId === "all" ? query : query.eq("portfolio_id", portfolioId);
+
+  const [deals, merchants] = await Promise.all([
+    fetchAllPages<DealComputedRow>((from, to) =>
+      scope(supabase.from("deal_computed").select("*"))
+        .eq("funder_id", funderId)
+        .order("date_funded")
+        .range(from, to)
+    ),
+    fetchAllPages<{ id: string; name: string }>((from, to) =>
+      scope(supabase.from("merchants").select("id, name"))
+        .eq("funder_id", funderId)
+        .order("id")
+        .range(from, to)
+    ),
+  ]);
+
+  const names = new Map(merchants.map((m) => [m.id, m.name]));
+  return deals.map((d) => ({
+    ...d,
+    merchant_name: d.merchant_id != null ? (names.get(d.merchant_id) ?? null) : null,
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -114,8 +169,8 @@ export interface PortfolioKpis {
   dealCount: number;
 }
 
-export function computeKpis(monthly: PortfolioMonthlyRow[]): PortfolioKpis {
-  const sum = (pick: (r: PortfolioMonthlyRow) => number | null) =>
+export function computeKpis(monthly: MonthlyStatsRow[]): PortfolioKpis {
+  const sum = (pick: (r: MonthlyStatsRow) => number | null) =>
     monthly.reduce((acc, r) => acc + (pick(r) ?? 0), 0);
 
   const costBasis = sum((r) => r.cost_basis);
@@ -132,6 +187,60 @@ export function computeKpis(monthly: PortfolioMonthlyRow[]): PortfolioKpis {
     badDebtPct: initialNetRtr > 0 ? sum((r) => r.bad_debt_rtr) / initialNetRtr : 0,
     dealCount: sum((r) => r.deal_count),
   };
+}
+
+/**
+ * Collapse per-portfolio (or per-funder) vintage rows into one row per month
+ * for the combined "All Portfolios" view. Dollar columns and deal counts sum;
+ * the weighted averages (factor, term, points/month) are re-weighted by cost
+ * basis across the contributing rows.
+ */
+export function aggregateMonthlyByVintage(rows: MonthlyStatsRow[]): MonthlyStatsRow[] {
+  const byMonth = new Map<string, MonthlyStatsRow[]>();
+  for (const row of rows) {
+    if (!row.vintage_month) continue;
+    const group = byMonth.get(row.vintage_month) ?? [];
+    group.push(row);
+    byMonth.set(row.vintage_month, group);
+  }
+
+  return [...byMonth.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, group]) => {
+      const sum = (pick: (r: MonthlyStatsRow) => number | null) =>
+        group.reduce((acc, r) => acc + (pick(r) ?? 0), 0);
+      const weighted = (pick: (r: MonthlyStatsRow) => number | null): number | null => {
+        let weightTotal = 0;
+        let acc = 0;
+        for (const r of group) {
+          const value = pick(r);
+          const weight = r.cost_basis ?? 0;
+          if (value == null || weight <= 0) continue;
+          acc += value * weight;
+          weightTotal += weight;
+        }
+        return weightTotal > 0 ? acc / weightTotal : null;
+      };
+
+      return {
+        vintage_month: month,
+        deal_count: sum((r) => r.deal_count),
+        new_invested: sum((r) => r.new_invested),
+        rtr_invested: sum((r) => r.rtr_invested),
+        total_participation: sum((r) => r.total_participation),
+        total_commissions: sum((r) => r.total_commissions),
+        cost_basis: sum((r) => r.cost_basis),
+        initial_net_rtr: sum((r) => r.initial_net_rtr),
+        weighted_avg_factor: weighted((r) => r.weighted_avg_factor) ?? 0,
+        rtr_received: sum((r) => r.rtr_received),
+        principal_returned: sum((r) => r.principal_returned),
+        profit_returned: sum((r) => r.profit_returned),
+        net_rtr_outstanding_after_bad_debt: sum((r) => r.net_rtr_outstanding_after_bad_debt),
+        bad_debt_rtr: sum((r) => r.bad_debt_rtr),
+        weighted_avg_term_months: weighted((r) => r.weighted_avg_term_months),
+        points_per_month: weighted((r) => r.points_per_month),
+      };
+    });
 }
 
 /** "2024-05-01" → "May 24" (avoids Date parsing so timezones can't shift the month). */
@@ -223,12 +332,16 @@ export function latestMonthAllocation(
   if (months.length === 0) return { month: null, slices: [] };
   const latest = months.sort()[months.length - 1];
 
-  const slices = vintages
-    .filter((v) => v.vintage_month === latest && (v.cost_basis ?? 0) > 0)
-    .map((v) => ({
-      name: v.funder_id != null ? (funderNames[v.funder_id] ?? `Funder ${v.funder_id}`) : "Unknown",
-      value: v.cost_basis ?? 0,
-    }))
+  // Sum by funder — in the combined view a funder contributes one row per portfolio.
+  const byFunder = new Map<string, number>();
+  for (const v of vintages) {
+    if (v.vintage_month !== latest || (v.cost_basis ?? 0) <= 0) continue;
+    const name =
+      v.funder_id != null ? (funderNames[v.funder_id] ?? `Funder ${v.funder_id}`) : "Unknown";
+    byFunder.set(name, (byFunder.get(name) ?? 0) + (v.cost_basis ?? 0));
+  }
+  const slices = [...byFunder.entries()]
+    .map(([name, value]) => ({ name, value }))
     .sort((a, b) => b.value - a.value);
 
   return { month: formatMonth(latest), slices };
@@ -239,17 +352,18 @@ export function currentAllocation(
   allocations: FunderAllocationRow[],
   funderNames: Record<number, string>
 ): PieSlice[] {
-  return (
-    allocations
-      // fully-repaid funders can go slightly negative; they hold no allocation
-      .filter((a) => (a.current_cost_basis ?? 0) > 0)
-      .map((a) => ({
-        name:
-          a.funder_id != null ? (funderNames[a.funder_id] ?? `Funder ${a.funder_id}`) : "Unknown",
-        value: a.current_cost_basis ?? 0,
-      }))
-      .sort((a, b) => b.value - a.value)
-  );
+  // Sum by funder — in the combined view a funder contributes one row per portfolio.
+  const byFunder = new Map<string, number>();
+  for (const a of allocations) {
+    // fully-repaid funders can go slightly negative; they hold no allocation
+    if ((a.current_cost_basis ?? 0) <= 0) continue;
+    const name =
+      a.funder_id != null ? (funderNames[a.funder_id] ?? `Funder ${a.funder_id}`) : "Unknown";
+    byFunder.set(name, (byFunder.get(name) ?? 0) + (a.current_cost_basis ?? 0));
+  }
+  return [...byFunder.entries()]
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value);
 }
 
 export interface CommissionsMonthRow {
@@ -259,7 +373,7 @@ export interface CommissionsMonthRow {
 }
 
 /** "Commissions Paid by month" — ALDER Portfolio columns E/F per vintage. */
-export function buildCommissionsByMonth(monthly: PortfolioMonthlyRow[]): CommissionsMonthRow[] {
+export function buildCommissionsByMonth(monthly: MonthlyStatsRow[]): CommissionsMonthRow[] {
   return monthly
     .filter((r) => r.vintage_month != null)
     .map((r) => ({
@@ -331,7 +445,7 @@ export interface VintagePerformanceRow {
 }
 
 /** "Term vs Weighted Avg Net Factor" + "Points per Month" per vintage. */
-export function buildVintagePerformance(monthly: PortfolioMonthlyRow[]): VintagePerformanceRow[] {
+export function buildVintagePerformance(monthly: MonthlyStatsRow[]): VintagePerformanceRow[] {
   return monthly
     .filter((r) => r.vintage_month != null)
     .map((r) => ({


### PR DESCRIPTION
## Summary
- Adds an "All Portfolios" option to the dashboard switcher that aggregates every portfolio the user can see (RLS-scoped, unfiltered view reads), with vintage-month rows collapsed and re-weighted by cost basis
- Clicking a funder name in any legend, pie slice, or stacked bar drills into a funder-level view: KPIs, allocation snapshot cards, vintage charts (filtered client-side from data already fetched), and a new filterable/paginated deals table sourced from `deal_computed`
- Extracted the dashboard's chart cards out of `dashboard.tsx` into `components/dashboard/charts.tsx` so both the portfolio and funder views reuse the same components

No schema changes — every chart already reads from views keyed by `funder_id`.

## Test plan
- [x] `npm run lint` / `npm run format:check` / `npm run build` all pass
- [ ] `npm run dev:local` (or run the one-time workbook import against prod, currently empty) and manually verify: switching to "All Portfolios", clicking a funder from a chart/legend, the back button, the deals table filter/pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)