### PR TITLE
feat: add Deal Lookup page — filter/pivot/chart/export, deal CRUD, unmatched reconciliation

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -47,7 +47,7 @@ Schema is managed by CLI migrations in `supabase/migrations/` (`supabase migrati
 ## Functions (write paths)
 
 - **commit_funder_pivot(upload_id, rows jsonb, total_gross, total_fee, total_net, dry_run)** — the single write path from parser output to the DB. Replaces the upload's `funder_pivot_tables`/`funder_pivot_rows`, matches rows to `deals` on `funder_advance_id` (scoped to portfolio + funder; ambiguous matches flagged as duplicates), and unless `dry_run` writes `net_rtr_payments` — aborting unless matched + unmatched + duplicate nets equal the parser's `total_net` within a cent. Returns a reconciliation JSON. `SECURITY INVOKER`, so RLS applies.
-- **resolve_pivot_row(row_id, deal_id)** — resolves one unmatched pivot row to a deal and (re)writes that deal's payment for the pivot's report date; idempotent.
+- **resolve_pivot_row(row_id, deal_id)** — resolves one unmatched pivot row to a deal and (re)writes that deal's payment for the pivot's report date; idempotent. Unmatched rows live in `funder_pivot_rows` with `matched_deal_id IS NULL` (their dollars are excluded from `net_rtr_payments` until resolved); the Deal Lookup page's Unmatched tab lists them all for later reconciliation — match to an existing deal or create the deal and auto-resolve.
 - **import_funder_sheet(portfolio_id, funder_id, management_fee_rate, deals jsonb, total_net_payments)** — one-time onboarding import of a workbook funder sheet (merchants, deals, import-sourced payments); idempotent per sheet.
 
 Deal CRUD from the Deal Lookup page (`deal-editor-service.ts`) writes `deals`/`merchants` directly — the phase 1 RLS policies allow insert/update/delete for users with portfolio access. Deleting a deal cascades its `net_rtr_payments`.

--- a/docs/database.md
+++ b/docs/database.md
@@ -50,6 +50,8 @@ Schema is managed by CLI migrations in `supabase/migrations/` (`supabase migrati
 - **resolve_pivot_row(row_id, deal_id)** — resolves one unmatched pivot row to a deal and (re)writes that deal's payment for the pivot's report date; idempotent.
 - **import_funder_sheet(portfolio_id, funder_id, management_fee_rate, deals jsonb, total_net_payments)** — one-time onboarding import of a workbook funder sheet (merchants, deals, import-sourced payments); idempotent per sheet.
 
+Deal CRUD from the Deal Lookup page (`deal-editor-service.ts`) writes `deals`/`merchants` directly — the phase 1 RLS policies allow insert/update/delete for users with portfolio access. Deleting a deal cascades its `net_rtr_payments`.
+
 ## Monthly flow (cloud-only since Phase 5)
 
 `pivot-sync-service.ts` + `use-cloud-sync.ts`: the uploaded file's bytes go to

--- a/src/__tests__/deal-editor-service.test.ts
+++ b/src/__tests__/deal-editor-service.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import {
+  dealRowToFormValues,
+  formToDealRow,
+  validateDealForm,
+  EMPTY_DEAL_FORM,
+  type DealFormValues,
+} from "../services/deal-editor-service";
+import type { Database } from "../services/supabase.types";
+
+type DealRow = Database["public"]["Tables"]["deals"]["Row"];
+
+const validForm = (overrides: Partial<DealFormValues> = {}): DealFormValues => ({
+  ...EMPTY_DEAL_FORM,
+  portfolioId: 1,
+  funderId: 2,
+  merchantName: "Acme Bakery",
+  dateFunded: "2025-01-15",
+  ...overrides,
+});
+
+const dealRow = (overrides: Partial<DealRow> = {}): DealRow => ({
+  id: "deal-1",
+  merchant_id: "m-1",
+  portfolio_id: 1,
+  funder_id: 2,
+  advance_id: "A-1",
+  funder_advance_id: "F-1",
+  fico: 650,
+  buy_rate: 1.15,
+  commission: 0.1,
+  total_amount_funded: 100000,
+  num_daily_payments: null,
+  num_weekly_payments: 26,
+  deal_length_months: 6,
+  participation_on_amount: 50000,
+  new_dollars: true,
+  rtr: false,
+  is_default: false,
+  date_funded: "2025-01-15",
+  date_closed: null,
+  default_date: null,
+  default_notes: null,
+  created_at: "2025-01-15T00:00:00Z",
+  updated_at: "2025-01-15T00:00:00Z",
+  ...overrides,
+});
+
+describe("validateDealForm", () => {
+  it("accepts a minimal valid form", () => {
+    expect(validateDealForm(validForm())).toBeNull();
+  });
+
+  it("requires portfolio, funder, merchant, and date funded", () => {
+    expect(validateDealForm(validForm({ portfolioId: null }))).toMatch(/Portfolio/);
+    expect(validateDealForm(validForm({ funderId: null }))).toMatch(/Funder/);
+    expect(validateDealForm(validForm({ merchantName: "  " }))).toMatch(/Merchant/);
+    expect(validateDealForm(validForm({ dateFunded: "" }))).toMatch(/Date funded/);
+  });
+
+  it("rejects non-numeric numeric inputs but allows blanks", () => {
+    expect(validateDealForm(validForm({ buyRate: "abc" }))).toMatch(/Buy rate/);
+    expect(validateDealForm(validForm({ buyRate: "" }))).toBeNull();
+    expect(validateDealForm(validForm({ totalAmountFunded: "1,000" }))).toMatch(/Amount funded/);
+  });
+
+  it("requires a default date when flagged as defaulted", () => {
+    expect(validateDealForm(validForm({ isDefault: true }))).toMatch(/Default date/);
+    expect(validateDealForm(validForm({ isDefault: true, defaultDate: "2025-06-01" }))).toBeNull();
+  });
+});
+
+describe("formToDealRow", () => {
+  it("parses numerics and nulls out blanks", () => {
+    const row = formToDealRow(
+      validForm({
+        buyRate: "1.15",
+        commission: "",
+        totalAmountFunded: "100000",
+        numPayments: "26",
+        cadence: "weekly",
+      })
+    );
+    expect(row.buy_rate).toBe(1.15);
+    expect(row.commission).toBeNull();
+    expect(row.total_amount_funded).toBe(100000);
+    expect(row.num_weekly_payments).toBe(26);
+    expect(row.num_daily_payments).toBeNull();
+    expect(row.date_closed).toBeNull();
+  });
+
+  it("routes the payment count by cadence", () => {
+    const daily = formToDealRow(validForm({ cadence: "daily", numPayments: "120" }));
+    expect(daily.num_daily_payments).toBe(120);
+    expect(daily.num_weekly_payments).toBeNull();
+  });
+
+  it("clears the default date when the deal is not defaulted", () => {
+    const row = formToDealRow(validForm({ isDefault: false, defaultDate: "2025-06-01" }));
+    expect(row.is_default).toBe(false);
+    expect(row.default_date).toBeNull();
+  });
+
+  it("never touches advance_id or merchant_id", () => {
+    const row = formToDealRow(validForm());
+    expect("advance_id" in row).toBe(false);
+    expect("merchant_id" in row).toBe(false);
+  });
+});
+
+describe("dealRowToFormValues", () => {
+  it("round-trips a deal row through the form back to the same payload", () => {
+    const original = dealRow();
+    const values = dealRowToFormValues(original, {
+      id: "m-1",
+      name: "Acme Bakery",
+      portfolio_id: 1,
+      funder_id: 2,
+      industry_id: 5,
+      state_id: 33,
+      website: null,
+    });
+    expect(values.cadence).toBe("weekly");
+    expect(values.numPayments).toBe("26");
+    expect(values.merchantId).toBe("m-1");
+
+    const row = formToDealRow(values);
+    expect(row).toMatchObject({
+      portfolio_id: 1,
+      funder_id: 2,
+      funder_advance_id: "F-1",
+      fico: 650,
+      buy_rate: 1.15,
+      commission: 0.1,
+      total_amount_funded: 100000,
+      participation_on_amount: 50000,
+      num_daily_payments: null,
+      num_weekly_payments: 26,
+      deal_length_months: 6,
+      new_dollars: true,
+      rtr: false,
+      is_default: false,
+      date_funded: "2025-01-15",
+      date_closed: null,
+      default_date: null,
+    });
+  });
+
+  it("maps daily deals to the daily cadence", () => {
+    const values = dealRowToFormValues(
+      dealRow({ num_daily_payments: 120, num_weekly_payments: null }),
+      null
+    );
+    expect(values.cadence).toBe("daily");
+    expect(values.numPayments).toBe("120");
+    expect(values.merchantId).toBeNull();
+    expect(values.merchantName).toBe("");
+  });
+});

--- a/src/__tests__/deal-explorer-service.test.ts
+++ b/src/__tests__/deal-explorer-service.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyFilters,
+  buildChartData,
+  buildPivot,
+  chartRowsToPie,
+  countActiveFilters,
+  formatFieldValue,
+  pivotToCsv,
+  recordsToCsv,
+  EMPTY_FILTERS,
+  type DealRecord,
+  type ExplorerFilters,
+  type FilterRule,
+} from "../services/deal-explorer-service";
+
+const deal = (overrides: Partial<DealRecord> = {}): DealRecord => ({
+  id: "deal-1",
+  portfolio_id: 1,
+  funder_id: 1,
+  merchant_id: "m-1",
+  advance_id: "A-1",
+  funder_advance_id: "F-1",
+  fico: 650,
+  date_funded: "2025-01-15",
+  date_closed: null,
+  is_default: false,
+  new_dollars: true,
+  rtr: false,
+  vintage_month: "2025-01-01",
+  buy_rate: 1.15,
+  commission: 0.1,
+  sell_rate: 1.25,
+  total_amount_funded: 100000,
+  participation_on_amount: 50000,
+  management_fee_rate: 0.04,
+  commission_dollars: 10000,
+  total_rtr: 125000,
+  term_months: 6,
+  is_daily: false,
+  rh_pct_of_deal: 0.5,
+  pro_rata_commission: 5000,
+  rh_rtr: 62500,
+  cost_basis: 55000,
+  net_rtr: 60000,
+  new_dollars_at_work: 55000,
+  rtr_dollars_at_work: 0,
+  all_in_factor: 1.09,
+  points_per_month: 1.5,
+  gross_payment_expected: 5000,
+  net_payment_expected: 4800,
+  weekly_payment_expected: 1200,
+  total_net_received: 30000,
+  total_gross_received: 31000,
+  total_fee_paid: 1000,
+  net_rtr_balance: 30000,
+  pct_rtr_paid: 0.5,
+  return_on_cost_basis: 0.09,
+  bad_debt_rtr: 0,
+  default_dollars_lost: 0,
+  merchant_name: "Acme Bakery",
+  industry: "Restaurants",
+  state: "NY",
+  merchant_website: null,
+  funder_name: "BIG",
+  portfolio_name: "Alder",
+  status: "Active",
+  ...overrides,
+});
+
+const filters = (overrides: Partial<ExplorerFilters> = {}): ExplorerFilters => ({
+  ...EMPTY_FILTERS,
+  ...overrides,
+});
+
+const rule = (overrides: Partial<FilterRule>): FilterRule => ({
+  id: "r1",
+  field: "total_amount_funded",
+  operator: "gte",
+  value: "",
+  value2: "",
+  ...overrides,
+});
+
+describe("applyFilters", () => {
+  const records = [
+    deal({ id: "1", merchant_name: "Acme Bakery", industry: "Restaurants" }),
+    deal({
+      id: "2",
+      merchant_name: "Bolt Trucking",
+      industry: "Transportation",
+      vintage_month: "2025-03-01",
+      total_amount_funded: 250000,
+      status: "Defaulted",
+      is_default: true,
+      pct_rtr_paid: 0.2,
+    }),
+    deal({
+      id: "3",
+      merchant_name: "Corner Deli",
+      industry: "Restaurants",
+      vintage_month: "2024-11-01",
+      funder_name: "CFG",
+      status: "Closed",
+      date_closed: "2025-02-01",
+    }),
+  ];
+
+  it("matches free-text search across merchant and IDs", () => {
+    expect(applyFilters(records, filters({ search: "bolt" })).map((r) => r.id)).toEqual(["2"]);
+    expect(applyFilters(records, filters({ search: "F-1" }))).toHaveLength(3);
+  });
+
+  it("filters by multi-select facets", () => {
+    expect(
+      applyFilters(records, filters({ industries: ["Restaurants"] })).map((r) => r.id)
+    ).toEqual(["1", "3"]);
+    expect(applyFilters(records, filters({ funders: ["CFG"] })).map((r) => r.id)).toEqual(["3"]);
+    expect(applyFilters(records, filters({ statuses: ["Defaulted"] })).map((r) => r.id)).toEqual([
+      "2",
+    ]);
+  });
+
+  it("filters by vintage month range", () => {
+    expect(
+      applyFilters(records, filters({ monthFrom: "2025-01", monthTo: "2025-03" })).map((r) => r.id)
+    ).toEqual(["1", "2"]);
+    expect(applyFilters(records, filters({ monthTo: "2024-12" })).map((r) => r.id)).toEqual(["3"]);
+  });
+
+  it("applies numeric rules", () => {
+    const out = applyFilters(
+      records,
+      filters({ rules: [rule({ field: "total_amount_funded", operator: "gt", value: "100000" })] })
+    );
+    expect(out.map((r) => r.id)).toEqual(["2"]);
+  });
+
+  it("treats percent rule values as percentages", () => {
+    const out = applyFilters(
+      records,
+      filters({ rules: [rule({ field: "pct_rtr_paid", operator: "lt", value: "30" })] })
+    );
+    expect(out.map((r) => r.id)).toEqual(["2"]);
+  });
+
+  it("ignores incomplete rules", () => {
+    const out = applyFilters(records, filters({ rules: [rule({ value: "" })] }));
+    expect(out).toHaveLength(3);
+  });
+
+  it("applies boolean rules", () => {
+    const out = applyFilters(
+      records,
+      filters({ rules: [rule({ field: "is_default", operator: "is_true" })] })
+    );
+    expect(out.map((r) => r.id)).toEqual(["2"]);
+  });
+
+  it("counts active filters", () => {
+    expect(countActiveFilters(EMPTY_FILTERS)).toBe(0);
+    expect(
+      countActiveFilters(
+        filters({
+          search: "x",
+          industries: ["Restaurants"],
+          monthFrom: "2025-01",
+          rules: [rule({})],
+        })
+      )
+    ).toBe(4);
+  });
+});
+
+describe("buildPivot", () => {
+  const records = [
+    deal({ id: "1", funder_name: "BIG", vintage_month: "2025-01-01", cost_basis: 100 }),
+    deal({ id: "2", funder_name: "BIG", vintage_month: "2025-02-01", cost_basis: 200 }),
+    deal({ id: "3", funder_name: "CFG", vintage_month: "2025-01-01", cost_basis: 50 }),
+  ];
+
+  it("sums by row and column dimensions with totals", () => {
+    const pivot = buildPivot(records, {
+      rowField: "vintage_month",
+      colField: "funder_name",
+      valueField: "cost_basis",
+      agg: "sum",
+    });
+    expect(pivot.colLabels).toEqual(["BIG", "CFG"]);
+    expect(pivot.rows).toEqual([
+      { label: "Jan 25", values: [100, 50], total: 150 },
+      { label: "Feb 25", values: [200, null], total: 200 },
+    ]);
+    expect(pivot.colTotals).toEqual([300, 50]);
+    expect(pivot.grandTotal).toBe(350);
+  });
+
+  it("counts deals when agg is count", () => {
+    const pivot = buildPivot(records, {
+      rowField: "funder_name",
+      colField: null,
+      valueField: "cost_basis",
+      agg: "count",
+    });
+    expect(pivot.rows).toEqual([
+      { label: "BIG", values: [2], total: 2 },
+      { label: "CFG", values: [1], total: 1 },
+    ]);
+    expect(pivot.grandTotal).toBe(3);
+  });
+
+  it("averages over underlying deals, not over cell averages", () => {
+    const pivot = buildPivot(records, {
+      rowField: "vintage_month",
+      colField: "funder_name",
+      valueField: "cost_basis",
+      agg: "avg",
+    });
+    // Jan: (100 + 50) / 2, not (100 + 50) / 2 cells' averages
+    expect(pivot.rows[0].total).toBe(75);
+    expect(pivot.grandTotal).toBeCloseTo(350 / 3);
+  });
+});
+
+describe("buildChartData", () => {
+  const records = [
+    deal({ id: "1", funder_name: "BIG", vintage_month: "2025-01-01", cost_basis: 100 }),
+    deal({ id: "2", funder_name: "CFG", vintage_month: "2025-02-01", cost_basis: 200 }),
+  ];
+
+  it("builds stacked series with zero-filled gaps, months formatted", () => {
+    const data = buildChartData(records, {
+      type: "bar",
+      dimension: "vintage_month",
+      seriesField: "funder_name",
+      metric: "cost_basis",
+      agg: "sum",
+    });
+    expect(data.series).toEqual(["CFG", "BIG"]); // largest total first
+    expect(data.rows).toEqual([
+      { category: "Jan 25", BIG: 100, CFG: 0 },
+      { category: "Feb 25", BIG: 0, CFG: 200 },
+    ]);
+    expect(data.valueType).toBe("money");
+  });
+
+  it("supports count metric without a series split", () => {
+    const data = buildChartData(records, {
+      type: "bar",
+      dimension: "funder_name",
+      seriesField: null,
+      metric: "count",
+      agg: "sum",
+    });
+    expect(data.rows).toEqual([
+      { category: "BIG", "Deal Count": 1 },
+      { category: "CFG", "Deal Count": 1 },
+    ]);
+  });
+
+  it("collapses small slices into Other for pies", () => {
+    const many = Array.from({ length: 14 }, (_, i) =>
+      deal({
+        id: String(i),
+        industry: `Industry ${String(i).padStart(2, "0")}`,
+        cost_basis: 100 - i,
+      })
+    );
+    const data = buildChartData(many, {
+      type: "pie",
+      dimension: "industry",
+      seriesField: null,
+      metric: "cost_basis",
+      agg: "sum",
+    });
+    const slices = chartRowsToPie(data, 11);
+    expect(slices).toHaveLength(12);
+    expect(slices[11].name).toBe("Other");
+    expect(slices.reduce((acc, s) => acc + s.value, 0)).toBe(
+      many.reduce((acc, d) => acc + (d.cost_basis ?? 0), 0)
+    );
+  });
+});
+
+describe("CSV export", () => {
+  it("writes raw values with escaped labels", () => {
+    const records = [
+      deal({ merchant_name: 'Joe\'s "Best" Pizza, LLC', total_amount_funded: 1234.5 }),
+    ];
+    const csv = recordsToCsv(records, ["merchant_name", "total_amount_funded", "status"]);
+    expect(csv.split("\n")).toEqual([
+      "Merchant,Amount Funded,Status",
+      '"Joe\'s ""Best"" Pizza, LLC",1234.5,Active',
+    ]);
+  });
+
+  it("round-trips a pivot with totals", () => {
+    const pivot = buildPivot(
+      [
+        deal({ id: "1", funder_name: "BIG", vintage_month: "2025-01-01", cost_basis: 100 }),
+        deal({ id: "2", funder_name: "CFG", vintage_month: "2025-01-01", cost_basis: 50 }),
+      ],
+      { rowField: "vintage_month", colField: "funder_name", valueField: "cost_basis", agg: "sum" }
+    );
+    expect(pivotToCsv(pivot).split("\n")).toEqual([
+      "Vintage Month,BIG,CFG,Total",
+      "Jan 25,100,50,150",
+      "Total,100,50,150",
+    ]);
+  });
+});
+
+describe("formatFieldValue", () => {
+  it("formats each field type", () => {
+    expect(formatFieldValue(1234.5, "money")).toBe("$1,234.50");
+    expect(formatFieldValue(0.256, "percent")).toBe("25.6%");
+    expect(formatFieldValue(1.2345, "number")).toBe("1.235");
+    expect(formatFieldValue("2025-01-01", "month")).toBe("Jan 25");
+    expect(formatFieldValue(true, "boolean")).toBe("Yes");
+    expect(formatFieldValue(null, "money")).toBe("—");
+  });
+});

--- a/src/__tests__/deal-explorer-service.test.ts
+++ b/src/__tests__/deal-explorer-service.test.ts
@@ -7,6 +7,7 @@ import {
   countActiveFilters,
   formatFieldValue,
   pivotToCsv,
+  rankCandidateDeals,
   recordsToCsv,
   EMPTY_FILTERS,
   type DealRecord,
@@ -307,6 +308,52 @@ describe("CSV export", () => {
       "Jan 25,100,50,150",
       "Total,100,50,150",
     ]);
+  });
+});
+
+describe("rankCandidateDeals", () => {
+  const pivotRow = {
+    advance_id: "ADV-42",
+    merchant_name: "Acme Bakery",
+    portfolio_id: 1,
+    funder_id: 2,
+  };
+  const deals = [
+    deal({ id: "other-scope", portfolio_id: 2, funder_id: 2, funder_advance_id: "ADV-42" }),
+    deal({
+      id: "old",
+      portfolio_id: 1,
+      funder_id: 2,
+      funder_advance_id: "X",
+      merchant_name: "Bolt Trucking",
+      date_funded: "2024-01-01",
+    }),
+    deal({
+      id: "name-match",
+      portfolio_id: 1,
+      funder_id: 2,
+      funder_advance_id: "Y",
+      merchant_name: "Acme Bakery LLC",
+      date_funded: "2024-06-01",
+    }),
+    deal({
+      id: "exact",
+      portfolio_id: 1,
+      funder_id: 2,
+      funder_advance_id: "ADV-42",
+      merchant_name: "Renamed Corp",
+      date_funded: "2023-01-01",
+    }),
+  ];
+
+  it("scopes to the row's portfolio + funder and ranks exact ID first", () => {
+    const ranked = rankCandidateDeals(pivotRow, deals);
+    expect(ranked.map((d) => d.id)).toEqual(["exact", "name-match", "old"]);
+  });
+
+  it("falls back to merchant-name and recency without an advance id", () => {
+    const ranked = rankCandidateDeals({ ...pivotRow, advance_id: null }, deals);
+    expect(ranked.map((d) => d.id)).toEqual(["name-match", "old", "exact"]);
   });
 });
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,7 @@ import Layout from "./layout";
 import Dashboard from "@pages/dashboard";
 import AlderPortfolio from "@pages/alder-portfolio";
 import WhiteRabbitPortfolio from "@pages/white-rabbit-portfolio";
+import DealLookup from "@pages/deal-lookup";
 import Settings from "@pages/settings";
 import Login from "@pages/login";
 import { ProtectedRoute } from "@components/auth/protected-route";
@@ -40,6 +41,7 @@ function App() {
         <Route path="dashboard" element={<Dashboard />} />
         <Route path="alder-portfolio" element={<AlderPortfolio />} />
         <Route path="white-rabbit-portfolio" element={<WhiteRabbitPortfolio />} />
+        <Route path="deal-lookup" element={<DealLookup />} />
         <Route path="settings" element={<Settings />} />
       </Route>
     </Routes>

--- a/src/components/deal-explorer/chart-builder.tsx
+++ b/src/components/deal-explorer/chart-builder.tsx
@@ -1,0 +1,295 @@
+import { useMemo } from "react";
+import { Card, Select, SelectItem } from "@heroui/react";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  AreaChart,
+  Area,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+import {
+  funderColor,
+  EmptyChart,
+  FunderLegend,
+  StackedTooltip,
+} from "@components/dashboard/charts";
+import { formatMoney } from "@services/analytics-service";
+import {
+  buildChartData,
+  chartRowsToPie,
+  formatFieldValue,
+  AGGREGATION_LABELS,
+  COUNT_METRIC,
+  DIMENSION_FIELDS,
+  NUMERIC_FIELDS,
+  type Aggregation,
+  type ChartConfig,
+  type ChartType,
+  type DealRecord,
+  type FieldType,
+} from "@services/deal-explorer-service";
+
+const NO_SERIES_KEY = "__none__";
+
+const CHART_TYPES: { key: ChartType; label: string }[] = [
+  { key: "bar", label: "Bar (stacked)" },
+  { key: "line", label: "Line" },
+  { key: "area", label: "Area (stacked)" },
+  { key: "pie", label: "Pie" },
+];
+
+/** Compact tick labels; money gets the $1.2M treatment, the rest plain numbers. */
+const axisFormatter = (valueType: FieldType) => (value: number) =>
+  valueType === "money"
+    ? formatMoney(value)
+    : valueType === "percent"
+      ? `${(value * 100).toFixed(0)}%`
+      : value.toLocaleString("en-US", { maximumFractionDigits: 2 });
+
+const ChartBuilder = ({
+  records,
+  config,
+  onConfigChange,
+}: {
+  records: DealRecord[];
+  config: ChartConfig;
+  onConfigChange: (config: ChartConfig) => void;
+}) => {
+  const data = useMemo(() => buildChartData(records, config), [records, config]);
+  const pieSlices = useMemo(
+    () => (config.type === "pie" ? chartRowsToPie(data) : []),
+    [config.type, data]
+  );
+  const tooltipFormat = (value: number) => formatFieldValue(value, data.valueType);
+
+  const singleKeySelect = (
+    label: string,
+    selected: string,
+    items: { key: string; label: string }[],
+    onSelect: (key: string) => void,
+    width = "w-full sm:max-w-[200px]"
+  ) => (
+    <Select
+      aria-label={label}
+      label={label}
+      size="sm"
+      className={width}
+      selectedKeys={[selected]}
+      onSelectionChange={(keys) => {
+        const key = Array.from(keys)[0];
+        if (key != null) onSelect(String(key));
+      }}
+    >
+      {items.map((item) => (
+        <SelectItem key={item.key}>{item.label}</SelectItem>
+      ))}
+    </Select>
+  );
+
+  const dimensionItems = DIMENSION_FIELDS.map((f) => ({ key: f.key as string, label: f.label }));
+  const metricItems = [
+    { key: COUNT_METRIC, label: "Deal Count" },
+    ...NUMERIC_FIELDS.map((f) => ({ key: f.key as string, label: f.label })),
+  ];
+
+  const axisProps = {
+    strokeOpacity: 0.25,
+    style: { fontSize: "var(--heroui-font-size-tiny)" },
+    tickLine: false,
+  };
+  const grid = (
+    <CartesianGrid stroke="hsl(var(--heroui-default-200))" strokeDasharray="3 3" vertical={false} />
+  );
+  const tooltip = (
+    <Tooltip
+      content={<StackedTooltip formatter={tooltipFormat} />}
+      cursor={{ fill: "hsl(var(--heroui-default-100))", opacity: 0.4 }}
+    />
+  );
+  const xAxis = <XAxis dataKey="category" {...axisProps} minTickGap={16} />;
+  const yAxis = (
+    <YAxis axisLine={false} {...axisProps} tickFormatter={axisFormatter(data.valueType)} />
+  );
+
+  const renderChart = () => {
+    if (config.type === "pie") {
+      if (pieSlices.length === 0) return <EmptyChart height={340} />;
+      return (
+        <>
+          <ResponsiveContainer height={340} width="100%">
+            <PieChart accessibilityLayer>
+              <Tooltip
+                content={({ payload }) => {
+                  if (!payload || payload.length === 0) return null;
+                  const total = pieSlices.reduce((acc, s) => acc + s.value, 0);
+                  return (
+                    <div className="rounded-medium bg-background text-tiny shadow-small p-2">
+                      {payload.map((entry, index) => (
+                        <div key={index} className="flex items-center gap-x-2">
+                          <span
+                            className="h-2 w-2 rounded-full"
+                            style={{ backgroundColor: entry.payload.fill }}
+                          />
+                          <span className="text-default-500">{entry.name}:</span>
+                          <span className="text-default-700 font-medium">
+                            {tooltipFormat(entry.value as number)}
+                            {total > 0 &&
+                              ` (${(((entry.value as number) / total) * 100).toFixed(1)}%)`}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  );
+                }}
+                cursor={false}
+              />
+              <Pie
+                animationDuration={800}
+                animationEasing="ease"
+                cornerRadius={6}
+                data={pieSlices}
+                dataKey="value"
+                nameKey="name"
+                innerRadius="55%"
+                paddingAngle={2}
+                strokeWidth={0}
+              >
+                {pieSlices.map((slice, index) => (
+                  <Cell key={slice.name} fill={funderColor(index)} />
+                ))}
+              </Pie>
+            </PieChart>
+          </ResponsiveContainer>
+          <FunderLegend funders={pieSlices.map((s) => s.name)} />
+        </>
+      );
+    }
+
+    if (data.rows.length === 0) return <EmptyChart height={340} />;
+
+    const margin = { top: 20, right: 14, left: 8, bottom: 5 };
+    if (config.type === "line") {
+      return (
+        <ResponsiveContainer height={340} width="100%">
+          <LineChart accessibilityLayer data={data.rows} margin={margin}>
+            {grid}
+            {xAxis}
+            {yAxis}
+            {tooltip}
+            {data.series.map((name, index) => (
+              <Line
+                key={name}
+                animationDuration={600}
+                dataKey={name}
+                stroke={funderColor(index)}
+                strokeWidth={2}
+                dot={false}
+                type="monotone"
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      );
+    }
+    if (config.type === "area") {
+      return (
+        <ResponsiveContainer height={340} width="100%">
+          <AreaChart accessibilityLayer data={data.rows} margin={margin}>
+            {grid}
+            {xAxis}
+            {yAxis}
+            {tooltip}
+            {data.series.map((name, index) => (
+              <Area
+                key={name}
+                animationDuration={600}
+                dataKey={name}
+                stackId="chart"
+                fill={funderColor(index)}
+                fillOpacity={0.7}
+                stroke={funderColor(index)}
+                strokeWidth={1}
+                type="monotone"
+              />
+            ))}
+          </AreaChart>
+        </ResponsiveContainer>
+      );
+    }
+    return (
+      <ResponsiveContainer height={340} width="100%">
+        <BarChart accessibilityLayer data={data.rows} margin={margin}>
+          {grid}
+          {xAxis}
+          {yAxis}
+          {tooltip}
+          {data.series.map((name, index) => (
+            <Bar
+              key={name}
+              animationDuration={450}
+              dataKey={name}
+              stackId="chart"
+              fill={funderColor(index)}
+            />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  };
+
+  return (
+    <Card className="dark:border-default-100 border border-transparent">
+      <div className="flex flex-wrap items-end gap-2 p-4 pb-2">
+        {singleKeySelect(
+          "Chart type",
+          config.type,
+          CHART_TYPES,
+          (type) => onConfigChange({ ...config, type: type as ChartType }),
+          "w-full sm:max-w-[160px]"
+        )}
+        {singleKeySelect(
+          config.type === "pie" ? "Slices" : "X axis",
+          config.dimension,
+          dimensionItems,
+          (dimension) => onConfigChange({ ...config, dimension })
+        )}
+        {config.type !== "pie" &&
+          singleKeySelect(
+            "Split by",
+            config.seriesField ?? NO_SERIES_KEY,
+            [{ key: NO_SERIES_KEY, label: "None" }, ...dimensionItems],
+            (key) => onConfigChange({ ...config, seriesField: key === NO_SERIES_KEY ? null : key })
+          )}
+        {singleKeySelect("Metric", config.metric, metricItems, (metric) =>
+          onConfigChange({ ...config, metric })
+        )}
+        {config.metric !== COUNT_METRIC &&
+          singleKeySelect(
+            "Aggregation",
+            config.agg,
+            Object.entries(AGGREGATION_LABELS)
+              .filter(([key]) => key !== "count")
+              .map(([key, label]) => ({ key, label })),
+            (agg) => onConfigChange({ ...config, agg: agg as Aggregation }),
+            "w-full sm:max-w-[130px]"
+          )}
+      </div>
+
+      <div className="p-4 pt-2 [&_.recharts-surface]:outline-hidden">
+        {renderChart()}
+        {config.type !== "pie" && data.series.length > 1 && <FunderLegend funders={data.series} />}
+      </div>
+    </Card>
+  );
+};
+
+export default ChartBuilder;

--- a/src/components/deal-explorer/deal-form-modal.tsx
+++ b/src/components/deal-explorer/deal-form-modal.tsx
@@ -1,0 +1,347 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Autocomplete,
+  AutocompleteItem,
+  Button,
+  Checkbox,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Select,
+  SelectItem,
+} from "@heroui/react";
+import { Icon } from "@iconify/react";
+import {
+  createDeal,
+  updateDeal,
+  validateDealForm,
+  EMPTY_DEAL_FORM,
+  type DealFormValues,
+  type EditorLookups,
+  type PaymentCadence,
+} from "@services/deal-editor-service";
+
+const NumberSelect = ({
+  label,
+  items,
+  selected,
+  onChange,
+  isRequired,
+}: {
+  label: string;
+  items: { id: number; label: string }[];
+  selected: number | null;
+  onChange: (id: number | null) => void;
+  isRequired?: boolean;
+}) => (
+  <Select
+    aria-label={label}
+    label={label}
+    size="sm"
+    isRequired={isRequired}
+    selectedKeys={selected != null ? [String(selected)] : []}
+    onSelectionChange={(keys) => {
+      const key = Array.from(keys)[0];
+      onChange(key != null ? Number(key) : null);
+    }}
+  >
+    {items.map((item) => (
+      <SelectItem key={String(item.id)}>{item.label}</SelectItem>
+    ))}
+  </Select>
+);
+
+const DealFormModal = ({
+  isOpen,
+  onClose,
+  lookups,
+  /** null → create; otherwise the deal being edited with its loaded inputs. */
+  editing,
+  onSaved,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  lookups: EditorLookups;
+  editing: { dealId: string; values: DealFormValues } | null;
+  onSaved: () => void;
+}) => {
+  const [values, setValues] = useState<DealFormValues>(EMPTY_DEAL_FORM);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setValues(editing?.values ?? EMPTY_DEAL_FORM);
+      setError(null);
+    }
+  }, [isOpen, editing]);
+
+  const set = <K extends keyof DealFormValues>(key: K, value: DealFormValues[K]) =>
+    setValues((current) => ({ ...current, [key]: value }));
+
+  // Offer merchants already under the chosen portfolio + funder first; the
+  // user can still type a brand-new name.
+  const merchantOptions = useMemo(() => {
+    const scoped = lookups.merchants.filter(
+      (m) =>
+        (values.portfolioId == null || m.portfolio_id === values.portfolioId) &&
+        (values.funderId == null || m.funder_id === values.funderId)
+    );
+    return scoped.length > 0 ? scoped : lookups.merchants;
+  }, [lookups.merchants, values.portfolioId, values.funderId]);
+
+  const pickMerchant = (id: string | null) => {
+    if (id == null) {
+      set("merchantId", null);
+      return;
+    }
+    const merchant = lookups.merchants.find((m) => m.id === id);
+    if (!merchant) return;
+    setValues((current) => ({
+      ...current,
+      merchantId: merchant.id,
+      merchantName: merchant.name,
+      industryId: merchant.industry_id,
+      stateId: merchant.state_id,
+      website: merchant.website ?? "",
+    }));
+  };
+
+  const submit = async () => {
+    const problem = validateDealForm(values);
+    if (problem != null) {
+      setError(problem);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      if (editing != null) {
+        await updateDeal(editing.dealId, values);
+      } else {
+        await createDeal(values);
+      }
+      onSaved();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => !open && onClose()}
+      size="2xl"
+      scrollBehavior="inside"
+    >
+      <ModalContent>
+        <ModalHeader>{editing != null ? "Edit Deal" : "New Deal"}</ModalHeader>
+        <ModalBody>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <NumberSelect
+              label="Portfolio"
+              isRequired
+              items={lookups.portfolios.map((p) => ({ id: p.id, label: p.name }))}
+              selected={values.portfolioId}
+              onChange={(portfolioId) => set("portfolioId", portfolioId)}
+            />
+            <NumberSelect
+              label="Funder"
+              isRequired
+              items={lookups.funders.map((f) => ({ id: f.id, label: f.name }))}
+              selected={values.funderId}
+              onChange={(funderId) => set("funderId", funderId)}
+            />
+            <Autocomplete
+              aria-label="Merchant"
+              label="Merchant"
+              size="sm"
+              isRequired
+              allowsCustomValue
+              className="sm:col-span-2"
+              placeholder="Pick an existing merchant or type a new name"
+              inputValue={values.merchantName}
+              selectedKey={values.merchantId}
+              onInputChange={(name) => {
+                setValues((current) => ({
+                  ...current,
+                  merchantName: name,
+                  // typing a different name detaches from the picked merchant
+                  merchantId:
+                    current.merchantId != null &&
+                    lookups.merchants.find((m) => m.id === current.merchantId)?.name === name
+                      ? current.merchantId
+                      : null,
+                }));
+              }}
+              onSelectionChange={(key) => pickMerchant(key != null ? String(key) : null)}
+            >
+              {merchantOptions.map((merchant) => (
+                <AutocompleteItem key={merchant.id}>{merchant.name}</AutocompleteItem>
+              ))}
+            </Autocomplete>
+            <NumberSelect
+              label="Industry"
+              items={lookups.industries.map((i) => ({ id: i.id, label: i.name }))}
+              selected={values.industryId}
+              onChange={(industryId) => set("industryId", industryId)}
+            />
+            <NumberSelect
+              label="State"
+              items={lookups.states.map((s) => ({ id: s.id, label: s.code }))}
+              selected={values.stateId}
+              onChange={(stateId) => set("stateId", stateId)}
+            />
+            <Input
+              label="Website"
+              size="sm"
+              value={values.website}
+              onValueChange={(website) => set("website", website)}
+            />
+            <Input
+              label="Advance ID"
+              size="sm"
+              value={values.funderAdvanceId}
+              onValueChange={(funderAdvanceId) => set("funderAdvanceId", funderAdvanceId)}
+            />
+            <Input
+              label="Date funded"
+              size="sm"
+              type="date"
+              isRequired
+              value={values.dateFunded}
+              onValueChange={(dateFunded) => set("dateFunded", dateFunded)}
+            />
+            <Input
+              label="FICO"
+              size="sm"
+              value={values.fico}
+              onValueChange={(fico) => set("fico", fico)}
+            />
+            <Input
+              label="Buy rate"
+              size="sm"
+              placeholder="e.g. 1.15"
+              value={values.buyRate}
+              onValueChange={(buyRate) => set("buyRate", buyRate)}
+            />
+            <Input
+              label="Commission rate"
+              size="sm"
+              placeholder="e.g. 0.10"
+              value={values.commission}
+              onValueChange={(commission) => set("commission", commission)}
+            />
+            <Input
+              label="Amount funded"
+              size="sm"
+              placeholder="e.g. 100000"
+              startContent={<span className="text-default-400 text-small">$</span>}
+              value={values.totalAmountFunded}
+              onValueChange={(totalAmountFunded) => set("totalAmountFunded", totalAmountFunded)}
+            />
+            <Input
+              label="Participation"
+              size="sm"
+              placeholder="e.g. 50000"
+              startContent={<span className="text-default-400 text-small">$</span>}
+              value={values.participation}
+              onValueChange={(participation) => set("participation", participation)}
+            />
+            <Select
+              aria-label="Payment cadence"
+              label="Payment cadence"
+              size="sm"
+              selectedKeys={[values.cadence]}
+              onSelectionChange={(keys) => {
+                const key = Array.from(keys)[0];
+                if (key != null) set("cadence", key as PaymentCadence);
+              }}
+            >
+              <SelectItem key="weekly">Weekly</SelectItem>
+              <SelectItem key="daily">Daily</SelectItem>
+            </Select>
+            <Input
+              label={values.cadence === "daily" ? "Daily payments" : "Weekly payments"}
+              size="sm"
+              placeholder="payment count"
+              value={values.numPayments}
+              onValueChange={(numPayments) => set("numPayments", numPayments)}
+            />
+            <Input
+              label="Deal length (months)"
+              size="sm"
+              value={values.dealLengthMonths}
+              onValueChange={(dealLengthMonths) => set("dealLengthMonths", dealLengthMonths)}
+            />
+            <Input
+              label="Date closed"
+              size="sm"
+              type="date"
+              value={values.dateClosed}
+              onValueChange={(dateClosed) => set("dateClosed", dateClosed)}
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4 pt-1">
+            <Checkbox
+              size="sm"
+              isSelected={values.newDollars}
+              onValueChange={(newDollars) => set("newDollars", newDollars)}
+            >
+              New dollars
+            </Checkbox>
+            <Checkbox
+              size="sm"
+              isSelected={values.rtrReinvestment}
+              onValueChange={(rtrReinvestment) => set("rtrReinvestment", rtrReinvestment)}
+            >
+              RTR reinvestment
+            </Checkbox>
+            <Checkbox
+              size="sm"
+              isSelected={values.isDefault}
+              onValueChange={(isDefault) => set("isDefault", isDefault)}
+            >
+              Defaulted
+            </Checkbox>
+            {values.isDefault && (
+              <Input
+                aria-label="Default date"
+                label="Default date"
+                size="sm"
+                type="date"
+                className="max-w-[180px]"
+                value={values.defaultDate}
+                onValueChange={(defaultDate) => set("defaultDate", defaultDate)}
+              />
+            )}
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-2 text-danger text-small">
+              <Icon icon="solar:danger-triangle-bold" width={16} />
+              {error}
+            </div>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button size="sm" variant="light" onPress={onClose} isDisabled={saving}>
+            Cancel
+          </Button>
+          <Button size="sm" color="primary" isLoading={saving} onPress={submit}>
+            {editing != null ? "Save changes" : "Create deal"}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default DealFormModal;

--- a/src/components/deal-explorer/deal-form-modal.tsx
+++ b/src/components/deal-explorer/deal-form-modal.tsx
@@ -60,13 +60,16 @@ const DealFormModal = ({
   lookups,
   /** null → create; otherwise the deal being edited with its loaded inputs. */
   editing,
+  /** Prefilled values for create mode (e.g. from an unmatched pivot row). */
+  createDefaults,
   onSaved,
 }: {
   isOpen: boolean;
   onClose: () => void;
   lookups: EditorLookups;
   editing: { dealId: string; values: DealFormValues } | null;
-  onSaved: () => void;
+  createDefaults?: DealFormValues | null;
+  onSaved: (dealId: string) => void;
 }) => {
   const [values, setValues] = useState<DealFormValues>(EMPTY_DEAL_FORM);
   const [saving, setSaving] = useState(false);
@@ -74,10 +77,10 @@ const DealFormModal = ({
 
   useEffect(() => {
     if (isOpen) {
-      setValues(editing?.values ?? EMPTY_DEAL_FORM);
+      setValues(editing?.values ?? createDefaults ?? EMPTY_DEAL_FORM);
       setError(null);
     }
-  }, [isOpen, editing]);
+  }, [isOpen, editing, createDefaults]);
 
   const set = <K extends keyof DealFormValues>(key: K, value: DealFormValues[K]) =>
     setValues((current) => ({ ...current, [key]: value }));
@@ -119,12 +122,14 @@ const DealFormModal = ({
     setSaving(true);
     setError(null);
     try {
+      let dealId: string;
       if (editing != null) {
         await updateDeal(editing.dealId, values);
+        dealId = editing.dealId;
       } else {
-        await createDeal(values);
+        dealId = await createDeal(values);
       }
-      onSaved();
+      onSaved(dealId);
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));

--- a/src/components/deal-explorer/explorer-table.tsx
+++ b/src/components/deal-explorer/explorer-table.tsx
@@ -46,18 +46,26 @@ function compareValues(a: unknown, b: unknown): number {
   return String(a).localeCompare(String(b));
 }
 
+const ACTIONS_KEY = "__actions";
+
 const ExplorerTable = ({
   records,
   visibleFields,
   onVisibleFieldsChange,
   onExport,
   exporting,
+  onCreate,
+  onEdit,
+  onDelete,
 }: {
   records: DealRecord[];
   visibleFields: string[];
   onVisibleFieldsChange: (fields: string[]) => void;
   onExport: () => void;
   exporting: boolean;
+  onCreate: () => void;
+  onEdit: (record: DealRecord) => void;
+  onDelete: (record: DealRecord) => void;
 }) => {
   const [page, setPage] = useState(1);
   const [sort, setSort] = useState<SortDescriptor>({
@@ -67,7 +75,14 @@ const ExplorerTable = ({
 
   // Keep registry order so the table layout is stable however columns are picked.
   const columns = useMemo(
-    () => DEAL_FIELDS.filter((f) => visibleFields.includes(f.key as string)),
+    () => [
+      ...DEAL_FIELDS.filter((f) => visibleFields.includes(f.key as string)).map((f) => ({
+        key: f.key as string,
+        label: f.label,
+        type: f.type,
+      })),
+      { key: ACTIONS_KEY, label: "", type: "text" as FieldType },
+    ],
     [visibleFields]
   );
 
@@ -86,6 +101,14 @@ const ExplorerTable = ({
       <div className="flex flex-wrap items-center justify-between gap-3 p-4 pb-2">
         <span className="text-tiny text-default-400">{records.length.toLocaleString()} deals</span>
         <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            color="primary"
+            startContent={<Icon icon="solar:add-circle-linear" width={16} />}
+            onPress={onCreate}
+          >
+            New Deal
+          </Button>
           <Dropdown closeOnSelect={false}>
             <DropdownTrigger>
               <Button
@@ -150,8 +173,8 @@ const ExplorerTable = ({
           <TableHeader columns={columns}>
             {(column) => (
               <TableColumn
-                key={column.key as string}
-                allowsSorting
+                key={column.key}
+                allowsSorting={column.key !== ACTIONS_KEY}
                 align={isNumericType(column.type) ? "end" : "start"}
               >
                 {column.label.toUpperCase()}
@@ -162,6 +185,33 @@ const ExplorerTable = ({
             {(record) => (
               <TableRow key={record.id}>
                 {(columnKey) => {
+                  if (columnKey === ACTIONS_KEY) {
+                    return (
+                      <TableCell>
+                        <div className="flex items-center gap-1">
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            variant="light"
+                            aria-label="Edit deal"
+                            onPress={() => onEdit(record)}
+                          >
+                            <Icon icon="solar:pen-linear" width={16} />
+                          </Button>
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            variant="light"
+                            color="danger"
+                            aria-label="Delete deal"
+                            onPress={() => onDelete(record)}
+                          >
+                            <Icon icon="solar:trash-bin-minimalistic-linear" width={16} />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    );
+                  }
                   const def = fieldDef(String(columnKey));
                   const value = def ? record[def.key] : null;
                   if (def?.key === "status") {

--- a/src/components/deal-explorer/explorer-table.tsx
+++ b/src/components/deal-explorer/explorer-table.tsx
@@ -1,0 +1,191 @@
+import { useMemo, useState } from "react";
+import {
+  Button,
+  Card,
+  Chip,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownTrigger,
+  Pagination,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+  type SortDescriptor,
+} from "@heroui/react";
+import { Icon } from "@iconify/react";
+import {
+  fieldDef,
+  formatFieldValue,
+  DEAL_FIELDS,
+  type DealRecord,
+  type FieldType,
+} from "@services/deal-explorer-service";
+
+const ROWS_PER_PAGE = 20;
+
+const isNumericType = (type: FieldType) =>
+  type === "number" || type === "money" || type === "percent";
+
+const statusColor = (status: string) =>
+  status === "Defaulted"
+    ? ("danger" as const)
+    : status === "Closed"
+      ? ("default" as const)
+      : ("success" as const);
+
+function compareValues(a: unknown, b: unknown): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1; // nulls last
+  if (b == null) return -1;
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  if (typeof a === "boolean" && typeof b === "boolean") return Number(a) - Number(b);
+  return String(a).localeCompare(String(b));
+}
+
+const ExplorerTable = ({
+  records,
+  visibleFields,
+  onVisibleFieldsChange,
+  onExport,
+  exporting,
+}: {
+  records: DealRecord[];
+  visibleFields: string[];
+  onVisibleFieldsChange: (fields: string[]) => void;
+  onExport: () => void;
+  exporting: boolean;
+}) => {
+  const [page, setPage] = useState(1);
+  const [sort, setSort] = useState<SortDescriptor>({
+    column: "date_funded",
+    direction: "descending",
+  });
+
+  // Keep registry order so the table layout is stable however columns are picked.
+  const columns = useMemo(
+    () => DEAL_FIELDS.filter((f) => visibleFields.includes(f.key as string)),
+    [visibleFields]
+  );
+
+  const sorted = useMemo(() => {
+    const key = String(sort.column) as keyof DealRecord;
+    const out = [...records].sort((a, b) => compareValues(a[key], b[key]));
+    return sort.direction === "descending" ? out.reverse() : out;
+  }, [records, sort]);
+
+  const pages = Math.max(1, Math.ceil(sorted.length / ROWS_PER_PAGE));
+  const currentPage = Math.min(page, pages);
+  const pageRows = sorted.slice((currentPage - 1) * ROWS_PER_PAGE, currentPage * ROWS_PER_PAGE);
+
+  return (
+    <Card className="dark:border-default-100 border border-transparent">
+      <div className="flex flex-wrap items-center justify-between gap-3 p-4 pb-2">
+        <span className="text-tiny text-default-400">{records.length.toLocaleString()} deals</span>
+        <div className="flex items-center gap-2">
+          <Dropdown closeOnSelect={false}>
+            <DropdownTrigger>
+              <Button
+                size="sm"
+                variant="flat"
+                startContent={<Icon icon="solar:tuning-2-linear" width={16} />}
+              >
+                Columns ({columns.length})
+              </Button>
+            </DropdownTrigger>
+            <DropdownMenu
+              aria-label="Visible columns"
+              selectionMode="multiple"
+              className="max-h-[400px] overflow-y-auto"
+              selectedKeys={new Set(visibleFields)}
+              onSelectionChange={(keys) => {
+                const next = Array.from(keys) as string[];
+                if (next.length > 0) onVisibleFieldsChange(next);
+              }}
+            >
+              {DEAL_FIELDS.map((field) => (
+                <DropdownItem key={field.key as string}>{field.label}</DropdownItem>
+              ))}
+            </DropdownMenu>
+          </Dropdown>
+          <Button
+            size="sm"
+            variant="flat"
+            color="primary"
+            isLoading={exporting}
+            startContent={!exporting && <Icon icon="solar:download-linear" width={16} />}
+            onPress={onExport}
+          >
+            Export CSV
+          </Button>
+        </div>
+      </div>
+
+      <div className="p-4 pt-0 overflow-x-auto">
+        <Table
+          aria-label="Deals"
+          removeWrapper
+          sortDescriptor={sort}
+          onSortChange={(descriptor) => {
+            setSort(descriptor);
+            setPage(1);
+          }}
+          bottomContent={
+            pages > 1 ? (
+              <div className="flex justify-center">
+                <Pagination
+                  size="sm"
+                  showControls
+                  page={currentPage}
+                  total={pages}
+                  onChange={setPage}
+                />
+              </div>
+            ) : null
+          }
+        >
+          <TableHeader columns={columns}>
+            {(column) => (
+              <TableColumn
+                key={column.key as string}
+                allowsSorting
+                align={isNumericType(column.type) ? "end" : "start"}
+              >
+                {column.label.toUpperCase()}
+              </TableColumn>
+            )}
+          </TableHeader>
+          <TableBody items={pageRows} emptyContent="No deals match the current filters">
+            {(record) => (
+              <TableRow key={record.id}>
+                {(columnKey) => {
+                  const def = fieldDef(String(columnKey));
+                  const value = def ? record[def.key] : null;
+                  if (def?.key === "status") {
+                    return (
+                      <TableCell>
+                        <Chip size="sm" variant="flat" color={statusColor(record.status)}>
+                          {record.status}
+                        </Chip>
+                      </TableCell>
+                    );
+                  }
+                  return (
+                    <TableCell className="text-tiny whitespace-nowrap">
+                      {def ? formatFieldValue(value, def.type) : "—"}
+                    </TableCell>
+                  );
+                }}
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </Card>
+  );
+};
+
+export default ExplorerTable;

--- a/src/components/deal-explorer/filter-panel.tsx
+++ b/src/components/deal-explorer/filter-panel.tsx
@@ -1,0 +1,312 @@
+import { Button, Card, Chip, Input, Select, SelectItem } from "@heroui/react";
+import { Icon } from "@iconify/react";
+import {
+  countActiveFilters,
+  fieldDef,
+  formatFieldValue,
+  DEAL_FIELDS,
+  EMPTY_FILTERS,
+  OPERATORS_BY_TYPE,
+  OPERATOR_LABELS,
+  type ExplorerFilters,
+  type FilterOperator,
+  type FilterRule,
+} from "@services/deal-explorer-service";
+
+/** Distinct values present in the loaded data, so filters only offer real options. */
+export interface FilterOptions {
+  portfolios: string[];
+  funders: string[];
+  industries: string[];
+  states: string[];
+  /** Vintage months as "YYYY-MM", ascending. */
+  months: string[];
+}
+
+const STATUS_OPTIONS = ["Active", "Closed", "Defaulted"];
+
+const MultiSelect = ({
+  label,
+  options,
+  selected,
+  onChange,
+}: {
+  label: string;
+  options: string[];
+  selected: string[];
+  onChange: (values: string[]) => void;
+}) => (
+  <Select
+    aria-label={label}
+    label={label}
+    size="sm"
+    className="w-full sm:max-w-[180px]"
+    selectionMode="multiple"
+    selectedKeys={new Set(selected)}
+    onSelectionChange={(keys) => onChange(Array.from(keys) as string[])}
+    isDisabled={options.length === 0}
+  >
+    {options.map((option) => (
+      <SelectItem key={option}>{option}</SelectItem>
+    ))}
+  </Select>
+);
+
+const MonthSelect = ({
+  label,
+  months,
+  value,
+  onChange,
+}: {
+  label: string;
+  months: string[];
+  value: string | null;
+  onChange: (value: string | null) => void;
+}) => (
+  <Select
+    aria-label={label}
+    label={label}
+    size="sm"
+    className="w-full sm:max-w-[150px]"
+    selectedKeys={value != null ? [value] : []}
+    onSelectionChange={(keys) => {
+      const key = Array.from(keys)[0];
+      onChange(key != null ? String(key) : null);
+    }}
+    isDisabled={months.length === 0}
+  >
+    {months.map((month) => (
+      <SelectItem key={month}>{formatFieldValue(`${month}-01`, "month")}</SelectItem>
+    ))}
+  </Select>
+);
+
+const ruleValuePlaceholder = (fieldKey: string): string => {
+  const def = fieldDef(fieldKey);
+  switch (def?.type) {
+    case "percent":
+      return "e.g. 50 (%)";
+    case "money":
+    case "number":
+      return "value";
+    case "month":
+      return "YYYY-MM";
+    case "date":
+      return "YYYY-MM-DD";
+    default:
+      return "value";
+  }
+};
+
+const RuleRow = ({
+  rule,
+  onChange,
+  onRemove,
+}: {
+  rule: FilterRule;
+  onChange: (rule: FilterRule) => void;
+  onRemove: () => void;
+}) => {
+  const def = fieldDef(rule.field);
+  const operators = def ? OPERATORS_BY_TYPE[def.type] : [];
+  const needsValue = rule.operator !== "is_true" && rule.operator !== "is_false";
+  const needsSecond = rule.operator === "between";
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Select
+        aria-label="Filter field"
+        size="sm"
+        className="w-[210px]"
+        selectedKeys={[rule.field]}
+        onSelectionChange={(keys) => {
+          const key = Array.from(keys)[0];
+          if (key == null) return;
+          const nextDef = fieldDef(String(key));
+          const nextOps = nextDef ? OPERATORS_BY_TYPE[nextDef.type] : [];
+          onChange({
+            ...rule,
+            field: String(key),
+            operator: nextOps.includes(rule.operator) ? rule.operator : nextOps[0],
+            value: "",
+            value2: "",
+          });
+        }}
+      >
+        {DEAL_FIELDS.map((field) => (
+          <SelectItem key={field.key as string}>{field.label}</SelectItem>
+        ))}
+      </Select>
+      <Select
+        aria-label="Filter operator"
+        size="sm"
+        className="w-[130px]"
+        selectedKeys={[rule.operator]}
+        onSelectionChange={(keys) => {
+          const key = Array.from(keys)[0];
+          if (key != null) onChange({ ...rule, operator: key as FilterOperator });
+        }}
+      >
+        {operators.map((op) => (
+          <SelectItem key={op}>{OPERATOR_LABELS[op]}</SelectItem>
+        ))}
+      </Select>
+      {needsValue && (
+        <Input
+          aria-label="Filter value"
+          size="sm"
+          className="w-[150px]"
+          placeholder={ruleValuePlaceholder(rule.field)}
+          value={rule.value}
+          onValueChange={(value) => onChange({ ...rule, value })}
+        />
+      )}
+      {needsSecond && (
+        <>
+          <span className="text-tiny text-default-400">and</span>
+          <Input
+            aria-label="Filter upper bound"
+            size="sm"
+            className="w-[150px]"
+            placeholder={ruleValuePlaceholder(rule.field)}
+            value={rule.value2}
+            onValueChange={(value2) => onChange({ ...rule, value2 })}
+          />
+        </>
+      )}
+      <Button isIconOnly size="sm" variant="light" aria-label="Remove filter" onPress={onRemove}>
+        <Icon icon="solar:trash-bin-minimalistic-linear" width={16} />
+      </Button>
+    </div>
+  );
+};
+
+let nextRuleId = 1;
+
+const FilterPanel = ({
+  filters,
+  onChange,
+  options,
+}: {
+  filters: ExplorerFilters;
+  onChange: (filters: ExplorerFilters) => void;
+  options: FilterOptions;
+}) => {
+  const activeCount = countActiveFilters(filters);
+
+  const addRule = () => {
+    const rule: FilterRule = {
+      id: `rule-${nextRuleId++}`,
+      field: "total_amount_funded",
+      operator: "gte",
+      value: "",
+      value2: "",
+    };
+    onChange({ ...filters, rules: [...filters.rules, rule] });
+  };
+
+  return (
+    <Card className="dark:border-default-100 border border-transparent mb-4">
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex flex-wrap items-end gap-2">
+          <Input
+            aria-label="Search deals"
+            label="Search"
+            size="sm"
+            className="w-full sm:max-w-[240px]"
+            placeholder="Merchant, advance ID, industry…"
+            startContent={<Icon icon="solar:magnifer-linear" width={16} />}
+            value={filters.search}
+            onValueChange={(search) => onChange({ ...filters, search })}
+            isClearable
+          />
+          <MultiSelect
+            label="Portfolio"
+            options={options.portfolios}
+            selected={filters.portfolios}
+            onChange={(portfolios) => onChange({ ...filters, portfolios })}
+          />
+          <MultiSelect
+            label="Funder"
+            options={options.funders}
+            selected={filters.funders}
+            onChange={(funders) => onChange({ ...filters, funders })}
+          />
+          <MultiSelect
+            label="Industry"
+            options={options.industries}
+            selected={filters.industries}
+            onChange={(industries) => onChange({ ...filters, industries })}
+          />
+          <MultiSelect
+            label="State"
+            options={options.states}
+            selected={filters.states}
+            onChange={(states) => onChange({ ...filters, states })}
+          />
+          <MultiSelect
+            label="Status"
+            options={STATUS_OPTIONS}
+            selected={filters.statuses}
+            onChange={(statuses) => onChange({ ...filters, statuses })}
+          />
+          <MonthSelect
+            label="Vintage from"
+            months={options.months}
+            value={filters.monthFrom}
+            onChange={(monthFrom) => onChange({ ...filters, monthFrom })}
+          />
+          <MonthSelect
+            label="Vintage to"
+            months={options.months}
+            value={filters.monthTo}
+            onChange={(monthTo) => onChange({ ...filters, monthTo })}
+          />
+        </div>
+
+        {filters.rules.length > 0 && (
+          <div className="flex flex-col gap-2">
+            {filters.rules.map((rule) => (
+              <RuleRow
+                key={rule.id}
+                rule={rule}
+                onChange={(next) =>
+                  onChange({
+                    ...filters,
+                    rules: filters.rules.map((r) => (r.id === next.id ? next : r)),
+                  })
+                }
+                onRemove={() =>
+                  onChange({ ...filters, rules: filters.rules.filter((r) => r.id !== rule.id) })
+                }
+              />
+            ))}
+          </div>
+        )}
+
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="flat"
+            startContent={<Icon icon="solar:add-circle-linear" width={16} />}
+            onPress={addRule}
+          >
+            Add field filter
+          </Button>
+          {activeCount > 0 && (
+            <>
+              <Chip size="sm" variant="flat" color="primary">
+                {activeCount} active filter{activeCount === 1 ? "" : "s"}
+              </Chip>
+              <Button size="sm" variant="light" onPress={() => onChange(EMPTY_FILTERS)}>
+                Clear all
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default FilterPanel;

--- a/src/components/deal-explorer/pivot-builder.tsx
+++ b/src/components/deal-explorer/pivot-builder.tsx
@@ -1,0 +1,166 @@
+import { useMemo } from "react";
+import { Button, Card, Select, SelectItem } from "@heroui/react";
+import { Icon } from "@iconify/react";
+import {
+  buildPivot,
+  formatFieldValue,
+  AGGREGATION_LABELS,
+  DIMENSION_FIELDS,
+  NUMERIC_FIELDS,
+  type Aggregation,
+  type DealRecord,
+  type PivotConfig,
+} from "@services/deal-explorer-service";
+
+const NO_COLUMN_KEY = "__none__";
+
+const PivotBuilder = ({
+  records,
+  config,
+  onConfigChange,
+  onExport,
+  exporting,
+}: {
+  records: DealRecord[];
+  config: PivotConfig;
+  onConfigChange: (config: PivotConfig) => void;
+  onExport: (pivot: ReturnType<typeof buildPivot>) => void;
+  exporting: boolean;
+}) => {
+  const pivot = useMemo(() => buildPivot(records, config), [records, config]);
+  const format = (value: number | null) =>
+    value == null ? "—" : formatFieldValue(value, pivot.valueType);
+
+  const singleKeySelect = (
+    label: string,
+    selected: string,
+    items: { key: string; label: string }[],
+    onSelect: (key: string) => void,
+    width = "w-full sm:max-w-[200px]"
+  ) => (
+    <Select
+      aria-label={label}
+      label={label}
+      size="sm"
+      className={width}
+      selectedKeys={[selected]}
+      onSelectionChange={(keys) => {
+        const key = Array.from(keys)[0];
+        if (key != null) onSelect(String(key));
+      }}
+    >
+      {items.map((item) => (
+        <SelectItem key={item.key}>{item.label}</SelectItem>
+      ))}
+    </Select>
+  );
+
+  const dimensionItems = DIMENSION_FIELDS.map((f) => ({
+    key: f.key as string,
+    label: f.label,
+  }));
+
+  return (
+    <Card className="dark:border-default-100 border border-transparent">
+      <div className="flex flex-wrap items-end justify-between gap-3 p-4 pb-2">
+        <div className="flex flex-wrap items-end gap-2">
+          {singleKeySelect("Rows", config.rowField, dimensionItems, (rowField) =>
+            onConfigChange({ ...config, rowField })
+          )}
+          {singleKeySelect(
+            "Columns",
+            config.colField ?? NO_COLUMN_KEY,
+            [{ key: NO_COLUMN_KEY, label: "None" }, ...dimensionItems],
+            (key) => onConfigChange({ ...config, colField: key === NO_COLUMN_KEY ? null : key })
+          )}
+          {singleKeySelect(
+            "Aggregation",
+            config.agg,
+            Object.entries(AGGREGATION_LABELS).map(([key, label]) => ({ key, label })),
+            (agg) => onConfigChange({ ...config, agg: agg as Aggregation }),
+            "w-full sm:max-w-[130px]"
+          )}
+          {config.agg !== "count" &&
+            singleKeySelect(
+              "Value",
+              config.valueField,
+              NUMERIC_FIELDS.map((f) => ({ key: f.key as string, label: f.label })),
+              (valueField) => onConfigChange({ ...config, valueField })
+            )}
+        </div>
+        <Button
+          size="sm"
+          variant="flat"
+          color="primary"
+          isLoading={exporting}
+          startContent={!exporting && <Icon icon="solar:download-linear" width={16} />}
+          onPress={() => onExport(pivot)}
+        >
+          Export CSV
+        </Button>
+      </div>
+
+      <div className="p-4 pt-2 overflow-auto max-h-[560px]">
+        {pivot.rows.length === 0 ? (
+          <div className="h-[200px] flex items-center justify-center">
+            <span className="text-default-400">No deals match the current filters</span>
+          </div>
+        ) : (
+          <table className="w-full text-tiny">
+            <thead className="sticky top-0 bg-content1 z-10">
+              <tr className="text-default-500">
+                <th className="text-left font-medium px-2 py-2 border-b border-divider">
+                  {pivot.rowLabel.toUpperCase()}
+                </th>
+                {pivot.colLabels.map((label) => (
+                  <th
+                    key={label}
+                    className="text-right font-medium px-2 py-2 border-b border-divider whitespace-nowrap"
+                  >
+                    {label.toUpperCase()}
+                  </th>
+                ))}
+                <th className="text-right font-semibold px-2 py-2 border-b border-divider">
+                  TOTAL
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {pivot.rows.map((row) => (
+                <tr key={row.label} className="hover:bg-default-50">
+                  <td className="px-2 py-1.5 border-b border-divider whitespace-nowrap">
+                    {row.label}
+                  </td>
+                  {row.values.map((value, index) => (
+                    <td
+                      key={index}
+                      className="text-right px-2 py-1.5 border-b border-divider whitespace-nowrap tabular-nums"
+                    >
+                      {format(value)}
+                    </td>
+                  ))}
+                  <td className="text-right font-medium px-2 py-1.5 border-b border-divider whitespace-nowrap tabular-nums">
+                    {format(row.total)}
+                  </td>
+                </tr>
+              ))}
+              <tr className="font-semibold">
+                <td className="px-2 py-2">Total</td>
+                {pivot.colTotals.map((value, index) => (
+                  <td key={index} className="text-right px-2 py-2 whitespace-nowrap tabular-nums">
+                    {format(value)}
+                  </td>
+                ))}
+                <td className="text-right px-2 py-2 whitespace-nowrap tabular-nums">
+                  {format(pivot.grandTotal)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        )}
+      </div>
+    </Card>
+  );
+};
+
+export default PivotBuilder;

--- a/src/components/deal-explorer/reconcile-panel.tsx
+++ b/src/components/deal-explorer/reconcile-panel.tsx
@@ -1,0 +1,204 @@
+import { useMemo, useState } from "react";
+import { Autocomplete, AutocompleteItem, Button, Card, Chip, Skeleton } from "@heroui/react";
+import { Icon } from "@iconify/react";
+import type { UnresolvedPivotRow } from "@services/pivot-sync-service";
+import { rankCandidateDeals, type DealRecord } from "@services/deal-explorer-service";
+import type { EditorLookups } from "@services/deal-editor-service";
+
+const money = (value: number) =>
+  `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const RowCard = ({
+  row,
+  deals,
+  funderName,
+  portfolioName,
+  onResolve,
+  onCreateDeal,
+  busy,
+}: {
+  row: UnresolvedPivotRow;
+  deals: DealRecord[];
+  funderName: string;
+  portfolioName: string;
+  onResolve: (row: UnresolvedPivotRow, dealId: string) => void;
+  onCreateDeal: (row: UnresolvedPivotRow) => void;
+  busy: boolean;
+}) => {
+  const [selectedDealId, setSelectedDealId] = useState<string | null>(null);
+  const candidates = useMemo(() => rankCandidateDeals(row, deals), [row, deals]);
+  const exactMatches = useMemo(
+    () =>
+      row.advance_id != null
+        ? candidates.filter((d) => d.funder_advance_id === row.advance_id).length
+        : 0,
+    [candidates, row.advance_id]
+  );
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 p-3 border-b border-divider last:border-b-0">
+      <div className="flex flex-col gap-1 min-w-[260px] flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-small">{row.merchant_name || "Unknown merchant"}</span>
+          {row.advance_id != null && (
+            <span className="font-mono text-tiny text-default-500">{row.advance_id}</span>
+          )}
+          {exactMatches > 1 && (
+            <Chip size="sm" variant="flat" color="danger">
+              {exactMatches} deals share this ID
+            </Chip>
+          )}
+        </div>
+        <div className="flex items-center gap-2 text-tiny text-default-400">
+          <Chip size="sm" variant="flat">
+            {portfolioName}
+          </Chip>
+          <Chip size="sm" variant="flat" color="primary">
+            {funderName}
+          </Chip>
+          <span>{row.report_date}</span>
+          <span className="font-medium text-default-600">{money(row.net)} net</span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Autocomplete
+          aria-label="Match to deal"
+          size="sm"
+          className="w-[300px]"
+          placeholder="Match to existing deal…"
+          selectedKey={selectedDealId}
+          onSelectionChange={(key) => setSelectedDealId(key != null ? String(key) : null)}
+          items={candidates}
+        >
+          {(deal) => (
+            <AutocompleteItem
+              key={deal.id}
+              textValue={`${deal.merchant_name ?? "Unknown"} ${deal.funder_advance_id ?? ""}`}
+            >
+              <div className="flex flex-col">
+                <span className="text-small">{deal.merchant_name ?? "Unknown"}</span>
+                <span className="text-tiny text-default-400">
+                  {deal.funder_advance_id ?? "no advance ID"} · funded {deal.date_funded ?? "—"} ·{" "}
+                  {deal.status}
+                </span>
+              </div>
+            </AutocompleteItem>
+          )}
+        </Autocomplete>
+        <Button
+          size="sm"
+          color="primary"
+          variant="flat"
+          isDisabled={selectedDealId == null || busy}
+          isLoading={busy}
+          onPress={() => selectedDealId != null && onResolve(row, selectedDealId)}
+        >
+          Resolve
+        </Button>
+        <Button
+          size="sm"
+          variant="flat"
+          startContent={<Icon icon="solar:add-circle-linear" width={16} />}
+          isDisabled={busy}
+          onPress={() => onCreateDeal(row)}
+        >
+          New deal
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+const ReconcilePanel = ({
+  rows,
+  deals,
+  lookups,
+  loading,
+  busyRowId,
+  onResolve,
+  onCreateDeal,
+}: {
+  rows: UnresolvedPivotRow[];
+  deals: DealRecord[];
+  lookups: EditorLookups;
+  loading: boolean;
+  /** Row currently being resolved, to disable its buttons. */
+  busyRowId: string | null;
+  onResolve: (row: UnresolvedPivotRow, dealId: string) => void;
+  onCreateDeal: (row: UnresolvedPivotRow) => void;
+}) => {
+  const funderNames = useMemo(
+    () => new Map(lookups.funders.map((f) => [f.id, f.name])),
+    [lookups.funders]
+  );
+  const portfolioNames = useMemo(
+    () => new Map(lookups.portfolios.map((p) => [p.id, p.name])),
+    [lookups.portfolios]
+  );
+
+  const totalNet = rows.reduce((acc, r) => acc + r.net, 0);
+
+  if (loading) {
+    return (
+      <Card className="dark:border-default-100 border border-transparent">
+        <div className="p-4">
+          <Skeleton className="rounded-lg mb-4">
+            <div className="h-4 w-48 bg-default-200"></div>
+          </Skeleton>
+          <Skeleton className="rounded-lg">
+            <div className="h-[200px] w-full bg-default-200"></div>
+          </Skeleton>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="dark:border-default-100 border border-transparent">
+      <div className="flex flex-wrap items-center justify-between gap-2 p-4 pb-2">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-small text-default-500 font-medium">Unmatched pivot rows</h3>
+          <span className="text-tiny text-default-400">
+            {rows.length.toLocaleString()} rows · {money(totalNet)} net not yet recorded as payments
+          </span>
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="p-8 flex flex-col items-center gap-2 text-center">
+          <Icon icon="solar:check-circle-bold" className="text-success" width={32} />
+          <p className="text-default-600 font-medium">Every pivot row is matched to a deal</p>
+          <p className="text-default-400 text-small">
+            Unmatched rows from monthly funder uploads will appear here for reconciliation.
+          </p>
+        </div>
+      ) : (
+        <div className="pb-2">
+          {rows.map((row) => (
+            <RowCard
+              key={row.row_id}
+              row={row}
+              deals={deals}
+              funderName={
+                row.funder_id != null
+                  ? (funderNames.get(row.funder_id) ?? `Funder ${row.funder_id}`)
+                  : "Unknown funder"
+              }
+              portfolioName={
+                row.portfolio_id != null
+                  ? (portfolioNames.get(row.portfolio_id) ?? `Portfolio ${row.portfolio_id}`)
+                  : "Unknown portfolio"
+              }
+              onResolve={onResolve}
+              onCreateDeal={onCreateDeal}
+              busy={busyRowId === row.row_id}
+            />
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default ReconcilePanel;

--- a/src/components/portfolio/pivot-reconciliation-modal.tsx
+++ b/src/components/portfolio/pivot-reconciliation-modal.tsx
@@ -108,8 +108,9 @@ export function PivotReconciliationModal({
                           </TableBody>
                         </Table>
                         <p className="text-xs text-default-500 mt-2">
-                          Unmatched rows are saved with the pivot and can be resolved to deals later
-                          — their payments are not written until resolved.
+                          Unmatched rows are saved with the pivot — their payments are not written
+                          until resolved. Reconcile them any time from the Deal Lookup page&apos;s
+                          Unmatched tab.
                         </p>
                       </div>
                     )}

--- a/src/features/sidebar/sidebar-items.tsx
+++ b/src/features/sidebar/sidebar-items.tsx
@@ -24,6 +24,11 @@ export const items: SidebarItem[] = [
     icon: "solar:safe-square-outline",
     title: "White Rabbit Portfolio",
   },
+  {
+    key: "deal-lookup",
+    icon: "solar:magnifer-zoom-in-outline",
+    title: "Deal Lookup",
+  },
 ];
 
 export const settingsItem: SidebarItem = {

--- a/src/pages/deal-lookup.tsx
+++ b/src/pages/deal-lookup.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Button,
   Card,
+  Chip,
   Input,
   Modal,
   ModalBody,
@@ -37,14 +38,17 @@ import {
   deleteDeal,
   getDealFormValues,
   getEditorLookups,
+  EMPTY_DEAL_FORM,
   type DealFormValues,
   type EditorLookups,
 } from "@services/deal-editor-service";
+import PivotSyncService, { type UnresolvedPivotRow } from "@services/pivot-sync-service";
 import FilterPanel, { type FilterOptions } from "@components/deal-explorer/filter-panel";
 import ExplorerTable from "@components/deal-explorer/explorer-table";
 import PivotBuilder from "@components/deal-explorer/pivot-builder";
 import ChartBuilder from "@components/deal-explorer/chart-builder";
 import DealFormModal from "@components/deal-explorer/deal-form-modal";
+import ReconcilePanel from "@components/deal-explorer/reconcile-panel";
 
 const EMPTY_LOOKUPS: EditorLookups = {
   portfolios: [],
@@ -98,8 +102,16 @@ function DealLookup() {
   const [lookups, setLookups] = useState<EditorLookups>(EMPTY_LOOKUPS);
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<{ dealId: string; values: DealFormValues } | null>(null);
+  const [createDefaults, setCreateDefaults] = useState<DealFormValues | null>(null);
   const [deleting, setDeleting] = useState<DealRecord | null>(null);
   const [deleteBusy, setDeleteBusy] = useState(false);
+
+  // Unmatched pivot-row reconciliation
+  const [unresolvedRows, setUnresolvedRows] = useState<UnresolvedPivotRow[]>([]);
+  const [unresolvedLoading, setUnresolvedLoading] = useState(true);
+  const [busyRowId, setBusyRowId] = useState<string | null>(null);
+  /** When set, the next saved deal also resolves this pivot row. */
+  const [pendingResolveRowId, setPendingResolveRowId] = useState<string | null>(null);
 
   const fetchLookups = useCallback(() => {
     getEditorLookups()
@@ -122,11 +134,28 @@ function DealLookup() {
       .finally(() => setLoading(false));
   }, []);
 
+  const fetchUnresolved = useCallback(() => {
+    setUnresolvedLoading(true);
+    PivotSyncService.listUnresolvedRows()
+      .then(setUnresolvedRows)
+      .catch((err) =>
+        showToast({
+          title: "Failed to load unmatched pivot rows",
+          description: err instanceof Error ? err.message : String(err),
+          type: "error",
+        })
+      )
+      .finally(() => setUnresolvedLoading(false));
+  }, [showToast]);
+
   useEffect(fetchRecords, [fetchRecords]);
   useEffect(fetchLookups, [fetchLookups]);
+  useEffect(fetchUnresolved, [fetchUnresolved]);
 
   const openCreate = () => {
     setEditing(null);
+    setCreateDefaults(null);
+    setPendingResolveRowId(null);
     setFormOpen(true);
   };
 
@@ -134,6 +163,8 @@ function DealLookup() {
     try {
       const values = await getDealFormValues(record.id);
       setEditing({ dealId: record.id, values });
+      setCreateDefaults(null);
+      setPendingResolveRowId(null);
       setFormOpen(true);
     } catch (err) {
       showToast({
@@ -144,8 +175,54 @@ function DealLookup() {
     }
   };
 
-  const handleSaved = () => {
+  const resolveRow = async (row: UnresolvedPivotRow, dealId: string) => {
+    setBusyRowId(row.row_id);
+    try {
+      await PivotSyncService.resolveRow(row.row_id, dealId);
+      showToast({
+        title: "Pivot row resolved",
+        description: `${row.merchant_name} — payment written for ${row.report_date}`,
+        type: "success",
+      });
+      fetchRecords();
+      fetchUnresolved();
+    } catch (err) {
+      showToast({
+        title: "Failed to resolve pivot row",
+        description: err instanceof Error ? err.message : String(err),
+        type: "error",
+      });
+    } finally {
+      setBusyRowId(null);
+    }
+  };
+
+  /** "New deal" from an unmatched row: prefill the form, resolve after save. */
+  const createDealFromRow = (row: UnresolvedPivotRow) => {
+    setEditing(null);
+    setCreateDefaults({
+      ...EMPTY_DEAL_FORM,
+      portfolioId: row.portfolio_id,
+      funderId: row.funder_id,
+      merchantName: row.merchant_name,
+      funderAdvanceId: row.advance_id ?? "",
+      dateFunded: row.report_date,
+    });
+    setPendingResolveRowId(row.row_id);
+    setFormOpen(true);
+  };
+
+  const handleSaved = async (dealId: string) => {
     showToast({ title: editing != null ? "Deal updated" : "Deal created", type: "success" });
+    if (pendingResolveRowId != null) {
+      const row = unresolvedRows.find((r) => r.row_id === pendingResolveRowId);
+      setPendingResolveRowId(null);
+      if (row != null) {
+        await resolveRow(row, dealId);
+        fetchLookups();
+        return; // resolveRow already refetched records
+      }
+    }
     fetchRecords();
     fetchLookups(); // a save may have added or renamed a merchant
   };
@@ -417,6 +494,30 @@ function DealLookup() {
           >
             <ChartBuilder records={filtered} config={chartConfig} onConfigChange={setChartConfig} />
           </Tab>
+          <Tab
+            key="unmatched"
+            title={
+              <div className="flex items-center gap-2">
+                <Icon icon="solar:link-broken-linear" width={16} />
+                Unmatched
+                {unresolvedRows.length > 0 && (
+                  <Chip size="sm" variant="flat" color="warning">
+                    {unresolvedRows.length}
+                  </Chip>
+                )}
+              </div>
+            }
+          >
+            <ReconcilePanel
+              rows={unresolvedRows}
+              deals={records}
+              lookups={lookups}
+              loading={unresolvedLoading}
+              busyRowId={busyRowId}
+              onResolve={resolveRow}
+              onCreateDeal={createDealFromRow}
+            />
+          </Tab>
         </Tabs>
       )}
 
@@ -425,6 +526,7 @@ function DealLookup() {
         onClose={() => setFormOpen(false)}
         lookups={lookups}
         editing={editing}
+        createDefaults={createDefaults}
         onSaved={handleSaved}
       />
 

--- a/src/pages/deal-lookup.tsx
+++ b/src/pages/deal-lookup.tsx
@@ -33,10 +33,26 @@ import {
   type PivotConfig,
   type PivotData,
 } from "@services/deal-explorer-service";
+import {
+  deleteDeal,
+  getDealFormValues,
+  getEditorLookups,
+  type DealFormValues,
+  type EditorLookups,
+} from "@services/deal-editor-service";
 import FilterPanel, { type FilterOptions } from "@components/deal-explorer/filter-panel";
 import ExplorerTable from "@components/deal-explorer/explorer-table";
 import PivotBuilder from "@components/deal-explorer/pivot-builder";
 import ChartBuilder from "@components/deal-explorer/chart-builder";
+import DealFormModal from "@components/deal-explorer/deal-form-modal";
+
+const EMPTY_LOOKUPS: EditorLookups = {
+  portfolios: [],
+  funders: [],
+  industries: [],
+  states: [],
+  merchants: [],
+};
 
 const VIEWS_STORAGE_KEY = "excelerate.deal-lookup.views";
 
@@ -78,6 +94,25 @@ function DealLookup() {
   const [saveModalOpen, setSaveModalOpen] = useState(false);
   const [exporting, setExporting] = useState(false);
 
+  // Deal CRUD
+  const [lookups, setLookups] = useState<EditorLookups>(EMPTY_LOOKUPS);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<{ dealId: string; values: DealFormValues } | null>(null);
+  const [deleting, setDeleting] = useState<DealRecord | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+
+  const fetchLookups = useCallback(() => {
+    getEditorLookups()
+      .then(setLookups)
+      .catch((err) =>
+        showToast({
+          title: "Failed to load deal form lookups",
+          description: err instanceof Error ? err.message : String(err),
+          type: "error",
+        })
+      );
+  }, [showToast]);
+
   const fetchRecords = useCallback(() => {
     setLoading(true);
     setError(null);
@@ -88,6 +123,55 @@ function DealLookup() {
   }, []);
 
   useEffect(fetchRecords, [fetchRecords]);
+  useEffect(fetchLookups, [fetchLookups]);
+
+  const openCreate = () => {
+    setEditing(null);
+    setFormOpen(true);
+  };
+
+  const openEdit = async (record: DealRecord) => {
+    try {
+      const values = await getDealFormValues(record.id);
+      setEditing({ dealId: record.id, values });
+      setFormOpen(true);
+    } catch (err) {
+      showToast({
+        title: "Failed to load deal",
+        description: err instanceof Error ? err.message : String(err),
+        type: "error",
+      });
+    }
+  };
+
+  const handleSaved = () => {
+    showToast({ title: editing != null ? "Deal updated" : "Deal created", type: "success" });
+    fetchRecords();
+    fetchLookups(); // a save may have added or renamed a merchant
+  };
+
+  const confirmDelete = async () => {
+    if (deleting == null) return;
+    setDeleteBusy(true);
+    try {
+      await deleteDeal(deleting.id);
+      showToast({
+        title: "Deal deleted",
+        description: deleting.merchant_name ?? deleting.funder_advance_id ?? deleting.id,
+        type: "success",
+      });
+      setDeleting(null);
+      fetchRecords();
+    } catch (err) {
+      showToast({
+        title: "Delete failed",
+        description: err instanceof Error ? err.message : String(err),
+        type: "error",
+      });
+    } finally {
+      setDeleteBusy(false);
+    }
+  };
 
   const options = useMemo<FilterOptions>(
     () => ({
@@ -300,6 +384,9 @@ function DealLookup() {
               onVisibleFieldsChange={setVisibleFields}
               onExport={exportTable}
               exporting={exporting}
+              onCreate={openCreate}
+              onEdit={openEdit}
+              onDelete={setDeleting}
             />
           </Tab>
           <Tab
@@ -332,6 +419,54 @@ function DealLookup() {
           </Tab>
         </Tabs>
       )}
+
+      <DealFormModal
+        isOpen={formOpen}
+        onClose={() => setFormOpen(false)}
+        lookups={lookups}
+        editing={editing}
+        onSaved={handleSaved}
+      />
+
+      <Modal
+        isOpen={deleting != null}
+        onOpenChange={(open) => !open && setDeleting(null)}
+        size="sm"
+      >
+        <ModalContent>
+          <ModalHeader>Delete deal</ModalHeader>
+          <ModalBody>
+            <p className="text-small">
+              Delete the deal for{" "}
+              <span className="font-semibold">{deleting?.merchant_name ?? "this merchant"}</span>
+              {deleting?.funder_advance_id != null && (
+                <span className="text-default-500"> ({deleting.funder_advance_id})</span>
+              )}
+              ?
+            </p>
+            {deleting != null && deleting.total_net_received > 0 && (
+              <p className="text-small text-danger">
+                {formatMoney(deleting.total_net_received)} of recorded payments will be deleted with
+                it.
+              </p>
+            )}
+            <p className="text-tiny text-default-400">This cannot be undone.</p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              size="sm"
+              variant="light"
+              onPress={() => setDeleting(null)}
+              isDisabled={deleteBusy}
+            >
+              Cancel
+            </Button>
+            <Button size="sm" color="danger" isLoading={deleteBusy} onPress={confirmDelete}>
+              Delete
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
 
       <Modal isOpen={saveModalOpen} onOpenChange={setSaveModalOpen} size="sm">
         <ModalContent>

--- a/src/pages/deal-lookup.tsx
+++ b/src/pages/deal-lookup.tsx
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  Card,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Select,
+  SelectItem,
+  Skeleton,
+  Tab,
+  Tabs,
+} from "@heroui/react";
+import { Icon } from "@iconify/react";
+import { useToast } from "@/contexts/toast-context";
+import { formatMoney } from "@services/analytics-service";
+import {
+  applyFilters,
+  getDealRecords,
+  pivotToCsv,
+  recordsToCsv,
+  saveCsvFile,
+  DEFAULT_CHART_CONFIG,
+  DEFAULT_PIVOT_CONFIG,
+  DEFAULT_VISIBLE_FIELDS,
+  EMPTY_FILTERS,
+  type ChartConfig,
+  type DealRecord,
+  type ExplorerFilters,
+  type PivotConfig,
+  type PivotData,
+} from "@services/deal-explorer-service";
+import FilterPanel, { type FilterOptions } from "@components/deal-explorer/filter-panel";
+import ExplorerTable from "@components/deal-explorer/explorer-table";
+import PivotBuilder from "@components/deal-explorer/pivot-builder";
+import ChartBuilder from "@components/deal-explorer/chart-builder";
+
+const VIEWS_STORAGE_KEY = "excelerate.deal-lookup.views";
+
+interface SavedView {
+  id: string;
+  name: string;
+  filters: ExplorerFilters;
+  visibleFields: string[];
+  pivot: PivotConfig;
+  chart: ChartConfig;
+}
+
+function loadSavedViews(): SavedView[] {
+  try {
+    const raw = localStorage.getItem(VIEWS_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as SavedView[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+const uniqueSorted = (values: (string | null)[]): string[] =>
+  [...new Set(values.filter((v): v is string => v != null && v !== ""))].sort();
+
+function DealLookup() {
+  const { showToast } = useToast();
+  const [records, setRecords] = useState<DealRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [filters, setFilters] = useState<ExplorerFilters>(EMPTY_FILTERS);
+  const [visibleFields, setVisibleFields] = useState<string[]>(DEFAULT_VISIBLE_FIELDS);
+  const [pivotConfig, setPivotConfig] = useState<PivotConfig>(DEFAULT_PIVOT_CONFIG);
+  const [chartConfig, setChartConfig] = useState<ChartConfig>(DEFAULT_CHART_CONFIG);
+
+  const [savedViews, setSavedViews] = useState<SavedView[]>(loadSavedViews);
+  const [activeViewId, setActiveViewId] = useState<string | null>(null);
+  const [viewName, setViewName] = useState("");
+  const [saveModalOpen, setSaveModalOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
+
+  const fetchRecords = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    getDealRecords()
+      .then(setRecords)
+      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load deals"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(fetchRecords, [fetchRecords]);
+
+  const options = useMemo<FilterOptions>(
+    () => ({
+      portfolios: uniqueSorted(records.map((r) => r.portfolio_name)),
+      funders: uniqueSorted(records.map((r) => r.funder_name)),
+      industries: uniqueSorted(records.map((r) => r.industry)),
+      states: uniqueSorted(records.map((r) => r.state)),
+      months: uniqueSorted(records.map((r) => r.vintage_month?.slice(0, 7) ?? null)),
+    }),
+    [records]
+  );
+
+  const filtered = useMemo(() => applyFilters(records, filters), [records, filters]);
+
+  const summary = useMemo(() => {
+    const sum = (pick: (r: DealRecord) => number | null) =>
+      filtered.reduce((acc, r) => acc + (pick(r) ?? 0), 0);
+    return {
+      funded: sum((r) => r.total_amount_funded),
+      costBasis: sum((r) => r.cost_basis),
+      netReceived: sum((r) => r.total_net_received),
+      balance: sum((r) => r.net_rtr_balance),
+    };
+  }, [filtered]);
+
+  const persistViews = (views: SavedView[]) => {
+    setSavedViews(views);
+    localStorage.setItem(VIEWS_STORAGE_KEY, JSON.stringify(views));
+  };
+
+  const saveCurrentView = () => {
+    const name = viewName.trim();
+    if (!name) return;
+    const view: SavedView = {
+      id: `view-${Date.now()}`,
+      name,
+      filters,
+      visibleFields,
+      pivot: pivotConfig,
+      chart: chartConfig,
+    };
+    persistViews([...savedViews, view]);
+    setActiveViewId(view.id);
+    setViewName("");
+    setSaveModalOpen(false);
+    showToast({ title: `View "${name}" saved`, type: "success" });
+  };
+
+  const applyView = (view: SavedView) => {
+    // Merge over defaults so views saved before new filters/configs still load.
+    setFilters({ ...EMPTY_FILTERS, ...view.filters });
+    setVisibleFields(view.visibleFields.length > 0 ? view.visibleFields : DEFAULT_VISIBLE_FIELDS);
+    setPivotConfig({ ...DEFAULT_PIVOT_CONFIG, ...view.pivot });
+    setChartConfig({ ...DEFAULT_CHART_CONFIG, ...view.chart });
+    setActiveViewId(view.id);
+  };
+
+  const deleteActiveView = () => {
+    if (activeViewId == null) return;
+    const view = savedViews.find((v) => v.id === activeViewId);
+    persistViews(savedViews.filter((v) => v.id !== activeViewId));
+    setActiveViewId(null);
+    if (view) showToast({ title: `View "${view.name}" deleted`, type: "info" });
+  };
+
+  const exportCsv = async (defaultName: string, csv: string) => {
+    setExporting(true);
+    try {
+      const path = await saveCsvFile(defaultName, csv);
+      if (path != null) {
+        showToast({ title: "Export complete", description: path, type: "success" });
+      }
+    } catch (err) {
+      showToast({
+        title: "Export failed",
+        description: err instanceof Error ? err.message : String(err),
+        type: "error",
+      });
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const today = () => new Date().toISOString().slice(0, 10);
+  const exportTable = () =>
+    exportCsv(`deals-${today()}.csv`, recordsToCsv(filtered, visibleFields));
+  const exportPivot = (pivot: PivotData) =>
+    exportCsv(`deal-pivot-${today()}.csv`, pivotToCsv(pivot));
+
+  const summaryCards = [
+    { label: "Deals", value: filtered.length.toLocaleString() },
+    { label: "Amount Funded", value: formatMoney(summary.funded) },
+    { label: "Cost Basis", value: formatMoney(summary.costBasis) },
+    { label: "Net Received", value: formatMoney(summary.netReceived) },
+    { label: "Net RTR Balance", value: formatMoney(summary.balance) },
+  ];
+
+  return (
+    <div className="p-6">
+      <div className="flex flex-wrap justify-between items-center mb-6 gap-4">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-3xl font-bold">Deal Lookup</h1>
+          <p className="text-small text-default-400">
+            Filter, pivot, chart, and export every deal you have access to.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select
+            aria-label="Saved views"
+            placeholder="Saved views"
+            size="sm"
+            className="w-[200px]"
+            isDisabled={savedViews.length === 0}
+            selectedKeys={activeViewId != null ? [activeViewId] : []}
+            onSelectionChange={(keys) => {
+              const key = Array.from(keys)[0];
+              const view = savedViews.find((v) => v.id === key);
+              if (view) applyView(view);
+            }}
+          >
+            {savedViews.map((view) => (
+              <SelectItem key={view.id}>{view.name}</SelectItem>
+            ))}
+          </Select>
+          {activeViewId != null && (
+            <Button
+              isIconOnly
+              size="sm"
+              variant="light"
+              aria-label="Delete saved view"
+              onPress={deleteActiveView}
+            >
+              <Icon icon="solar:trash-bin-minimalistic-linear" width={16} />
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="flat"
+            startContent={<Icon icon="solar:bookmark-linear" width={16} />}
+            onPress={() => setSaveModalOpen(true)}
+          >
+            Save view
+          </Button>
+          <Button
+            isIconOnly
+            size="sm"
+            variant="flat"
+            aria-label="Refresh data"
+            isLoading={loading}
+            onPress={fetchRecords}
+          >
+            {!loading && <Icon icon="solar:refresh-linear" width={16} />}
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <Card className="mb-6 bg-danger-50 border-danger-200">
+          <div className="p-4 flex items-center gap-2">
+            <Icon icon="solar:danger-triangle-bold" className="text-danger" width={20} />
+            <span className="text-danger">{error}</span>
+          </div>
+        </Card>
+      )}
+
+      <FilterPanel filters={filters} onChange={setFilters} options={options} />
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-5 gap-3 mb-4">
+        {summaryCards.map((card) => (
+          <Card key={card.label} className="dark:border-default-100 border border-transparent">
+            <div className="p-3 flex flex-col gap-1">
+              <span className="text-tiny text-default-500">{card.label}</span>
+              {loading ? (
+                <Skeleton className="rounded-lg">
+                  <div className="h-6 w-20 bg-default-200"></div>
+                </Skeleton>
+              ) : (
+                <span className="text-large font-semibold">{card.value}</span>
+              )}
+            </div>
+          </Card>
+        ))}
+      </div>
+
+      {loading ? (
+        <Card className="dark:border-default-100 border border-transparent">
+          <div className="p-4">
+            <Skeleton className="rounded-lg mb-4">
+              <div className="h-4 w-48 bg-default-200"></div>
+            </Skeleton>
+            <Skeleton className="rounded-lg">
+              <div className="h-[400px] w-full bg-default-200"></div>
+            </Skeleton>
+          </div>
+        </Card>
+      ) : (
+        <Tabs aria-label="Deal lookup views" className="mb-2">
+          <Tab
+            key="table"
+            title={
+              <div className="flex items-center gap-2">
+                <Icon icon="solar:list-linear" width={16} />
+                Table
+              </div>
+            }
+          >
+            <ExplorerTable
+              records={filtered}
+              visibleFields={visibleFields}
+              onVisibleFieldsChange={setVisibleFields}
+              onExport={exportTable}
+              exporting={exporting}
+            />
+          </Tab>
+          <Tab
+            key="pivot"
+            title={
+              <div className="flex items-center gap-2">
+                <Icon icon="solar:widget-linear" width={16} />
+                Pivot
+              </div>
+            }
+          >
+            <PivotBuilder
+              records={filtered}
+              config={pivotConfig}
+              onConfigChange={setPivotConfig}
+              onExport={exportPivot}
+              exporting={exporting}
+            />
+          </Tab>
+          <Tab
+            key="chart"
+            title={
+              <div className="flex items-center gap-2">
+                <Icon icon="solar:chart-2-linear" width={16} />
+                Chart
+              </div>
+            }
+          >
+            <ChartBuilder records={filtered} config={chartConfig} onConfigChange={setChartConfig} />
+          </Tab>
+        </Tabs>
+      )}
+
+      <Modal isOpen={saveModalOpen} onOpenChange={setSaveModalOpen} size="sm">
+        <ModalContent>
+          <ModalHeader>Save current view</ModalHeader>
+          <ModalBody>
+            <p className="text-small text-default-500">
+              Saves the filters, visible columns, pivot, and chart setup so you can reapply them
+              later.
+            </p>
+            <Input
+              aria-label="View name"
+              autoFocus
+              label="View name"
+              size="sm"
+              value={viewName}
+              onValueChange={setViewName}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") saveCurrentView();
+              }}
+            />
+          </ModalBody>
+          <ModalFooter>
+            <Button size="sm" variant="light" onPress={() => setSaveModalOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              color="primary"
+              isDisabled={!viewName.trim()}
+              onPress={saveCurrentView}
+            >
+              Save
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+}
+
+export default DealLookup;

--- a/src/services/deal-editor-service.ts
+++ b/src/services/deal-editor-service.ts
@@ -258,12 +258,15 @@ async function upsertMerchant(values: DealFormValues): Promise<string> {
   return data.id;
 }
 
-export async function createDeal(values: DealFormValues): Promise<void> {
+export async function createDeal(values: DealFormValues): Promise<string> {
   const merchantId = await upsertMerchant(values);
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("deals")
-    .insert({ ...formToDealRow(values), merchant_id: merchantId });
+    .insert({ ...formToDealRow(values), merchant_id: merchantId })
+    .select("id")
+    .single();
   if (error) throw new Error(`Failed to create deal: ${error.message}`);
+  return data.id;
 }
 
 export async function updateDeal(dealId: string, values: DealFormValues): Promise<void> {

--- a/src/services/deal-editor-service.ts
+++ b/src/services/deal-editor-service.ts
@@ -1,0 +1,282 @@
+import { supabase } from "./supabase";
+import type { Database } from "./supabase.types";
+
+type DealInsert = Database["public"]["Tables"]["deals"]["Insert"];
+type DealRow = Database["public"]["Tables"]["deals"]["Row"];
+
+// ---------------------------------------------------------------------------
+// Lookups for the deal form selects
+// ---------------------------------------------------------------------------
+
+export interface IdName {
+  id: number;
+  name: string;
+}
+
+export interface MerchantOption {
+  id: string;
+  name: string;
+  portfolio_id: number | null;
+  funder_id: number | null;
+  industry_id: number | null;
+  state_id: number | null;
+  website: string | null;
+}
+
+export interface EditorLookups {
+  portfolios: IdName[];
+  funders: IdName[];
+  industries: IdName[];
+  states: { id: number; code: string }[];
+  merchants: MerchantOption[];
+}
+
+const PAGE_SIZE = 1000; // PostgREST response cap; merchants can exceed it
+
+export async function getEditorLookups(): Promise<EditorLookups> {
+  const [portfolios, funders, industries, states] = await Promise.all([
+    supabase.from("portfolios").select("id, name").order("name"),
+    supabase.from("funders").select("id, name").order("name"),
+    supabase.from("industries").select("id, name").order("name"),
+    supabase.from("states").select("id, code").order("code"),
+  ]);
+  for (const lookup of [portfolios, funders, industries, states]) {
+    if (lookup.error) throw new Error(`Failed to load lookups: ${lookup.error.message}`);
+  }
+
+  const merchants: MerchantOption[] = [];
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from("merchants")
+      .select("id, name, portfolio_id, funder_id, industry_id, state_id, website")
+      .order("name")
+      .range(from, from + PAGE_SIZE - 1);
+    if (error) throw new Error(`Failed to load merchants: ${error.message}`);
+    if (!data || data.length === 0) break;
+    merchants.push(...data);
+    if (data.length < PAGE_SIZE) break;
+  }
+
+  return {
+    portfolios: portfolios.data ?? [],
+    funders: funders.data ?? [],
+    industries: industries.data ?? [],
+    states: states.data ?? [],
+    merchants,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Form model — strings for numeric inputs, parsed on submit
+// ---------------------------------------------------------------------------
+
+export type PaymentCadence = "daily" | "weekly";
+
+export interface DealFormValues {
+  portfolioId: number | null;
+  funderId: number | null;
+  /** Existing merchant when picked from the autocomplete; null creates one. */
+  merchantId: string | null;
+  merchantName: string;
+  industryId: number | null;
+  stateId: number | null;
+  website: string;
+  funderAdvanceId: string;
+  fico: string;
+  /** Rate factors as entered on the funder sheet, e.g. 1.15 buy + 0.10 commission. */
+  buyRate: string;
+  commission: string;
+  totalAmountFunded: string;
+  participation: string;
+  cadence: PaymentCadence;
+  numPayments: string;
+  dealLengthMonths: string;
+  dateFunded: string;
+  dateClosed: string;
+  newDollars: boolean;
+  rtrReinvestment: boolean;
+  isDefault: boolean;
+  defaultDate: string;
+}
+
+export const EMPTY_DEAL_FORM: DealFormValues = {
+  portfolioId: null,
+  funderId: null,
+  merchantId: null,
+  merchantName: "",
+  industryId: null,
+  stateId: null,
+  website: "",
+  funderAdvanceId: "",
+  fico: "",
+  buyRate: "",
+  commission: "",
+  totalAmountFunded: "",
+  participation: "",
+  cadence: "weekly",
+  numPayments: "",
+  dealLengthMonths: "",
+  dateFunded: "",
+  dateClosed: "",
+  newDollars: true,
+  rtrReinvestment: false,
+  isDefault: false,
+  defaultDate: "",
+};
+
+/** Load a deal's raw input row (deal_computed lacks the payment-count inputs). */
+export async function getDealFormValues(dealId: string): Promise<DealFormValues> {
+  const { data: deal, error } = await supabase.from("deals").select("*").eq("id", dealId).single();
+  if (error) throw new Error(`Failed to load deal: ${error.message}`);
+
+  let merchant: MerchantOption | null = null;
+  if (deal.merchant_id != null) {
+    const { data, error: merchantError } = await supabase
+      .from("merchants")
+      .select("id, name, portfolio_id, funder_id, industry_id, state_id, website")
+      .eq("id", deal.merchant_id)
+      .single();
+    if (merchantError) throw new Error(`Failed to load merchant: ${merchantError.message}`);
+    merchant = data;
+  }
+
+  return dealRowToFormValues(deal, merchant);
+}
+
+const numToStr = (value: number | null) => (value != null ? String(value) : "");
+
+export function dealRowToFormValues(
+  deal: DealRow,
+  merchant: MerchantOption | null
+): DealFormValues {
+  return {
+    portfolioId: deal.portfolio_id,
+    funderId: deal.funder_id,
+    merchantId: merchant?.id ?? null,
+    merchantName: merchant?.name ?? "",
+    industryId: merchant?.industry_id ?? null,
+    stateId: merchant?.state_id ?? null,
+    website: merchant?.website ?? "",
+    funderAdvanceId: deal.funder_advance_id ?? "",
+    fico: numToStr(deal.fico),
+    buyRate: numToStr(deal.buy_rate),
+    commission: numToStr(deal.commission),
+    totalAmountFunded: numToStr(deal.total_amount_funded),
+    participation: numToStr(deal.participation_on_amount),
+    cadence: deal.num_daily_payments != null ? "daily" : "weekly",
+    numPayments: numToStr(deal.num_daily_payments ?? deal.num_weekly_payments),
+    dealLengthMonths: numToStr(deal.deal_length_months),
+    dateFunded: deal.date_funded ?? "",
+    dateClosed: deal.date_closed ?? "",
+    newDollars: deal.new_dollars,
+    rtrReinvestment: deal.rtr,
+    isDefault: deal.is_default,
+    defaultDate: deal.default_date ?? "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Validation + payload building (pure, unit-tested)
+// ---------------------------------------------------------------------------
+
+const parseNum = (value: string): number | null => {
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export function validateDealForm(values: DealFormValues): string | null {
+  if (values.portfolioId == null) return "Portfolio is required";
+  if (values.funderId == null) return "Funder is required";
+  if (!values.merchantName.trim()) return "Merchant name is required";
+  if (!values.dateFunded) return "Date funded is required";
+  const numerics: [string, string][] = [
+    [values.fico, "FICO"],
+    [values.buyRate, "Buy rate"],
+    [values.commission, "Commission rate"],
+    [values.totalAmountFunded, "Amount funded"],
+    [values.participation, "Participation"],
+    [values.numPayments, "Payment count"],
+    [values.dealLengthMonths, "Deal length"],
+  ];
+  for (const [raw, label] of numerics) {
+    if (raw.trim() !== "" && parseNum(raw) == null) return `${label} must be a number`;
+  }
+  if (values.isDefault && !values.defaultDate) return "Default date is required for defaults";
+  return null;
+}
+
+/**
+ * The deals columns the form edits. advance_id is intentionally absent so
+ * workbook-imported IDs survive edits.
+ */
+export function formToDealRow(values: DealFormValues): Omit<DealInsert, "id" | "merchant_id"> {
+  const numPayments = parseNum(values.numPayments);
+  return {
+    portfolio_id: values.portfolioId,
+    funder_id: values.funderId,
+    funder_advance_id: values.funderAdvanceId.trim() || null,
+    fico: parseNum(values.fico),
+    buy_rate: parseNum(values.buyRate),
+    commission: parseNum(values.commission),
+    total_amount_funded: parseNum(values.totalAmountFunded),
+    participation_on_amount: parseNum(values.participation),
+    num_daily_payments: values.cadence === "daily" ? numPayments : null,
+    num_weekly_payments: values.cadence === "weekly" ? numPayments : null,
+    deal_length_months: parseNum(values.dealLengthMonths),
+    new_dollars: values.newDollars,
+    rtr: values.rtrReinvestment,
+    is_default: values.isDefault,
+    date_funded: values.dateFunded || null,
+    date_closed: values.dateClosed || null,
+    default_date: values.isDefault ? values.defaultDate || null : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mutations — direct table writes; RLS scopes them by portfolio_access
+// ---------------------------------------------------------------------------
+
+/** Create the merchant when none was picked, update it when one was. */
+async function upsertMerchant(values: DealFormValues): Promise<string> {
+  const fields = {
+    name: values.merchantName.trim(),
+    industry_id: values.industryId,
+    state_id: values.stateId,
+    website: values.website.trim() || null,
+    portfolio_id: values.portfolioId,
+    funder_id: values.funderId,
+  };
+  if (values.merchantId != null) {
+    const { error } = await supabase.from("merchants").update(fields).eq("id", values.merchantId);
+    if (error) throw new Error(`Failed to update merchant: ${error.message}`);
+    return values.merchantId;
+  }
+  const { data, error } = await supabase.from("merchants").insert(fields).select("id").single();
+  if (error) throw new Error(`Failed to create merchant: ${error.message}`);
+  return data.id;
+}
+
+export async function createDeal(values: DealFormValues): Promise<void> {
+  const merchantId = await upsertMerchant(values);
+  const { error } = await supabase
+    .from("deals")
+    .insert({ ...formToDealRow(values), merchant_id: merchantId });
+  if (error) throw new Error(`Failed to create deal: ${error.message}`);
+}
+
+export async function updateDeal(dealId: string, values: DealFormValues): Promise<void> {
+  const merchantId = await upsertMerchant(values);
+  const { error } = await supabase
+    .from("deals")
+    .update({ ...formToDealRow(values), merchant_id: merchantId })
+    .eq("id", dealId);
+  if (error) throw new Error(`Failed to update deal: ${error.message}`);
+}
+
+/** Deletes the deal; its net_rtr_payments rows cascade with it. */
+export async function deleteDeal(dealId: string): Promise<void> {
+  const { error } = await supabase.from("deals").delete().eq("id", dealId);
+  if (error) throw new Error(`Failed to delete deal: ${error.message}`);
+}

--- a/src/services/deal-explorer-service.ts
+++ b/src/services/deal-explorer-service.ts
@@ -1,0 +1,689 @@
+import { save } from "@tauri-apps/plugin-dialog";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import { downloadDir, join } from "@tauri-apps/api/path";
+import { supabase } from "./supabase";
+import type { Database } from "./supabase.types";
+import { formatMonth } from "./analytics-service";
+
+type DealComputedRow = Database["public"]["Views"]["deal_computed"]["Row"];
+
+export type DealStatus = "Active" | "Closed" | "Defaulted";
+
+/** A deal_computed row flattened with its lookups, ready for filtering/grouping. */
+export interface DealRecord extends DealComputedRow {
+  merchant_name: string | null;
+  industry: string | null;
+  state: string | null;
+  merchant_website: string | null;
+  funder_name: string | null;
+  portfolio_name: string | null;
+  status: DealStatus;
+}
+
+// ---------------------------------------------------------------------------
+// Field registry — drives the column picker, filter builder, pivot and charts
+// ---------------------------------------------------------------------------
+
+export type FieldType = "text" | "number" | "money" | "percent" | "date" | "month" | "boolean";
+
+export interface FieldDef {
+  key: keyof DealRecord;
+  label: string;
+  type: FieldType;
+  /** Usable as a group-by dimension in pivots and charts. */
+  dimension?: boolean;
+  /** Shown in the table when no view customizes columns. */
+  defaultVisible?: boolean;
+}
+
+export const DEAL_FIELDS: FieldDef[] = [
+  { key: "funder_advance_id", label: "Advance ID", type: "text", defaultVisible: true },
+  { key: "advance_id", label: "Internal Advance ID", type: "text" },
+  { key: "merchant_name", label: "Merchant", type: "text", dimension: true, defaultVisible: true },
+  { key: "merchant_website", label: "Website", type: "text" },
+  { key: "funder_name", label: "Funder", type: "text", dimension: true, defaultVisible: true },
+  { key: "portfolio_name", label: "Portfolio", type: "text", dimension: true },
+  { key: "industry", label: "Industry", type: "text", dimension: true, defaultVisible: true },
+  { key: "state", label: "State", type: "text", dimension: true, defaultVisible: true },
+  { key: "status", label: "Status", type: "text", dimension: true, defaultVisible: true },
+  {
+    key: "vintage_month",
+    label: "Vintage Month",
+    type: "month",
+    dimension: true,
+    defaultVisible: true,
+  },
+  { key: "date_funded", label: "Date Funded", type: "date" },
+  { key: "date_closed", label: "Date Closed", type: "date" },
+  { key: "fico", label: "FICO", type: "number" },
+  { key: "buy_rate", label: "Buy Rate", type: "number" },
+  { key: "sell_rate", label: "Sell Rate", type: "number" },
+  { key: "commission", label: "Commission Rate", type: "percent" },
+  { key: "management_fee_rate", label: "Management Fee Rate", type: "percent" },
+  { key: "total_amount_funded", label: "Amount Funded", type: "money", defaultVisible: true },
+  { key: "participation_on_amount", label: "Participation", type: "money", defaultVisible: true },
+  { key: "commission_dollars", label: "Commission $", type: "money" },
+  { key: "pro_rata_commission", label: "Pro-Rata Commission", type: "money" },
+  { key: "rh_pct_of_deal", label: "% of Deal", type: "percent" },
+  { key: "cost_basis", label: "Cost Basis", type: "money", defaultVisible: true },
+  { key: "total_rtr", label: "Total RTR", type: "money" },
+  { key: "rh_rtr", label: "R&H RTR", type: "money" },
+  { key: "net_rtr", label: "Net RTR", type: "money", defaultVisible: true },
+  { key: "term_months", label: "Term (months)", type: "number" },
+  { key: "all_in_factor", label: "All-In Factor", type: "number" },
+  { key: "points_per_month", label: "Points / Month", type: "number" },
+  { key: "new_dollars_at_work", label: "New $ at Work", type: "money" },
+  { key: "rtr_dollars_at_work", label: "RTR $ at Work", type: "money" },
+  { key: "gross_payment_expected", label: "Gross Payment Expected", type: "money" },
+  { key: "net_payment_expected", label: "Net Payment Expected", type: "money" },
+  { key: "weekly_payment_expected", label: "Weekly Payment Expected", type: "money" },
+  { key: "total_gross_received", label: "Gross Received", type: "money" },
+  { key: "total_fee_paid", label: "Fees Paid", type: "money" },
+  { key: "total_net_received", label: "Net Received", type: "money", defaultVisible: true },
+  { key: "net_rtr_balance", label: "Net RTR Balance", type: "money", defaultVisible: true },
+  { key: "pct_rtr_paid", label: "% RTR Paid", type: "percent", defaultVisible: true },
+  { key: "return_on_cost_basis", label: "Return on Cost Basis", type: "percent" },
+  { key: "bad_debt_rtr", label: "Bad Debt RTR", type: "money" },
+  { key: "default_dollars_lost", label: "Default $ Lost", type: "money" },
+  { key: "is_default", label: "Defaulted", type: "boolean", dimension: true },
+  { key: "new_dollars", label: "New Dollars", type: "boolean", dimension: true },
+  { key: "rtr", label: "RTR Reinvestment", type: "boolean", dimension: true },
+  { key: "is_daily", label: "Daily Payer", type: "boolean", dimension: true },
+];
+
+const FIELDS_BY_KEY = new Map(DEAL_FIELDS.map((f) => [f.key as string, f]));
+
+export const fieldDef = (key: string): FieldDef | undefined => FIELDS_BY_KEY.get(key);
+
+export const DIMENSION_FIELDS = DEAL_FIELDS.filter((f) => f.dimension);
+export const NUMERIC_FIELDS = DEAL_FIELDS.filter(
+  (f) => f.type === "number" || f.type === "money" || f.type === "percent"
+);
+export const DEFAULT_VISIBLE_FIELDS = DEAL_FIELDS.filter((f) => f.defaultVisible).map(
+  (f) => f.key as string
+);
+
+const moneyFormat = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+});
+
+export function formatFieldValue(value: string | number | boolean | null, type: FieldType): string {
+  if (value == null || value === "") return "—";
+  switch (type) {
+    case "money":
+      return moneyFormat.format(value as number);
+    case "percent":
+      return `${((value as number) * 100).toFixed(1)}%`;
+    case "number":
+      return (value as number).toLocaleString("en-US", { maximumFractionDigits: 3 });
+    case "month":
+      return formatMonth(String(value));
+    case "boolean":
+      return value ? "Yes" : "No";
+    default:
+      return String(value);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Data fetch — deal_computed joined client-side with its lookups
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE = 1000; // PostgREST response cap
+
+async function fetchAllPages<T>(
+  buildQuery: (
+    from: number,
+    to: number
+  ) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>
+): Promise<T[]> {
+  const rows: T[] = [];
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await buildQuery(from, from + PAGE_SIZE - 1);
+    if (error) throw new Error(error.message);
+    if (!data || data.length === 0) break;
+    rows.push(...data);
+    if (data.length < PAGE_SIZE) break;
+  }
+  return rows;
+}
+
+interface MerchantLookupRow {
+  id: string;
+  name: string;
+  industry_id: number | null;
+  state_id: number | null;
+  website: string | null;
+}
+
+function dealStatus(deal: DealComputedRow): DealStatus {
+  if (deal.is_default) return "Defaulted";
+  if (deal.date_closed != null) return "Closed";
+  return "Active";
+}
+
+/** Every deal visible to the user (RLS scopes reads), flattened with lookups. */
+export async function getDealRecords(): Promise<DealRecord[]> {
+  const [deals, merchants, industries, states, funders, portfolios] = await Promise.all([
+    fetchAllPages<DealComputedRow>((from, to) =>
+      supabase.from("deal_computed").select("*").order("date_funded").range(from, to)
+    ),
+    fetchAllPages<MerchantLookupRow>((from, to) =>
+      supabase
+        .from("merchants")
+        .select("id, name, industry_id, state_id, website")
+        .order("id")
+        .range(from, to)
+    ),
+    supabase.from("industries").select("id, name"),
+    supabase.from("states").select("id, code"),
+    supabase.from("funders").select("id, name"),
+    supabase.from("portfolios").select("id, name"),
+  ]);
+
+  for (const lookup of [industries, states, funders, portfolios]) {
+    if (lookup.error) throw new Error(`Failed to load lookups: ${lookup.error.message}`);
+  }
+
+  const industryNames = new Map((industries.data ?? []).map((i) => [i.id, i.name]));
+  const stateCodes = new Map((states.data ?? []).map((s) => [s.id, s.code]));
+  const funderNames = new Map((funders.data ?? []).map((f) => [f.id, f.name]));
+  const portfolioNames = new Map((portfolios.data ?? []).map((p) => [p.id, p.name]));
+  const merchantsById = new Map(merchants.map((m) => [m.id, m]));
+
+  return deals.map((deal) => {
+    const merchant = deal.merchant_id != null ? merchantsById.get(deal.merchant_id) : undefined;
+    return {
+      ...deal,
+      merchant_name: merchant?.name ?? null,
+      industry:
+        merchant?.industry_id != null ? (industryNames.get(merchant.industry_id) ?? null) : null,
+      state: merchant?.state_id != null ? (stateCodes.get(merchant.state_id) ?? null) : null,
+      merchant_website: merchant?.website ?? null,
+      funder_name: deal.funder_id != null ? (funderNames.get(deal.funder_id) ?? null) : null,
+      portfolio_name:
+        deal.portfolio_id != null ? (portfolioNames.get(deal.portfolio_id) ?? null) : null,
+      status: dealStatus(deal),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+export type FilterOperator =
+  | "contains"
+  | "eq"
+  | "neq"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte"
+  | "between"
+  | "is_true"
+  | "is_false";
+
+export const OPERATORS_BY_TYPE: Record<FieldType, FilterOperator[]> = {
+  text: ["contains", "eq", "neq"],
+  number: ["eq", "neq", "gt", "gte", "lt", "lte", "between"],
+  money: ["eq", "neq", "gt", "gte", "lt", "lte", "between"],
+  percent: ["eq", "neq", "gt", "gte", "lt", "lte", "between"],
+  date: ["eq", "gte", "lte", "between"],
+  month: ["eq", "gte", "lte", "between"],
+  boolean: ["is_true", "is_false"],
+};
+
+export const OPERATOR_LABELS: Record<FilterOperator, string> = {
+  contains: "contains",
+  eq: "=",
+  neq: "≠",
+  gt: ">",
+  gte: "≥",
+  lt: "<",
+  lte: "≤",
+  between: "between",
+  is_true: "is yes",
+  is_false: "is no",
+};
+
+export interface FilterRule {
+  id: string;
+  field: string;
+  operator: FilterOperator;
+  value: string;
+  /** Upper bound for "between". */
+  value2: string;
+}
+
+export interface ExplorerFilters {
+  /** Free-text match on merchant, advance IDs, industry, state. */
+  search: string;
+  portfolios: string[];
+  funders: string[];
+  industries: string[];
+  states: string[];
+  statuses: string[];
+  /** Vintage month range, "YYYY-MM" keys. */
+  monthFrom: string | null;
+  monthTo: string | null;
+  rules: FilterRule[];
+}
+
+export const EMPTY_FILTERS: ExplorerFilters = {
+  search: "",
+  portfolios: [],
+  funders: [],
+  industries: [],
+  states: [],
+  statuses: [],
+  monthFrom: null,
+  monthTo: null,
+  rules: [],
+};
+
+export function countActiveFilters(filters: ExplorerFilters): number {
+  let count = 0;
+  if (filters.search.trim()) count++;
+  if (filters.portfolios.length > 0) count++;
+  if (filters.funders.length > 0) count++;
+  if (filters.industries.length > 0) count++;
+  if (filters.states.length > 0) count++;
+  if (filters.statuses.length > 0) count++;
+  if (filters.monthFrom != null || filters.monthTo != null) count++;
+  count += filters.rules.length;
+  return count;
+}
+
+function applyRule(record: DealRecord, rule: FilterRule): boolean {
+  const def = fieldDef(rule.field);
+  if (!def) return true;
+  const raw = record[def.key];
+
+  if (def.type === "boolean") {
+    const truthy = raw === true;
+    return rule.operator === "is_true" ? truthy : !truthy;
+  }
+
+  // An incomplete rule (no value yet) matches everything.
+  if (rule.value === "" || (rule.operator === "between" && rule.value2 === "")) return true;
+  if (raw == null) return false;
+
+  if (def.type === "text") {
+    const value = String(raw).toLowerCase();
+    const needle = rule.value.toLowerCase();
+    if (rule.operator === "contains") return value.includes(needle);
+    if (rule.operator === "eq") return value === needle;
+    return value !== needle;
+  }
+
+  if (def.type === "date" || def.type === "month") {
+    // ISO strings compare lexicographically; months compare on YYYY-MM.
+    const trim = (v: string) => (def.type === "month" ? v.slice(0, 7) : v);
+    const value = trim(String(raw));
+    const bound = trim(rule.value);
+    switch (rule.operator) {
+      case "eq":
+        return value === bound;
+      case "gte":
+        return value >= bound;
+      case "lte":
+        return value <= bound;
+      case "between":
+        return value >= bound && value <= trim(rule.value2);
+      default:
+        return true;
+    }
+  }
+
+  // number / money / percent — percent rules are entered as percentages.
+  const scale = def.type === "percent" ? 100 : 1;
+  const value = (raw as number) * scale;
+  const bound = Number(rule.value);
+  const bound2 = Number(rule.value2);
+  if (Number.isNaN(bound)) return true;
+  switch (rule.operator) {
+    case "eq":
+      return value === bound;
+    case "neq":
+      return value !== bound;
+    case "gt":
+      return value > bound;
+    case "gte":
+      return value >= bound;
+    case "lt":
+      return value < bound;
+    case "lte":
+      return value <= bound;
+    case "between":
+      return !Number.isNaN(bound2) && value >= bound && value <= bound2;
+    default:
+      return true;
+  }
+}
+
+export function applyFilters(records: DealRecord[], filters: ExplorerFilters): DealRecord[] {
+  const needle = filters.search.trim().toLowerCase();
+  const monthOf = (r: DealRecord) => r.vintage_month?.slice(0, 7) ?? null;
+
+  return records.filter((r) => {
+    if (needle) {
+      const haystack = [r.merchant_name, r.funder_advance_id, r.advance_id, r.industry, r.state]
+        .filter((v): v is string => v != null)
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(needle)) return false;
+    }
+    if (filters.portfolios.length > 0 && !filters.portfolios.includes(r.portfolio_name ?? ""))
+      return false;
+    if (filters.funders.length > 0 && !filters.funders.includes(r.funder_name ?? "")) return false;
+    if (filters.industries.length > 0 && !filters.industries.includes(r.industry ?? ""))
+      return false;
+    if (filters.states.length > 0 && !filters.states.includes(r.state ?? "")) return false;
+    if (filters.statuses.length > 0 && !filters.statuses.includes(r.status)) return false;
+    const month = monthOf(r);
+    if (filters.monthFrom != null && (month == null || month < filters.monthFrom)) return false;
+    if (filters.monthTo != null && (month == null || month > filters.monthTo)) return false;
+    return filters.rules.every((rule) => applyRule(r, rule));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Grouping (shared by pivot + charts)
+// ---------------------------------------------------------------------------
+
+export type Aggregation = "sum" | "avg" | "count" | "min" | "max";
+
+export const AGGREGATION_LABELS: Record<Aggregation, string> = {
+  sum: "Sum",
+  avg: "Average",
+  count: "Count",
+  min: "Min",
+  max: "Max",
+};
+
+/** Sortable key + display label for a record's value in a dimension field. */
+function dimensionValue(record: DealRecord, def: FieldDef): { key: string; label: string } {
+  const raw = record[def.key];
+  if (raw == null || raw === "") return { key: "￿", label: "Unknown" };
+  if (def.type === "boolean") return { key: raw ? "1" : "0", label: raw ? "Yes" : "No" };
+  if (def.type === "month") return { key: String(raw), label: formatMonth(String(raw)) };
+  return { key: String(raw), label: String(raw) };
+}
+
+function aggregate(values: number[], agg: Aggregation): number | null {
+  if (agg === "count") return values.length;
+  if (values.length === 0) return null;
+  switch (agg) {
+    case "sum":
+      return values.reduce((a, b) => a + b, 0);
+    case "avg":
+      return values.reduce((a, b) => a + b, 0) / values.length;
+    case "min":
+      return Math.min(...values);
+    case "max":
+      return Math.max(...values);
+  }
+}
+
+/** Metric samples for a group: for "count" every record contributes a 1. */
+function metricValues(records: DealRecord[], metricField: string | null): number[] {
+  if (metricField == null) return records.map(() => 1);
+  const def = fieldDef(metricField);
+  if (!def) return [];
+  const out: number[] = [];
+  for (const r of records) {
+    const v = r[def.key];
+    if (typeof v === "number") out.push(v);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Pivot tables
+// ---------------------------------------------------------------------------
+
+export interface PivotConfig {
+  rowField: string;
+  /** Optional second dimension across the top. */
+  colField: string | null;
+  /** Numeric field to aggregate; ignored when agg is "count". */
+  valueField: string;
+  agg: Aggregation;
+}
+
+export const DEFAULT_PIVOT_CONFIG: PivotConfig = {
+  rowField: "vintage_month",
+  colField: "funder_name",
+  valueField: "cost_basis",
+  agg: "sum",
+};
+
+export interface PivotRow {
+  label: string;
+  values: (number | null)[];
+  total: number | null;
+}
+
+export interface PivotData {
+  rowLabel: string;
+  colLabels: string[];
+  rows: PivotRow[];
+  colTotals: (number | null)[];
+  grandTotal: number | null;
+  /** How cell values should be formatted. */
+  valueType: FieldType;
+}
+
+export function buildPivot(records: DealRecord[], config: PivotConfig): PivotData {
+  const rowDef = fieldDef(config.rowField);
+  const colDef = config.colField != null ? fieldDef(config.colField) : undefined;
+  const metricField = config.agg === "count" ? null : config.valueField;
+  const valueType: FieldType =
+    config.agg === "count" ? "number" : (fieldDef(config.valueField)?.type ?? "number");
+  if (!rowDef) {
+    return {
+      rowLabel: "",
+      colLabels: [],
+      rows: [],
+      colTotals: [],
+      grandTotal: null,
+      valueType,
+    };
+  }
+
+  // group records by row key × col key
+  const rowMeta = new Map<string, string>(); // sort key -> label
+  const colMeta = new Map<string, string>();
+  const groups = new Map<string, Map<string, DealRecord[]>>();
+  for (const record of records) {
+    const row = dimensionValue(record, rowDef);
+    const col = colDef ? dimensionValue(record, colDef) : { key: "__all__", label: "Value" };
+    rowMeta.set(row.key, row.label);
+    colMeta.set(col.key, col.label);
+    const cols = groups.get(row.key) ?? new Map<string, DealRecord[]>();
+    const cell = cols.get(col.key) ?? [];
+    cell.push(record);
+    cols.set(col.key, cell);
+    groups.set(row.key, cols);
+  }
+
+  const rowKeys = [...rowMeta.keys()].sort();
+  const colKeys = [...colMeta.keys()].sort();
+
+  const rows: PivotRow[] = rowKeys.map((rowKey) => {
+    const cols = groups.get(rowKey)!;
+    const values = colKeys.map((colKey) => {
+      const cell = cols.get(colKey);
+      return cell ? aggregate(metricValues(cell, metricField), config.agg) : null;
+    });
+    const allRecords = [...cols.values()].flat();
+    return {
+      label: rowMeta.get(rowKey)!,
+      values,
+      total: aggregate(metricValues(allRecords, metricField), config.agg),
+    };
+  });
+
+  const colTotals = colKeys.map((colKey) => {
+    const cell = rowKeys.flatMap((rowKey) => groups.get(rowKey)!.get(colKey) ?? []);
+    return aggregate(metricValues(cell, metricField), config.agg);
+  });
+
+  return {
+    rowLabel: rowDef.label,
+    colLabels: colKeys.map((k) => colMeta.get(k)!),
+    rows,
+    colTotals,
+    grandTotal: aggregate(metricValues(records, metricField), config.agg),
+    valueType,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Chart builder
+// ---------------------------------------------------------------------------
+
+export type ChartType = "bar" | "line" | "area" | "pie";
+
+export interface ChartConfig {
+  type: ChartType;
+  dimension: string;
+  /** Optional split into stacked/multi series; ignored for pie. */
+  seriesField: string | null;
+  /** Numeric field key, or "count". */
+  metric: string;
+  agg: Aggregation;
+}
+
+export const COUNT_METRIC = "count";
+
+export const DEFAULT_CHART_CONFIG: ChartConfig = {
+  type: "bar",
+  dimension: "vintage_month",
+  seriesField: "funder_name",
+  metric: "cost_basis",
+  agg: "sum",
+};
+
+export interface ChartRow {
+  category: string;
+  [series: string]: string | number;
+}
+
+export interface ChartData {
+  /** Series (dataKey) names, largest total first. */
+  series: string[];
+  rows: ChartRow[];
+  valueType: FieldType;
+}
+
+export function buildChartData(records: DealRecord[], config: ChartConfig): ChartData {
+  const dimDef = fieldDef(config.dimension);
+  const isCount = config.metric === COUNT_METRIC;
+  const metricField = isCount ? null : config.metric;
+  const agg: Aggregation = isCount ? "count" : config.agg;
+  const valueType: FieldType = isCount ? "number" : (fieldDef(config.metric)?.type ?? "number");
+  const seriesDef =
+    config.type !== "pie" && config.seriesField != null ? fieldDef(config.seriesField) : undefined;
+  if (!dimDef) return { series: [], rows: [], valueType };
+
+  const metricLabel = isCount
+    ? "Deal Count"
+    : `${AGGREGATION_LABELS[agg]} of ${fieldDef(config.metric)?.label ?? config.metric}`;
+
+  const catMeta = new Map<string, string>();
+  const groups = new Map<string, Map<string, DealRecord[]>>();
+  const seriesTotals = new Map<string, number>();
+  for (const record of records) {
+    const cat = dimensionValue(record, dimDef);
+    const series = seriesDef ? dimensionValue(record, seriesDef).label : metricLabel;
+    catMeta.set(cat.key, cat.label);
+    const bySeries = groups.get(cat.key) ?? new Map<string, DealRecord[]>();
+    const cell = bySeries.get(series) ?? [];
+    cell.push(record);
+    bySeries.set(series, cell);
+    groups.set(cat.key, bySeries);
+  }
+
+  const catKeys = [...catMeta.keys()].sort();
+  const rows: ChartRow[] = catKeys.map((catKey) => {
+    const row: ChartRow = { category: catMeta.get(catKey)! };
+    for (const [series, cell] of groups.get(catKey)!) {
+      const value = aggregate(metricValues(cell, metricField), agg) ?? 0;
+      row[series] = value;
+      seriesTotals.set(series, (seriesTotals.get(series) ?? 0) + value);
+    }
+    return row;
+  });
+
+  const series = [...seriesTotals.entries()].sort((a, b) => b[1] - a[1]).map(([name]) => name);
+  // fill gaps so stacked charts don't break on missing keys
+  for (const row of rows) {
+    for (const name of series) if (!(name in row)) row[name] = 0;
+  }
+
+  return { series, rows, valueType };
+}
+
+/** Pie slices from chart rows: one slice per category, top slices + "Other". */
+export function chartRowsToPie(data: ChartData, maxSlices = 11): { name: string; value: number }[] {
+  const slices = data.rows
+    .map((row) => ({
+      name: row.category,
+      value: data.series.reduce((acc, s) => acc + Math.max(row[s] as number, 0), 0),
+    }))
+    .filter((s) => s.value > 0)
+    .sort((a, b) => b.value - a.value);
+  if (slices.length <= maxSlices) return slices;
+  const rest = slices.slice(maxSlices).reduce((acc, s) => acc + s.value, 0);
+  return [...slices.slice(0, maxSlices), { name: "Other", value: rest }];
+}
+
+// ---------------------------------------------------------------------------
+// CSV export
+// ---------------------------------------------------------------------------
+
+function csvEscape(value: string): string {
+  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+function csvLine(values: (string | number | boolean | null)[]): string {
+  return values.map((v) => csvEscape(v == null ? "" : String(v))).join(",");
+}
+
+/** Raw (unformatted) values so the CSV stays machine-readable. */
+export function recordsToCsv(records: DealRecord[], fieldKeys: string[]): string {
+  const defs = fieldKeys.map((key) => fieldDef(key)).filter((def): def is FieldDef => def != null);
+  const lines = [csvLine(defs.map((d) => d.label))];
+  for (const record of records) {
+    lines.push(csvLine(defs.map((d) => record[d.key])));
+  }
+  return lines.join("\n");
+}
+
+export function pivotToCsv(pivot: PivotData): string {
+  const lines = [csvLine([pivot.rowLabel, ...pivot.colLabels, "Total"])];
+  for (const row of pivot.rows) {
+    lines.push(csvLine([row.label, ...row.values, row.total]));
+  }
+  lines.push(csvLine(["Total", ...pivot.colTotals, pivot.grandTotal]));
+  return lines.join("\n");
+}
+
+/**
+ * Ask where to save and write the CSV. Returns the path, or null if the user
+ * cancelled. Note the fs scope only allows ~/Downloads and ~/Excelerate.
+ */
+export async function saveCsvFile(defaultName: string, csv: string): Promise<string | null> {
+  const defaultPath = await join(await downloadDir(), defaultName).catch(() => defaultName);
+  const filePath = await save({
+    defaultPath,
+    filters: [{ name: "CSV", extensions: ["csv"] }],
+  });
+  if (!filePath) return null;
+  await writeTextFile(filePath, csv);
+  return filePath;
+}

--- a/src/services/deal-explorer-service.ts
+++ b/src/services/deal-explorer-service.ts
@@ -215,16 +215,7 @@ export async function getDealRecords(): Promise<DealRecord[]> {
 // ---------------------------------------------------------------------------
 
 export type FilterOperator =
-  | "contains"
-  | "eq"
-  | "neq"
-  | "gt"
-  | "gte"
-  | "lt"
-  | "lte"
-  | "between"
-  | "is_true"
-  | "is_false";
+  "contains" | "eq" | "neq" | "gt" | "gte" | "lt" | "lte" | "between" | "is_true" | "is_false";
 
 export const OPERATORS_BY_TYPE: Record<FieldType, FilterOperator[]> = {
   text: ["contains", "eq", "neq"],

--- a/src/services/deal-explorer-service.ts
+++ b/src/services/deal-explorer-service.ts
@@ -643,6 +643,38 @@ export function chartRowsToPie(data: ChartData, maxSlices = 11): { name: string;
 }
 
 // ---------------------------------------------------------------------------
+// Unmatched pivot-row reconciliation
+// ---------------------------------------------------------------------------
+
+/**
+ * Candidate deals for an unresolved pivot row: same portfolio + funder,
+ * exact advance-id matches first (the duplicate-flag case), then merchant-
+ * name matches, then the rest newest-funded first.
+ */
+export function rankCandidateDeals(
+  row: {
+    advance_id: string | null;
+    merchant_name: string;
+    portfolio_id: number | null;
+    funder_id: number | null;
+  },
+  deals: DealRecord[]
+): DealRecord[] {
+  const merchant = row.merchant_name.trim().toLowerCase();
+  const score = (deal: DealRecord): number => {
+    if (row.advance_id != null && deal.funder_advance_id === row.advance_id) return 0;
+    const name = (deal.merchant_name ?? "").toLowerCase();
+    if (merchant && name && (name.includes(merchant) || merchant.includes(name))) return 1;
+    return 2;
+  };
+  return deals
+    .filter((d) => d.portfolio_id === row.portfolio_id && d.funder_id === row.funder_id)
+    .sort(
+      (a, b) => score(a) - score(b) || (b.date_funded ?? "").localeCompare(a.date_funded ?? "")
+    );
+}
+
+// ---------------------------------------------------------------------------
 // CSV export
 // ---------------------------------------------------------------------------
 

--- a/src/services/pivot-sync-service.ts
+++ b/src/services/pivot-sync-service.ts
@@ -73,6 +73,19 @@ export interface PreviewResult {
   validationWarnings: string[];
 }
 
+/** A pivot row still waiting to be matched to a deal, with its upload scope. */
+export interface UnresolvedPivotRow {
+  row_id: string;
+  advance_id: string | null;
+  merchant_name: string;
+  gross: number;
+  fee: number;
+  net: number;
+  portfolio_id: number | null;
+  funder_id: number | null;
+  report_date: string;
+}
+
 /** One funder_uploads row, resolved for display. */
 export interface CloudUploadInfo {
   id: string;
@@ -281,6 +294,66 @@ export class PivotSyncService {
     if (error) {
       throw new Error(`Failed to resolve pivot row: ${error.message}`);
     }
+  }
+
+  /**
+   * Every pivot row across all uploads still waiting for a deal
+   * (matched_deal_id IS NULL), newest report dates first. These are the
+   * rows whose dollars are not yet in net_rtr_payments.
+   */
+  static async listUnresolvedRows(): Promise<UnresolvedPivotRow[]> {
+    const PAGE = 1000; // PostgREST response cap
+    const rows: Array<{
+      id: string;
+      pivot_table_id: string;
+      advance_id: string | null;
+      merchant_name: string;
+      gross: number;
+      fee: number;
+      net: number;
+    }> = [];
+    for (let from = 0; ; from += PAGE) {
+      const { data, error } = await supabase
+        .from("funder_pivot_rows")
+        .select("id, pivot_table_id, advance_id, merchant_name, gross, fee, net")
+        .is("matched_deal_id", null)
+        .order("id")
+        .range(from, from + PAGE - 1);
+      if (error) throw new Error(`Failed to load unresolved pivot rows: ${error.message}`);
+      if (!data || data.length === 0) break;
+      rows.push(...data);
+      if (data.length < PAGE) break;
+    }
+    if (rows.length === 0) return [];
+
+    const pivotIds = [...new Set(rows.map((r) => r.pivot_table_id))];
+    const { data: pivots, error: pivotError } = await supabase
+      .from("funder_pivot_tables")
+      .select("id, portfolio_id, funder_id, report_date")
+      .in("id", pivotIds);
+    if (pivotError) throw new Error(`Failed to load pivot tables: ${pivotError.message}`);
+    const pivotsById = new Map((pivots ?? []).map((p) => [p.id, p]));
+
+    return rows
+      .map((row) => {
+        const pivot = pivotsById.get(row.pivot_table_id);
+        return {
+          row_id: row.id,
+          advance_id: row.advance_id,
+          merchant_name: row.merchant_name,
+          gross: row.gross,
+          fee: row.fee,
+          net: row.net,
+          portfolio_id: pivot?.portfolio_id ?? null,
+          funder_id: pivot?.funder_id ?? null,
+          report_date: pivot?.report_date ?? "",
+        };
+      })
+      .sort(
+        (a, b) =>
+          b.report_date.localeCompare(a.report_date) ||
+          a.merchant_name.localeCompare(b.merchant_name)
+      );
   }
 
   /** All funder uploads recorded in Supabase for one portfolio + report date. */


### PR DESCRIPTION
## Summary

New sidebar page for full-database deal exploration and management:

- **Filter, pivot, chart, export** — every visible deal (`deal_computed` joined client-side with merchant/industry/state/funder/portfolio lookups) with faceted filters (search, portfolio, funder, industry, state, status, vintage month range) plus type-aware field rules; a column-picker table, a pivot builder (row × column dimension, sum/avg/count/min/max), and a chart builder (bar/line/area/pie with optional series split). Table and pivot both export to CSV via the save dialog. Named views (filters + columns + pivot + chart) save to localStorage.
- **Deal CRUD** — New Deal button and per-row edit/delete on the table. The form covers every `deals` input column plus the merchant (autocomplete over existing merchants or type a new name). RLS already grants insert/update/delete to users with portfolio access, so this writes `deals`/`merchants` directly — no new migration needed. Deleting warns that the deal's recorded payments cascade with it.
- **Unmatched pivot-row reconciliation** — closes a real gap: `resolve_pivot_row` existed but nothing in the UI called it, so unmatched rows from monthly funder uploads became invisible after the upload modal closed. New Unmatched tab (with a count badge) lists every unresolved row across uploads, with its net not yet in `net_rtr_payments`. Each row gets a ranked deal autocomplete (exact advance-ID matches first, then merchant-name matches) or a New Deal button that prefills the form from the row and auto-resolves after creation.

## Test plan

- [x] `npm run lint` — 0 errors, 11 pre-existing warnings (none from new code)
- [x] `npm run format:check` — passes
- [x] `npm run build` — `tsc` + Vite build clean
- [x] `npm test` — 51/51 passing (19 new: filters, pivot/chart transforms, CSV export, deal form validation/conversion, candidate-deal ranking)
- [ ] Manual verification against `dev:local` (deal create/edit/delete, unmatched reconciliation flow, CSV export path) — not yet run in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)