### PR TITLE
feat: AI chat page with database tools, file uploads, and multiple providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-react-refresh": "^0.4.22",
     "husky": "^9.1.7",
     "jsdom": "^26.1.0",
-    "prettier": "^3.6.2",
+    "prettier": "3.6.2",
     "tailwindcss": "^4.1.13",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.45.0",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,11 @@
     "framer-motion": "^12.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.9.1",
     "react-spreadsheet": "^0.10.1",
     "recharts": "^2.15.1",
+    "remark-gfm": "^4.0.1",
     "usehooks-ts": "^3.1.1"
   },
   "overrides": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -573,6 +573,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -594,9 +604,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.9.4",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -607,7 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.9.4",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1023,9 +1033,12 @@ dependencies = [
 name = "excelerate"
 version = "0.1.1"
 dependencies = [
+ "base64 0.22.1",
  "calamine",
  "chrono",
  "csv",
+ "futures-util",
+ "reqwest",
  "rust_xlsxwriter",
  "serde",
  "serde_json",
@@ -1087,12 +1100,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1105,6 +1127,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1523,6 +1551,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.11.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1667,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1629,6 +1677,37 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1650,9 +1729,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2180,6 +2261,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,6 +2631,49 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3154,22 +3295,30 @@ checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3204,6 +3353,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3244,6 +3407,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,6 +3458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3326,6 +3531,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3601,7 +3829,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2 0.5.2",
@@ -3684,6 +3912,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3737,6 +3971,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,7 +4012,7 @@ checksum = "959469667dbcea91e5485fc48ba7dd6023face91bb0f1a14681a70f99847c3f7"
 dependencies = [
  "bitflags 2.9.4",
  "block2 0.6.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -4224,6 +4479,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4519,6 +4794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4565,6 +4846,12 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5032,6 +5319,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5074,6 +5372,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5538,6 +5845,12 @@ dependencies = [
  "syn 2.0.106",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,4 +30,7 @@ csv = "1.3"
 calamine = "0.26"
 thiserror = "2.0"
 rust_xlsxwriter = "0.96.0"
+reqwest = { version = "0.12", features = ["json", "stream"] }
+futures-util = "0.3"
+base64 = "0.22"
 

--- a/src-tauri/src/ai_chat/anthropic.rs
+++ b/src-tauri/src/ai_chat/anthropic.rs
@@ -1,0 +1,160 @@
+//! Anthropic Messages API client (raw HTTP — Anthropic ships no official
+//! Rust SDK). Streams `/v1/messages` SSE and reassembles the assistant turn.
+
+use serde_json::{json, Value};
+
+use super::sse::{ensure_success, read_sse};
+use super::types::{AssistantTurn, ChatBlock, ChatMessage, EventSink, ToolDef};
+
+const API_URL: &str = "https://api.anthropic.com/v1/messages";
+const API_VERSION: &str = "2023-06-01";
+const MAX_TOKENS: u32 = 8192;
+
+fn to_api_message(message: &ChatMessage) -> Value {
+    let content: Vec<Value> = message
+        .blocks
+        .iter()
+        .map(|block| match block {
+            ChatBlock::Text { text } => json!({ "type": "text", "text": text }),
+            ChatBlock::Image { media_type, data } => json!({
+                "type": "image",
+                "source": { "type": "base64", "media_type": media_type, "data": data }
+            }),
+            ChatBlock::Document {
+                media_type, data, ..
+            } => json!({
+                "type": "document",
+                "source": { "type": "base64", "media_type": media_type, "data": data }
+            }),
+            ChatBlock::ToolUse { id, name, input } => {
+                json!({ "type": "tool_use", "id": id, "name": name, "input": input })
+            }
+            ChatBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+                ..
+            } => json!({
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": content,
+                "is_error": is_error
+            }),
+        })
+        .collect();
+    json!({ "role": message.role, "content": content })
+}
+
+/// In-progress content block while parsing the SSE stream.
+enum BlockAcc {
+    Text(String),
+    ToolUse {
+        id: String,
+        name: String,
+        json: String,
+    },
+}
+
+pub async fn stream_chat(
+    client: &reqwest::Client,
+    api_key: &str,
+    model: &str,
+    system: &str,
+    messages: &[ChatMessage],
+    tools: &[ToolDef],
+    on_event: EventSink<'_>,
+) -> Result<AssistantTurn, String> {
+    let body = json!({
+        "model": model,
+        "max_tokens": MAX_TOKENS,
+        "stream": true,
+        "system": system,
+        "messages": messages.iter().map(to_api_message).collect::<Vec<_>>(),
+        "tools": tools.iter().map(|t| json!({
+            "name": t.name,
+            "description": t.description,
+            "input_schema": t.input_schema,
+        })).collect::<Vec<_>>(),
+    });
+
+    let response = client
+        .post(API_URL)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", API_VERSION)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Anthropic request failed: {e}"))?;
+    let response = ensure_success(response, "Anthropic").await?;
+
+    let mut blocks: Vec<ChatBlock> = Vec::new();
+    let mut current: Option<BlockAcc> = None;
+
+    read_sse(response, |event| {
+        let data: Value = serde_json::from_str(&event.data)
+            .map_err(|e| format!("Anthropic sent invalid JSON: {e}"))?;
+        match data["type"].as_str().unwrap_or_default() {
+            "content_block_start" => {
+                let block = &data["content_block"];
+                current = match block["type"].as_str().unwrap_or_default() {
+                    "tool_use" => Some(BlockAcc::ToolUse {
+                        id: block["id"].as_str().unwrap_or_default().to_string(),
+                        name: block["name"].as_str().unwrap_or_default().to_string(),
+                        json: String::new(),
+                    }),
+                    // Treat anything else (text, thinking summaries) as text.
+                    _ => Some(BlockAcc::Text(
+                        block["text"].as_str().unwrap_or_default().to_string(),
+                    )),
+                };
+            }
+            "content_block_delta" => match data["delta"]["type"].as_str().unwrap_or_default() {
+                "text_delta" => {
+                    let text = data["delta"]["text"].as_str().unwrap_or_default();
+                    if let Some(BlockAcc::Text(acc)) = current.as_mut() {
+                        acc.push_str(text);
+                    }
+                    on_event(super::types::AiChatEvent::TextDelta {
+                        text: text.to_string(),
+                    });
+                }
+                "input_json_delta" => {
+                    if let Some(BlockAcc::ToolUse { json, .. }) = current.as_mut() {
+                        json.push_str(data["delta"]["partial_json"].as_str().unwrap_or_default());
+                    }
+                }
+                _ => {}
+            },
+            "content_block_stop" => match current.take() {
+                Some(BlockAcc::Text(text)) => {
+                    if !text.is_empty() {
+                        blocks.push(ChatBlock::Text { text });
+                    }
+                }
+                Some(BlockAcc::ToolUse { id, name, json }) => {
+                    let input: Value = serde_json::from_str(&json)
+                        .unwrap_or_else(|_| Value::Object(Default::default()));
+                    on_event(super::types::AiChatEvent::ToolCall {
+                        id: id.clone(),
+                        name: name.clone(),
+                        input: input.clone(),
+                    });
+                    blocks.push(ChatBlock::ToolUse { id, name, input });
+                }
+                None => {}
+            },
+            "message_stop" => return Ok(false),
+            "error" => {
+                return Err(format!(
+                    "Anthropic stream error: {}",
+                    data["error"]["message"].as_str().unwrap_or(&event.data)
+                ));
+            }
+            _ => {}
+        }
+        Ok(true)
+    })
+    .await?;
+
+    Ok(AssistantTurn { blocks })
+}

--- a/src-tauri/src/ai_chat/attachments.rs
+++ b/src-tauri/src/ai_chat/attachments.rs
@@ -1,0 +1,148 @@
+//! Turns a picked file into chat blocks: spreadsheets/CSVs become inline
+//! text (all providers handle text), PDFs and images become base64 blocks.
+
+use std::path::Path;
+
+use base64::Engine;
+use calamine::{open_workbook_auto, Reader};
+use serde::Serialize;
+
+use super::types::ChatBlock;
+
+const MAX_TEXT_BYTES: usize = 200_000;
+const MAX_SHEET_ROWS: usize = 500;
+const MAX_PDF_BYTES: usize = 20 * 1024 * 1024;
+const MAX_IMAGE_BYTES: usize = 10 * 1024 * 1024;
+
+#[derive(Debug, Serialize)]
+pub struct PreparedAttachment {
+    pub name: String,
+    pub blocks: Vec<ChatBlock>,
+}
+
+fn file_name(path: &Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "file".to_string())
+}
+
+fn text_attachment(name: &str, mut body: String) -> PreparedAttachment {
+    let mut note = String::new();
+    if body.len() > MAX_TEXT_BYTES {
+        let mut cut = MAX_TEXT_BYTES;
+        while !body.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        body.truncate(cut);
+        note = "\n\n[File truncated for size]".to_string();
+    }
+    PreparedAttachment {
+        name: name.to_string(),
+        blocks: vec![ChatBlock::Text {
+            text: format!("Contents of uploaded file \"{name}\":\n\n{body}{note}"),
+        }],
+    }
+}
+
+fn excel_to_text(path: &Path) -> Result<String, String> {
+    let mut workbook =
+        open_workbook_auto(path).map_err(|e| format!("Cannot open spreadsheet: {e}"))?;
+    let sheet_names = workbook.sheet_names().to_vec();
+    let mut out = String::new();
+    for sheet_name in sheet_names {
+        let Ok(range) = workbook.worksheet_range(&sheet_name) else {
+            continue;
+        };
+        out.push_str(&format!("## Sheet: {sheet_name}\n"));
+        let total_rows = range.rows().count();
+        for row in range.rows().take(MAX_SHEET_ROWS) {
+            let line = row
+                .iter()
+                .map(|cell| {
+                    let s = cell.to_string();
+                    if s.contains(',') || s.contains('"') {
+                        format!("\"{}\"", s.replace('"', "\"\""))
+                    } else {
+                        s
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            out.push_str(&line);
+            out.push('\n');
+        }
+        if total_rows > MAX_SHEET_ROWS {
+            out.push_str(&format!(
+                "[... {} more rows omitted]\n",
+                total_rows - MAX_SHEET_ROWS
+            ));
+        }
+        out.push('\n');
+    }
+    Ok(out)
+}
+
+fn binary_attachment(
+    path: &Path,
+    name: &str,
+    media_type: &str,
+    max_bytes: usize,
+    is_image: bool,
+) -> Result<PreparedAttachment, String> {
+    let bytes = std::fs::read(path).map_err(|e| format!("Cannot read file: {e}"))?;
+    if bytes.len() > max_bytes {
+        return Err(format!(
+            "File is too large ({:.1} MB, max {} MB)",
+            bytes.len() as f64 / 1_048_576.0,
+            max_bytes / 1_048_576
+        ));
+    }
+    let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    let block = if is_image {
+        ChatBlock::Image {
+            media_type: media_type.to_string(),
+            data,
+        }
+    } else {
+        ChatBlock::Document {
+            media_type: media_type.to_string(),
+            data,
+            name: name.to_string(),
+        }
+    };
+    Ok(PreparedAttachment {
+        name: name.to_string(),
+        blocks: vec![block],
+    })
+}
+
+#[tauri::command]
+pub fn prepare_chat_attachment(path: String) -> Result<PreparedAttachment, String> {
+    let path = Path::new(&path);
+    let name = file_name(path);
+    let ext = path
+        .extension()
+        .map(|e| e.to_string_lossy().to_lowercase())
+        .unwrap_or_default();
+
+    match ext.as_str() {
+        "csv" | "txt" | "md" | "json" | "tsv" => {
+            let bytes = std::fs::read(path).map_err(|e| format!("Cannot read file: {e}"))?;
+            Ok(text_attachment(
+                &name,
+                String::from_utf8_lossy(&bytes).to_string(),
+            ))
+        }
+        "xlsx" | "xls" | "xlsm" | "xlsb" | "ods" => {
+            Ok(text_attachment(&name, excel_to_text(path)?))
+        }
+        "pdf" => binary_attachment(path, &name, "application/pdf", MAX_PDF_BYTES, false),
+        "png" => binary_attachment(path, &name, "image/png", MAX_IMAGE_BYTES, true),
+        "jpg" | "jpeg" => binary_attachment(path, &name, "image/jpeg", MAX_IMAGE_BYTES, true),
+        "gif" => binary_attachment(path, &name, "image/gif", MAX_IMAGE_BYTES, true),
+        "webp" => binary_attachment(path, &name, "image/webp", MAX_IMAGE_BYTES, true),
+        other => Err(format!(
+            "Unsupported file type: .{other}. Supported: csv, tsv, txt, md, json, xlsx, xls, pdf, png, jpg, gif, webp"
+        )),
+    }
+}

--- a/src-tauri/src/ai_chat/gemini.rs
+++ b/src-tauri/src/ai_chat/gemini.rs
@@ -1,0 +1,130 @@
+//! Google Gemini (Generative Language API) client. Streams
+//! `models/{model}:streamGenerateContent?alt=sse` and reassembles the turn.
+
+use serde_json::{json, Value};
+
+use super::sse::{ensure_success, read_sse};
+use super::types::{AssistantTurn, ChatBlock, ChatMessage, EventSink, ToolDef};
+
+const API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta/models";
+
+fn to_api_content(message: &ChatMessage) -> Value {
+    let role = if message.role == "assistant" {
+        "model"
+    } else {
+        "user"
+    };
+    let parts: Vec<Value> = message
+        .blocks
+        .iter()
+        .map(|block| match block {
+            ChatBlock::Text { text } => json!({ "text": text }),
+            ChatBlock::Image { media_type, data }
+            | ChatBlock::Document {
+                media_type, data, ..
+            } => json!({ "inlineData": { "mimeType": media_type, "data": data } }),
+            ChatBlock::ToolUse { name, input, .. } => {
+                json!({ "functionCall": { "name": name, "args": input } })
+            }
+            ChatBlock::ToolResult {
+                name,
+                content,
+                is_error,
+                ..
+            } => {
+                let response = if *is_error {
+                    json!({ "error": content })
+                } else {
+                    json!({ "result": content })
+                };
+                json!({ "functionResponse": { "name": name, "response": response } })
+            }
+        })
+        .collect();
+    json!({ "role": role, "parts": parts })
+}
+
+pub async fn stream_chat(
+    client: &reqwest::Client,
+    api_key: &str,
+    model: &str,
+    system: &str,
+    messages: &[ChatMessage],
+    tools: &[ToolDef],
+    on_event: EventSink<'_>,
+) -> Result<AssistantTurn, String> {
+    let body = json!({
+        "systemInstruction": { "parts": [{ "text": system }] },
+        "contents": messages.iter().map(to_api_content).collect::<Vec<_>>(),
+        "tools": [{
+            "functionDeclarations": tools.iter().map(|t| json!({
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.input_schema,
+            })).collect::<Vec<_>>()
+        }],
+    });
+
+    let url = format!("{API_BASE}/{model}:streamGenerateContent?alt=sse");
+    let response = client
+        .post(&url)
+        .header("x-goog-api-key", api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Gemini request failed: {e}"))?;
+    let response = ensure_success(response, "Gemini").await?;
+
+    let mut text = String::new();
+    let mut tool_calls: Vec<(String, Value)> = Vec::new();
+
+    read_sse(response, |event| {
+        let data: Value = serde_json::from_str(&event.data)
+            .map_err(|e| format!("Gemini sent invalid JSON: {e}"))?;
+        if let Some(error) = data.get("error") {
+            return Err(format!("Gemini stream error: {error}"));
+        }
+        if let Some(parts) = data["candidates"][0]["content"]["parts"].as_array() {
+            for part in parts {
+                if let Some(t) = part["text"].as_str() {
+                    text.push_str(t);
+                    on_event(super::types::AiChatEvent::TextDelta {
+                        text: t.to_string(),
+                    });
+                }
+                if part["functionCall"].is_object() {
+                    let name = part["functionCall"]["name"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .to_string();
+                    let args = part["functionCall"]["args"].clone();
+                    tool_calls.push((name, args));
+                }
+            }
+        }
+        Ok(true)
+    })
+    .await?;
+
+    let mut blocks: Vec<ChatBlock> = Vec::new();
+    if !text.is_empty() {
+        blocks.push(ChatBlock::Text { text });
+    }
+    for (index, (name, args)) in tool_calls.into_iter().enumerate() {
+        // Gemini function calls carry no id — synthesize one for the loop.
+        let id = format!("call_{index}");
+        let input = if args.is_object() {
+            args
+        } else {
+            Value::Object(Default::default())
+        };
+        on_event(super::types::AiChatEvent::ToolCall {
+            id: id.clone(),
+            name: name.clone(),
+            input: input.clone(),
+        });
+        blocks.push(ChatBlock::ToolUse { id, name, input });
+    }
+
+    Ok(AssistantTurn { blocks })
+}

--- a/src-tauri/src/ai_chat/mod.rs
+++ b/src-tauri/src/ai_chat/mod.rs
@@ -29,6 +29,7 @@ struct TurnCtx<'a> {
     model: &'a str,
     system: &'a str,
     tools: &'a [ToolDef],
+    lmstudio_base_url: &'a str,
 }
 
 impl TurnCtx<'_> {
@@ -44,8 +45,26 @@ impl TurnCtx<'_> {
                     .await
             }
             "openai" => {
-                openai::stream_chat(client, key, model, system, messages, self.tools, on_event)
-                    .await
+                let target = openai::OpenAiCompat {
+                    base_url: openai::OPENAI_BASE_URL,
+                    api_key: key,
+                    label: "OpenAI",
+                };
+                openai::stream_chat(
+                    client, &target, model, system, messages, self.tools, on_event,
+                )
+                .await
+            }
+            "lmstudio" => {
+                let target = openai::OpenAiCompat {
+                    base_url: self.lmstudio_base_url,
+                    api_key: key,
+                    label: "LM Studio",
+                };
+                openai::stream_chat(
+                    client, &target, model, system, messages, self.tools, on_event,
+                )
+                .await
             }
             "google" => {
                 gemini::stream_chat(client, key, model, system, messages, self.tools, on_event)
@@ -78,7 +97,8 @@ pub async fn ai_chat_stream(
 ) -> Result<Vec<ChatMessage>, String> {
     let ai_settings = settings::load(&app)?;
     let api_key = ai_settings.api_key_for(&request.provider).to_string();
-    if api_key.is_empty() {
+    // Local servers (LM Studio) don't authenticate; every cloud provider does.
+    if api_key.is_empty() && request.provider != "lmstudio" {
         return Err(format!(
             "No API key configured for {}. Add one in the chat settings.",
             request.provider
@@ -101,6 +121,7 @@ pub async fn ai_chat_stream(
         model: &request.model,
         system: &system,
         tools: &tool_defs,
+        lmstudio_base_url: &ai_settings.lmstudio_base_url,
     };
 
     let mut conversation = request.messages.clone();

--- a/src-tauri/src/ai_chat/mod.rs
+++ b/src-tauri/src/ai_chat/mod.rs
@@ -56,8 +56,15 @@ impl TurnCtx<'_> {
                 .await
             }
             "lmstudio" => {
+                // Tolerate URLs entered without the /v1 path segment.
+                let base = self.lmstudio_base_url.trim_end_matches('/');
+                let base_url = if base.ends_with("/v1") {
+                    base.to_string()
+                } else {
+                    format!("{base}/v1")
+                };
                 let target = openai::OpenAiCompat {
-                    base_url: self.lmstudio_base_url,
+                    base_url: &base_url,
                     api_key: key,
                     label: "LM Studio",
                 };

--- a/src-tauri/src/ai_chat/mod.rs
+++ b/src-tauri/src/ai_chat/mod.rs
@@ -1,0 +1,166 @@
+//! Provider-agnostic AI chat: streams one conversational turn, running the
+//! tool loop (model → database tools → model) until the assistant answers
+//! without tool calls. The frontend owns history and persistence; this side
+//! is stateless per invocation.
+
+mod anthropic;
+pub mod attachments;
+mod gemini;
+mod openai;
+pub mod settings;
+mod sse;
+mod tools;
+mod types;
+
+use tauri::ipc::Channel;
+
+use tools::SupabaseCtx;
+use types::{AiChatEvent, AiChatRequest, AssistantTurn, ChatBlock, ChatMessage, ToolDef};
+
+/// Safety cap on model↔tool round-trips within one user turn.
+const MAX_TOOL_ROUNDS: usize = 8;
+const TOOL_PREVIEW_CHARS: usize = 400;
+
+/// Everything that stays constant across the tool rounds of one user turn.
+struct TurnCtx<'a> {
+    provider: &'a str,
+    client: &'a reqwest::Client,
+    api_key: &'a str,
+    model: &'a str,
+    system: &'a str,
+    tools: &'a [ToolDef],
+}
+
+impl TurnCtx<'_> {
+    async fn run(
+        &self,
+        messages: &[ChatMessage],
+        on_event: types::EventSink<'_>,
+    ) -> Result<AssistantTurn, String> {
+        let (client, key, model, system) = (self.client, self.api_key, self.model, self.system);
+        match self.provider {
+            "anthropic" => {
+                anthropic::stream_chat(client, key, model, system, messages, self.tools, on_event)
+                    .await
+            }
+            "openai" => {
+                openai::stream_chat(client, key, model, system, messages, self.tools, on_event)
+                    .await
+            }
+            "google" => {
+                gemini::stream_chat(client, key, model, system, messages, self.tools, on_event)
+                    .await
+            }
+            other => Err(format!("Unknown provider: {other}")),
+        }
+    }
+}
+
+fn preview(content: &str) -> String {
+    if content.len() <= TOOL_PREVIEW_CHARS {
+        return content.to_string();
+    }
+    let mut cut = TOOL_PREVIEW_CHARS;
+    while !content.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{}…", &content[..cut])
+}
+
+/// Runs one user turn. Streams `AiChatEvent`s over the channel while running
+/// and returns the new messages (assistant turns + tool-result messages) for
+/// the frontend to append to history and persist.
+#[tauri::command]
+pub async fn ai_chat_stream(
+    app: tauri::AppHandle,
+    request: AiChatRequest,
+    on_event: Channel<AiChatEvent>,
+) -> Result<Vec<ChatMessage>, String> {
+    let ai_settings = settings::load(&app)?;
+    let api_key = ai_settings.api_key_for(&request.provider).to_string();
+    if api_key.is_empty() {
+        return Err(format!(
+            "No API key configured for {}. Add one in the chat settings.",
+            request.provider
+        ));
+    }
+
+    let client = reqwest::Client::new();
+    let supabase = SupabaseCtx {
+        client: client.clone(),
+        url: request.supabase_url.clone(),
+        anon_key: request.supabase_anon_key.clone(),
+        access_token: request.supabase_access_token.clone(),
+    };
+    let tool_defs = tools::tool_defs();
+    let system = tools::system_prompt();
+    let turn_ctx = TurnCtx {
+        provider: &request.provider,
+        client: &client,
+        api_key: &api_key,
+        model: &request.model,
+        system: &system,
+        tools: &tool_defs,
+    };
+
+    let mut conversation = request.messages.clone();
+    let mut new_messages: Vec<ChatMessage> = Vec::new();
+
+    for _round in 0..MAX_TOOL_ROUNDS {
+        let mut emit = |event: AiChatEvent| {
+            let _ = on_event.send(event);
+        };
+        let turn = turn_ctx.run(&conversation, &mut emit).await?;
+
+        let assistant = ChatMessage {
+            role: "assistant".into(),
+            blocks: turn.blocks,
+        };
+        let tool_calls: Vec<(String, String, serde_json::Value)> = assistant
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                ChatBlock::ToolUse { id, name, input } => {
+                    Some((id.clone(), name.clone(), input.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+
+        conversation.push(assistant.clone());
+        new_messages.push(assistant);
+        let _ = on_event.send(AiChatEvent::TurnComplete);
+
+        if tool_calls.is_empty() {
+            break;
+        }
+
+        let mut result_blocks: Vec<ChatBlock> = Vec::new();
+        for (id, name, input) in tool_calls {
+            let (content, is_error) = match tools::execute_tool(&name, &input, &supabase).await {
+                Ok(content) => (content, false),
+                Err(error) => (error, true),
+            };
+            let _ = on_event.send(AiChatEvent::ToolResult {
+                id: id.clone(),
+                name: name.clone(),
+                preview: preview(&content),
+                is_error,
+            });
+            result_blocks.push(ChatBlock::ToolResult {
+                tool_use_id: id,
+                name,
+                content,
+                is_error,
+            });
+        }
+        let results = ChatMessage {
+            role: "user".into(),
+            blocks: result_blocks,
+        };
+        conversation.push(results.clone());
+        new_messages.push(results);
+    }
+
+    Ok(new_messages)
+}

--- a/src-tauri/src/ai_chat/openai.rs
+++ b/src-tauri/src/ai_chat/openai.rs
@@ -1,5 +1,6 @@
-//! OpenAI Chat Completions client (raw HTTP). Streams tool-call and text
-//! deltas and reassembles them into the shared `AssistantTurn` shape.
+//! OpenAI Chat Completions client (raw HTTP). Also serves any
+//! OpenAI-compatible server (LM Studio, Ollama, …) via a custom base URL.
+//! Streams tool-call and text deltas into the shared `AssistantTurn` shape.
 
 use std::collections::BTreeMap;
 
@@ -8,7 +9,16 @@ use serde_json::{json, Value};
 use super::sse::{ensure_success, read_sse};
 use super::types::{AssistantTurn, ChatBlock, ChatMessage, EventSink, ToolDef};
 
-const API_URL: &str = "https://api.openai.com/v1/chat/completions";
+pub const OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+
+/// Where to send Chat Completions requests. `api_key` may be empty for
+/// local servers that don't authenticate.
+pub struct OpenAiCompat<'a> {
+    pub base_url: &'a str,
+    pub api_key: &'a str,
+    /// Provider name used in error messages ("OpenAI", "LM Studio").
+    pub label: &'a str,
+}
 
 /// One chat message can expand to several OpenAI messages: tool results must
 /// be their own `role: "tool"` messages.
@@ -85,7 +95,7 @@ struct ToolCallAcc {
 
 pub async fn stream_chat(
     client: &reqwest::Client,
-    api_key: &str,
+    target: &OpenAiCompat<'_>,
     model: &str,
     system: &str,
     messages: &[ChatMessage],
@@ -111,14 +121,16 @@ pub async fn stream_chat(
         })).collect::<Vec<_>>(),
     });
 
-    let response = client
-        .post(API_URL)
-        .bearer_auth(api_key)
-        .json(&body)
+    let url = format!("{}/chat/completions", target.base_url.trim_end_matches('/'));
+    let mut request = client.post(&url).json(&body);
+    if !target.api_key.is_empty() {
+        request = request.bearer_auth(target.api_key);
+    }
+    let response = request
         .send()
         .await
-        .map_err(|e| format!("OpenAI request failed: {e}"))?;
-    let response = ensure_success(response, "OpenAI").await?;
+        .map_err(|e| format!("{} request failed: {e}", target.label))?;
+    let response = ensure_success(response, target.label).await?;
 
     let mut text = String::new();
     let mut tool_accs: BTreeMap<u64, ToolCallAcc> = BTreeMap::new();
@@ -128,9 +140,9 @@ pub async fn stream_chat(
             return Ok(false);
         }
         let data: Value = serde_json::from_str(&event.data)
-            .map_err(|e| format!("OpenAI sent invalid JSON: {e}"))?;
+            .map_err(|e| format!("{} sent invalid JSON: {e}", target.label))?;
         if let Some(error) = data.get("error") {
-            return Err(format!("OpenAI stream error: {error}"));
+            return Err(format!("{} stream error: {error}", target.label));
         }
         let delta = &data["choices"][0]["delta"];
         if let Some(t) = delta["content"].as_str() {

--- a/src-tauri/src/ai_chat/openai.rs
+++ b/src-tauri/src/ai_chat/openai.rs
@@ -1,0 +1,188 @@
+//! OpenAI Chat Completions client (raw HTTP). Streams tool-call and text
+//! deltas and reassembles them into the shared `AssistantTurn` shape.
+
+use std::collections::BTreeMap;
+
+use serde_json::{json, Value};
+
+use super::sse::{ensure_success, read_sse};
+use super::types::{AssistantTurn, ChatBlock, ChatMessage, EventSink, ToolDef};
+
+const API_URL: &str = "https://api.openai.com/v1/chat/completions";
+
+/// One chat message can expand to several OpenAI messages: tool results must
+/// be their own `role: "tool"` messages.
+fn to_api_messages(message: &ChatMessage, out: &mut Vec<Value>) {
+    if message.role == "assistant" {
+        let mut text = String::new();
+        let mut tool_calls: Vec<Value> = Vec::new();
+        for block in &message.blocks {
+            match block {
+                ChatBlock::Text { text: t } => text.push_str(t),
+                ChatBlock::ToolUse { id, name, input } => tool_calls.push(json!({
+                    "id": id,
+                    "type": "function",
+                    "function": { "name": name, "arguments": input.to_string() }
+                })),
+                _ => {}
+            }
+        }
+        let mut msg = json!({ "role": "assistant" });
+        msg["content"] = if text.is_empty() {
+            Value::Null
+        } else {
+            Value::String(text)
+        };
+        if !tool_calls.is_empty() {
+            msg["tool_calls"] = Value::Array(tool_calls);
+        }
+        out.push(msg);
+        return;
+    }
+
+    let mut parts: Vec<Value> = Vec::new();
+    for block in &message.blocks {
+        match block {
+            ChatBlock::Text { text } => parts.push(json!({ "type": "text", "text": text })),
+            ChatBlock::Image { media_type, data } => parts.push(json!({
+                "type": "image_url",
+                "image_url": { "url": format!("data:{media_type};base64,{data}") }
+            })),
+            ChatBlock::Document {
+                media_type,
+                data,
+                name,
+            } => parts.push(json!({
+                "type": "file",
+                "file": {
+                    "filename": name,
+                    "file_data": format!("data:{media_type};base64,{data}")
+                }
+            })),
+            ChatBlock::ToolResult {
+                tool_use_id,
+                content,
+                ..
+            } => out.push(json!({
+                "role": "tool",
+                "tool_call_id": tool_use_id,
+                "content": content
+            })),
+            ChatBlock::ToolUse { .. } => {}
+        }
+    }
+    if !parts.is_empty() {
+        out.push(json!({ "role": "user", "content": parts }));
+    }
+}
+
+#[derive(Default)]
+struct ToolCallAcc {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+pub async fn stream_chat(
+    client: &reqwest::Client,
+    api_key: &str,
+    model: &str,
+    system: &str,
+    messages: &[ChatMessage],
+    tools: &[ToolDef],
+    on_event: EventSink<'_>,
+) -> Result<AssistantTurn, String> {
+    let mut api_messages = vec![json!({ "role": "system", "content": system })];
+    for message in messages {
+        to_api_messages(message, &mut api_messages);
+    }
+
+    let body = json!({
+        "model": model,
+        "stream": true,
+        "messages": api_messages,
+        "tools": tools.iter().map(|t| json!({
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.input_schema,
+            }
+        })).collect::<Vec<_>>(),
+    });
+
+    let response = client
+        .post(API_URL)
+        .bearer_auth(api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("OpenAI request failed: {e}"))?;
+    let response = ensure_success(response, "OpenAI").await?;
+
+    let mut text = String::new();
+    let mut tool_accs: BTreeMap<u64, ToolCallAcc> = BTreeMap::new();
+
+    read_sse(response, |event| {
+        if event.data.trim() == "[DONE]" {
+            return Ok(false);
+        }
+        let data: Value = serde_json::from_str(&event.data)
+            .map_err(|e| format!("OpenAI sent invalid JSON: {e}"))?;
+        if let Some(error) = data.get("error") {
+            return Err(format!("OpenAI stream error: {error}"));
+        }
+        let delta = &data["choices"][0]["delta"];
+        if let Some(t) = delta["content"].as_str() {
+            if !t.is_empty() {
+                text.push_str(t);
+                on_event(super::types::AiChatEvent::TextDelta {
+                    text: t.to_string(),
+                });
+            }
+        }
+        if let Some(calls) = delta["tool_calls"].as_array() {
+            for call in calls {
+                let index = call["index"].as_u64().unwrap_or(0);
+                let acc = tool_accs.entry(index).or_default();
+                if let Some(id) = call["id"].as_str() {
+                    acc.id.push_str(id);
+                }
+                if let Some(name) = call["function"]["name"].as_str() {
+                    acc.name.push_str(name);
+                }
+                if let Some(args) = call["function"]["arguments"].as_str() {
+                    acc.arguments.push_str(args);
+                }
+            }
+        }
+        Ok(true)
+    })
+    .await?;
+
+    let mut blocks: Vec<ChatBlock> = Vec::new();
+    if !text.is_empty() {
+        blocks.push(ChatBlock::Text { text });
+    }
+    for (index, acc) in tool_accs {
+        let id = if acc.id.is_empty() {
+            format!("call_{index}")
+        } else {
+            acc.id
+        };
+        let input: Value = serde_json::from_str(&acc.arguments)
+            .unwrap_or_else(|_| Value::Object(Default::default()));
+        on_event(super::types::AiChatEvent::ToolCall {
+            id: id.clone(),
+            name: acc.name.clone(),
+            input: input.clone(),
+        });
+        blocks.push(ChatBlock::ToolUse {
+            id,
+            name: acc.name,
+            input,
+        });
+    }
+
+    Ok(AssistantTurn { blocks })
+}

--- a/src-tauri/src/ai_chat/settings.rs
+++ b/src-tauri/src/ai_chat/settings.rs
@@ -10,6 +10,7 @@ use tauri::Manager;
 pub const DEFAULT_ANTHROPIC_MODEL: &str = "claude-opus-4-8";
 pub const DEFAULT_OPENAI_MODEL: &str = "gpt-5.1";
 pub const DEFAULT_GOOGLE_MODEL: &str = "gemini-2.5-pro";
+pub const DEFAULT_LMSTUDIO_BASE_URL: &str = "http://localhost:1234/v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
@@ -21,6 +22,10 @@ pub struct AiSettings {
     pub anthropic_model: String,
     pub openai_model: String,
     pub google_model: String,
+    /// OpenAI-compatible local server (LM Studio / Ollama). No API key needed.
+    pub lmstudio_base_url: String,
+    /// Model id as shown in LM Studio; empty until the user sets one.
+    pub lmstudio_model: String,
 }
 
 impl AiSettings {
@@ -36,6 +41,9 @@ impl AiSettings {
         }
         if self.google_model.is_empty() {
             self.google_model = DEFAULT_GOOGLE_MODEL.into();
+        }
+        if self.lmstudio_base_url.is_empty() {
+            self.lmstudio_base_url = DEFAULT_LMSTUDIO_BASE_URL.into();
         }
         self
     }

--- a/src-tauri/src/ai_chat/settings.rs
+++ b/src-tauri/src/ai_chat/settings.rs
@@ -22,10 +22,12 @@ pub struct AiSettings {
     pub anthropic_model: String,
     pub openai_model: String,
     pub google_model: String,
-    /// OpenAI-compatible local server (LM Studio / Ollama). No API key needed.
+    /// OpenAI-compatible local server (LM Studio / Ollama).
     pub lmstudio_base_url: String,
     /// Model id as shown in LM Studio; empty until the user sets one.
     pub lmstudio_model: String,
+    /// Optional — only needed when the local server has auth enabled.
+    pub lmstudio_api_key: String,
 }
 
 impl AiSettings {
@@ -53,6 +55,7 @@ impl AiSettings {
             "anthropic" => &self.anthropic_api_key,
             "openai" => &self.openai_api_key,
             "google" => &self.google_api_key,
+            "lmstudio" => &self.lmstudio_api_key,
             _ => "",
         }
     }

--- a/src-tauri/src/ai_chat/settings.rs
+++ b/src-tauri/src/ai_chat/settings.rs
@@ -1,0 +1,83 @@
+//! AI provider settings (API keys, default models). Stored as JSON in the
+//! app config dir — keys stay on the user's machine and never touch Supabase.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+
+pub const DEFAULT_ANTHROPIC_MODEL: &str = "claude-opus-4-8";
+pub const DEFAULT_OPENAI_MODEL: &str = "gpt-5.1";
+pub const DEFAULT_GOOGLE_MODEL: &str = "gemini-2.5-pro";
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct AiSettings {
+    pub default_provider: String,
+    pub anthropic_api_key: String,
+    pub openai_api_key: String,
+    pub google_api_key: String,
+    pub anthropic_model: String,
+    pub openai_model: String,
+    pub google_model: String,
+}
+
+impl AiSettings {
+    fn with_defaults(mut self) -> Self {
+        if self.default_provider.is_empty() {
+            self.default_provider = "anthropic".into();
+        }
+        if self.anthropic_model.is_empty() {
+            self.anthropic_model = DEFAULT_ANTHROPIC_MODEL.into();
+        }
+        if self.openai_model.is_empty() {
+            self.openai_model = DEFAULT_OPENAI_MODEL.into();
+        }
+        if self.google_model.is_empty() {
+            self.google_model = DEFAULT_GOOGLE_MODEL.into();
+        }
+        self
+    }
+
+    pub fn api_key_for(&self, provider: &str) -> &str {
+        match provider {
+            "anthropic" => &self.anthropic_api_key,
+            "openai" => &self.openai_api_key,
+            "google" => &self.google_api_key,
+            _ => "",
+        }
+    }
+}
+
+fn settings_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|e| format!("Cannot resolve app config dir: {e}"))?;
+    fs::create_dir_all(&dir).map_err(|e| format!("Cannot create config dir: {e}"))?;
+    Ok(dir.join("ai-settings.json"))
+}
+
+pub fn load(app: &tauri::AppHandle) -> Result<AiSettings, String> {
+    let path = settings_path(app)?;
+    let settings = match fs::read_to_string(&path) {
+        Ok(raw) => serde_json::from_str::<AiSettings>(&raw)
+            .map_err(|e| format!("Corrupt AI settings file: {e}"))?,
+        Err(_) => AiSettings::default(),
+    };
+    Ok(settings.with_defaults())
+}
+
+#[tauri::command]
+pub fn get_ai_settings(app: tauri::AppHandle) -> Result<AiSettings, String> {
+    load(&app)
+}
+
+#[tauri::command]
+pub fn save_ai_settings(app: tauri::AppHandle, settings: AiSettings) -> Result<(), String> {
+    let path = settings_path(&app)?;
+    let raw = serde_json::to_string_pretty(&settings.with_defaults())
+        .map_err(|e| format!("Cannot serialize settings: {e}"))?;
+    fs::write(&path, raw).map_err(|e| format!("Cannot write settings file: {e}"))
+}

--- a/src-tauri/src/ai_chat/sse.rs
+++ b/src-tauri/src/ai_chat/sse.rs
@@ -1,0 +1,74 @@
+//! Minimal Server-Sent-Events reader over a `reqwest` byte stream. All three
+//! provider APIs stream SSE; only the `event:` and `data:` fields matter.
+
+use futures_util::StreamExt;
+
+pub struct SseEvent {
+    #[allow(dead_code)]
+    pub event: Option<String>,
+    pub data: String,
+}
+
+/// Reads the response body as SSE, invoking `on_event` for each complete
+/// event. The callback returns `Ok(false)` to stop reading early.
+pub async fn read_sse(
+    response: reqwest::Response,
+    mut on_event: impl FnMut(SseEvent) -> Result<bool, String>,
+) -> Result<(), String> {
+    let mut stream = response.bytes_stream();
+    let mut buf: Vec<u8> = Vec::new();
+    let mut event_name: Option<String> = None;
+    let mut data_lines: Vec<String> = Vec::new();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("Stream read error: {e}"))?;
+        buf.extend_from_slice(&chunk);
+
+        while let Some(pos) = buf.iter().position(|&b| b == b'\n') {
+            let line_bytes: Vec<u8> = buf.drain(..=pos).collect();
+            let line = String::from_utf8_lossy(&line_bytes);
+            let line = line.trim_end_matches(['\n', '\r']);
+
+            if line.is_empty() {
+                if !data_lines.is_empty() {
+                    let keep_going = on_event(SseEvent {
+                        event: event_name.take(),
+                        data: data_lines.join("\n"),
+                    })?;
+                    data_lines.clear();
+                    if !keep_going {
+                        return Ok(());
+                    }
+                } else {
+                    event_name = None;
+                }
+            } else if let Some(rest) = line.strip_prefix("event:") {
+                event_name = Some(rest.trim().to_string());
+            } else if let Some(rest) = line.strip_prefix("data:") {
+                data_lines.push(rest.strip_prefix(' ').unwrap_or(rest).to_string());
+            }
+        }
+    }
+
+    if !data_lines.is_empty() {
+        on_event(SseEvent {
+            event: event_name.take(),
+            data: data_lines.join("\n"),
+        })?;
+    }
+    Ok(())
+}
+
+/// Shared pre-flight: bail with the response body when the request failed
+/// (provider errors arrive as JSON bodies with non-2xx status).
+pub async fn ensure_success(
+    response: reqwest::Response,
+    provider: &str,
+) -> Result<reqwest::Response, String> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body = response.text().await.unwrap_or_default();
+    Err(format!("{provider} API error ({status}): {body}"))
+}

--- a/src-tauri/src/ai_chat/tools.rs
+++ b/src-tauri/src/ai_chat/tools.rs
@@ -1,0 +1,300 @@
+//! Database tools exposed to the model, executed against Supabase's
+//! PostgREST endpoint with the signed-in user's JWT so RLS applies exactly
+//! as it does for the rest of the app.
+
+use serde_json::{json, Value};
+
+use super::types::ToolDef;
+
+/// Read-only relations the model may query. Anything else is rejected.
+const ALLOWED_RELATIONS: &[&str] = &[
+    "deal_computed",
+    "monthly_vintage_stats",
+    "portfolio_monthly",
+    "weekly_rtr_matrix",
+    "funder_allocation_current",
+    "deal_payments",
+    "deals",
+    "merchants",
+    "funders",
+    "portfolios",
+    "portfolio_funders",
+    "industries",
+    "states",
+    "net_rtr_payments",
+    "funder_uploads",
+];
+
+const ALLOWED_OPS: &[&str] = &[
+    "eq", "neq", "gt", "gte", "lt", "lte", "like", "ilike", "in", "is",
+];
+
+const MAX_RESULT_CHARS: usize = 35_000;
+const MAX_LIMIT: u64 = 1000;
+const DEFAULT_LIMIT: u64 = 100;
+
+pub struct SupabaseCtx {
+    pub client: reqwest::Client,
+    pub url: String,
+    pub anon_key: String,
+    pub access_token: String,
+}
+
+pub fn tool_defs() -> Vec<ToolDef> {
+    let filter_schema = json!({
+        "type": "array",
+        "description": "Filters ANDed together. Values are always strings: numbers as '125000', dates as '2024-03-01', booleans as 'true'. For op 'in' pass a comma-separated list; for 'like'/'ilike' use * as the wildcard; for 'is' pass 'null', 'true' or 'false'.",
+        "items": {
+            "type": "object",
+            "properties": {
+                "column": { "type": "string", "description": "Column name" },
+                "op": { "type": "string", "enum": ALLOWED_OPS },
+                "value": { "type": "string", "description": "Filter value encoded as a string" }
+            },
+            "required": ["column", "op", "value"]
+        }
+    });
+
+    vec![
+        ToolDef {
+            name: "query_data",
+            description: "Query rows from a table or analytics view in the Excelerate portfolio database. Returns matching rows as JSON plus the total row count. Prefer the analytics views (deal_computed, portfolio_monthly, monthly_vintage_stats, ...) — they contain the derived metrics. Use small limits and select only needed columns for wide relations.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "relation": {
+                        "type": "string",
+                        "enum": ALLOWED_RELATIONS,
+                        "description": "Table or view to query"
+                    },
+                    "select": {
+                        "type": "string",
+                        "description": "Comma-separated columns to return (default: all)"
+                    },
+                    "filters": filter_schema.clone(),
+                    "order_by": { "type": "string", "description": "Column to sort by" },
+                    "descending": { "type": "boolean", "description": "Sort descending (default false)" },
+                    "limit": { "type": "integer", "description": "Max rows to return, 1-1000 (default 100)" }
+                },
+                "required": ["relation"]
+            }),
+        },
+        ToolDef {
+            name: "count_rows",
+            description: "Count the rows in a table or view matching the given filters, without returning row data. Use this before large queries or to answer 'how many' questions.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "relation": {
+                        "type": "string",
+                        "enum": ALLOWED_RELATIONS,
+                        "description": "Table or view to count"
+                    },
+                    "filters": filter_schema
+                },
+                "required": ["relation"]
+            }),
+        },
+    ]
+}
+
+/// System prompt: role, schema reference, and tool guidance. Kept static so
+/// provider-side prompt caching can apply.
+pub fn system_prompt() -> String {
+    let today = chrono::Local::now().format("%Y-%m-%d");
+    format!(
+        r#"You are the AI assistant inside Excelerate, a desktop app for managing MCA (Merchant Cash Advance) participation portfolios. You answer questions about the user's portfolio data by querying their database with the provided tools, and you help analyze files they upload.
+
+Today's date: {today}.
+
+# Database reference (PostgreSQL via Supabase; all reads are scoped to the signed-in user's portfolios by row-level security)
+
+Core tables:
+- portfolios(id, name, profit_share_rate, dividend_rate) — the participation portfolios (e.g. Alder, White Rabbit).
+- funders(id, name, code, sheet_name) — MCA funders the portfolios participate with.
+- portfolio_funders(portfolio_id, funder_id, management_fee_rate).
+- merchants(id, name, industry_id, state_id, website, funder_id, portfolio_id).
+- deals(id, merchant_id, portfolio_id, funder_id, advance_id, funder_advance_id, fico, buy_rate, commission, total_amount_funded, num_daily_payments, num_weekly_payments, deal_length_months, participation_on_amount, new_dollars, rtr, is_default, date_funded, date_closed, default_date) — deal inputs only; derived metrics live in deal_computed.
+- net_rtr_payments(id, deal_id, payment_date, gross, fee, net) — payment history per deal.
+- funder_uploads(id, portfolio_id, funder_id, report_date, original_filename, created_at) — monthly report uploads.
+- industries(id, name), states(id, code, name) — lookups for merchants.
+
+Analytics views (prefer these — they implement the portfolio math):
+- deal_computed — one row per deal with derived metrics: vintage_month, sell_rate, commission_dollars, total_rtr, term_months, rh_pct_of_deal, cost_basis, net_rtr, all_in_factor, points_per_month, total_net_received, net_rtr_balance, pct_rtr_paid, return_on_cost_basis, bad_debt_rtr, default_dollars_lost, plus the deal input columns.
+- monthly_vintage_stats — per portfolio_id × funder_id × vintage_month: deal_count, new_invested, rtr_invested, cost_basis, initial_net_rtr, weighted_avg_factor, rtr_received, principal_returned, profit_returned, net_rtr_outstanding, bad_debt_rtr, net_rtr_outstanding_after_bad_debt, weighted_avg_term_months, vintage_return, bad_debt_pct, points_per_month, profit_share.
+- portfolio_monthly — same metrics rolled up per portfolio_id × vintage_month (plus profit_share_rate, dividend_rate).
+- weekly_rtr_matrix — per portfolio_id × funder_id × payment_date: total_gross, total_fee, total_net.
+- funder_allocation_current — current allocation snapshot per portfolio_id × funder_id: initial_cost_basis, current_cost_basis, rtr_received, factor, pct_current_cost_basis.
+- deal_payments — per deal_id × payment_date payment rows with portfolio_id/funder_id scope.
+
+# How to work
+- Resolve names first: portfolio and funder names live in `portfolios` and `funders`; most other relations reference them by portfolio_id/funder_id.
+- Dates are ISO strings (YYYY-MM-DD); vintage_month is the first day of the month. Money columns are numeric dollars; rates/factors are decimals.
+- Use count_rows for "how many" questions and to gauge result sizes; keep query_data limits small and select only the columns you need on wide relations like deal_computed.
+- When the user uploads a spreadsheet/CSV its contents appear as text in the conversation; PDFs and images are attached natively.
+- Present results clearly: use markdown tables for tabular answers, state the portfolio/funder scope you used, and round money to cents. If a query returns nothing, say so and suggest what to check.
+- You have read-only access. You cannot modify data; if asked to, explain that changes are made through the app's pages."#
+    )
+}
+
+fn valid_ident(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Builds the PostgREST query string pieces shared by both tools.
+fn build_params(input: &Value) -> Result<Vec<(String, String)>, String> {
+    let mut params: Vec<(String, String)> = Vec::new();
+
+    if let Some(filters) = input["filters"].as_array() {
+        for filter in filters {
+            let column = filter["column"].as_str().unwrap_or_default();
+            let op = filter["op"].as_str().unwrap_or_default();
+            let value = match &filter["value"] {
+                Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            if !valid_ident(column) {
+                return Err(format!("Invalid filter column: {column:?}"));
+            }
+            if !ALLOWED_OPS.contains(&op) {
+                return Err(format!("Invalid filter op: {op:?}"));
+            }
+            let rhs = if op == "in" {
+                let list = value
+                    .split(',')
+                    .map(|v| {
+                        let v = v.trim();
+                        if v.parse::<f64>().is_ok() {
+                            v.to_string()
+                        } else {
+                            format!("\"{}\"", v.replace('"', ""))
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("in.({list})")
+            } else {
+                format!("{op}.{value}")
+            };
+            params.push((column.to_string(), rhs));
+        }
+    }
+    Ok(params)
+}
+
+fn relation_from(input: &Value) -> Result<&str, String> {
+    let relation = input["relation"].as_str().unwrap_or_default();
+    if !ALLOWED_RELATIONS.contains(&relation) {
+        return Err(format!(
+            "Unknown relation {relation:?}. Allowed: {}",
+            ALLOWED_RELATIONS.join(", ")
+        ));
+    }
+    Ok(relation)
+}
+
+async fn send_query(
+    ctx: &SupabaseCtx,
+    relation: &str,
+    params: &[(String, String)],
+) -> Result<(u64, Value), String> {
+    let url = format!("{}/rest/v1/{}", ctx.url.trim_end_matches('/'), relation);
+    let response = ctx
+        .client
+        .get(&url)
+        .query(params)
+        .header("apikey", &ctx.anon_key)
+        .bearer_auth(&ctx.access_token)
+        .header("Prefer", "count=exact")
+        .send()
+        .await
+        .map_err(|e| format!("Database request failed: {e}"))?;
+
+    let status = response.status();
+    let total = response
+        .headers()
+        .get("content-range")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.rsplit('/').next().map(str::to_string))
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0);
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read database response: {e}"))?;
+    if !status.is_success() {
+        return Err(format!("Database error ({status}): {body}"));
+    }
+    let rows: Value =
+        serde_json::from_str(&body).map_err(|e| format!("Invalid database response: {e}"))?;
+    Ok((total, rows))
+}
+
+pub async fn execute_tool(name: &str, input: &Value, ctx: &SupabaseCtx) -> Result<String, String> {
+    match name {
+        "query_data" => {
+            let relation = relation_from(input)?;
+            let mut params = build_params(input)?;
+
+            let select = input["select"].as_str().unwrap_or("*").trim();
+            let select_ok = select == "*" || select.split(',').all(|c| valid_ident(c.trim()));
+            if !select_ok {
+                return Err(format!("Invalid select list: {select:?}"));
+            }
+            params.push(("select".into(), select.to_string()));
+
+            if let Some(order_by) = input["order_by"].as_str() {
+                if !valid_ident(order_by) {
+                    return Err(format!("Invalid order_by column: {order_by:?}"));
+                }
+                let dir = if input["descending"].as_bool().unwrap_or(false) {
+                    "desc"
+                } else {
+                    "asc"
+                };
+                params.push(("order".into(), format!("{order_by}.{dir}")));
+            }
+
+            let limit = input["limit"]
+                .as_u64()
+                .unwrap_or(DEFAULT_LIMIT)
+                .clamp(1, MAX_LIMIT);
+            params.push(("limit".into(), limit.to_string()));
+
+            let (total, rows) = send_query(ctx, relation, &params).await?;
+            let all_rows = rows.as_array().cloned().unwrap_or_default();
+
+            // Keep tool results bounded so they don't blow up the context.
+            let mut kept: Vec<Value> = Vec::new();
+            let mut size = 0usize;
+            let mut truncated = false;
+            for row in &all_rows {
+                let s = row.to_string();
+                if size + s.len() > MAX_RESULT_CHARS && !kept.is_empty() {
+                    truncated = true;
+                    break;
+                }
+                size += s.len();
+                kept.push(row.clone());
+            }
+
+            let result = json!({
+                "relation": relation,
+                "total_matching_rows": total,
+                "returned_rows": kept.len(),
+                "truncated_for_size": truncated,
+                "rows": kept,
+            });
+            Ok(result.to_string())
+        }
+        "count_rows" => {
+            let relation = relation_from(input)?;
+            let mut params = build_params(input)?;
+            params.push(("select".into(), "*".into()));
+            params.push(("limit".into(), "1".into()));
+            let (total, _) = send_query(ctx, relation, &params).await?;
+            Ok(json!({ "relation": relation, "total_matching_rows": total }).to_string())
+        }
+        other => Err(format!("Unknown tool: {other}")),
+    }
+}

--- a/src-tauri/src/ai_chat/types.rs
+++ b/src-tauri/src/ai_chat/types.rs
@@ -1,0 +1,99 @@
+//! Provider-agnostic chat types shared by the AI chat commands, the three
+//! provider clients, and the frontend (mirrored in `src/services/ai-chat-service.ts`).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// One piece of a chat message. The union covers everything the three
+/// providers need: plain text, inline images/documents, and the tool-use /
+/// tool-result pairs produced by the agent loop.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ChatBlock {
+    Text {
+        text: String,
+    },
+    /// Base64-encoded image (png/jpeg/gif/webp).
+    Image {
+        media_type: String,
+        data: String,
+    },
+    /// Base64-encoded document (currently always application/pdf).
+    Document {
+        media_type: String,
+        data: String,
+        name: String,
+    },
+    /// A tool call requested by the assistant.
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    /// The result for one tool call, sent back in a user-role message.
+    ToolResult {
+        tool_use_id: String,
+        name: String,
+        content: String,
+        is_error: bool,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    /// "user" or "assistant".
+    pub role: String,
+    pub blocks: Vec<ChatBlock>,
+}
+
+/// Everything the frontend sends for one turn. The Rust side is stateless:
+/// the full history comes in, the newly generated messages go back out.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AiChatRequest {
+    /// "anthropic" | "openai" | "google".
+    pub provider: String,
+    pub model: String,
+    pub messages: Vec<ChatMessage>,
+    pub supabase_url: String,
+    pub supabase_anon_key: String,
+    pub supabase_access_token: String,
+}
+
+/// Live streaming events pushed to the frontend over a Tauri channel while a
+/// turn is in flight. The canonical messages are returned by the command.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AiChatEvent {
+    TextDelta {
+        text: String,
+    },
+    ToolCall {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    ToolResult {
+        id: String,
+        name: String,
+        preview: String,
+        is_error: bool,
+    },
+    /// One assistant API turn finished (more may follow after tool calls).
+    TurnComplete,
+}
+
+/// Callback used by provider clients to surface streaming events.
+pub type EventSink<'a> = &'a mut (dyn FnMut(AiChatEvent) + Send);
+
+/// A tool exposed to the model. `input_schema` is a plain JSON Schema object
+/// kept to the subset all three providers accept.
+pub struct ToolDef {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub input_schema: Value,
+}
+
+/// The blocks of one completed assistant turn (text + tool calls).
+pub struct AssistantTurn {
+    pub blocks: Vec<ChatBlock>,
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod ai_chat;
 mod funder_pivot;
 mod notification;
 pub mod parsers;
@@ -13,7 +14,11 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             funder_pivot::parse_funder_pivot,
             workbook_import::parse_portfolio_workbook,
-            workbook_export::export_portfolio_workbook
+            workbook_export::export_portfolio_workbook,
+            ai_chat::ai_chat_stream,
+            ai_chat::settings::get_ai_settings,
+            ai_chat::settings::save_ai_settings,
+            ai_chat::attachments::prepare_chat_attachment
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,6 +5,7 @@ import Dashboard from "@pages/dashboard";
 import AlderPortfolio from "@pages/alder-portfolio";
 import WhiteRabbitPortfolio from "@pages/white-rabbit-portfolio";
 import DealLookup from "@pages/deal-lookup";
+import AiChat from "@pages/ai-chat";
 import Settings from "@pages/settings";
 import Login from "@pages/login";
 import { ProtectedRoute } from "@components/auth/protected-route";
@@ -42,6 +43,7 @@ function App() {
         <Route path="alder-portfolio" element={<AlderPortfolio />} />
         <Route path="white-rabbit-portfolio" element={<WhiteRabbitPortfolio />} />
         <Route path="deal-lookup" element={<DealLookup />} />
+        <Route path="ai-chat" element={<AiChat />} />
         <Route path="settings" element={<Settings />} />
       </Route>
     </Routes>

--- a/src/components/ai-chat/chat-message-view.tsx
+++ b/src/components/ai-chat/chat-message-view.tsx
@@ -1,0 +1,193 @@
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Chip, Spinner } from "@heroui/react";
+import { Icon } from "@iconify/react";
+import type { ChatBlock, ChatMessage } from "@services/ai-chat-service";
+
+/** react-markdown passes a `node` prop that must not reach the DOM. */
+function strip<T extends { node?: unknown }>(props: T) {
+  const { node: _ignored, ...rest } = props;
+  void _ignored;
+  return rest;
+}
+
+const markdownComponents: Components = {
+  p: (props) => <p className="mb-2 last:mb-0" {...strip(props)} />,
+  ul: (props) => <ul className="mb-2 list-disc pl-5" {...strip(props)} />,
+  ol: (props) => <ol className="mb-2 list-decimal pl-5" {...strip(props)} />,
+  li: (props) => <li className="mb-0.5" {...strip(props)} />,
+  h1: (props) => <h1 className="mb-2 mt-3 text-lg font-bold first:mt-0" {...strip(props)} />,
+  h2: (props) => <h2 className="mb-2 mt-3 text-base font-bold first:mt-0" {...strip(props)} />,
+  h3: (props) => <h3 className="mb-1 mt-2 text-sm font-bold first:mt-0" {...strip(props)} />,
+  a: (props) => (
+    <a className="text-primary underline" target="_blank" rel="noreferrer" {...strip(props)} />
+  ),
+  table: (props) => (
+    <div className="my-2 overflow-x-auto">
+      <table className="w-full border-collapse text-xs" {...strip(props)} />
+    </div>
+  ),
+  th: (props) => (
+    <th
+      className="border border-default-300 bg-default-100 px-2 py-1 text-left font-semibold"
+      {...strip(props)}
+    />
+  ),
+  td: (props) => <td className="border border-default-200 px-2 py-1" {...strip(props)} />,
+  pre: (props) => (
+    <pre
+      className="mb-2 overflow-x-auto rounded-medium bg-default-100 p-3 text-xs"
+      {...strip(props)}
+    />
+  ),
+  code: (props) => <code className="rounded bg-default-100 px-1 text-xs" {...strip(props)} />,
+  blockquote: (props) => (
+    <blockquote className="mb-2 border-l-2 border-default-300 pl-3" {...strip(props)} />
+  ),
+};
+
+export function Markdown({ text }: { text: string }) {
+  return (
+    <div className="text-small leading-relaxed">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+        {text}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+const ATTACHMENT_TEXT_RE = /^Contents of uploaded file "(.+?)":/;
+
+function ToolChip({ name, detail, isError }: { name: string; detail?: string; isError?: boolean }) {
+  return (
+    <Chip
+      size="sm"
+      variant="flat"
+      color={isError ? "danger" : "default"}
+      startContent={<Icon icon="solar:database-outline" width={14} />}
+      className="max-w-full"
+    >
+      <span className="font-mono text-tiny">
+        {name}
+        {detail ? ` ${detail}` : ""}
+      </span>
+    </Chip>
+  );
+}
+
+function summarizeToolInput(input: unknown): string {
+  if (input && typeof input === "object") {
+    const record = input as Record<string, unknown>;
+    if (typeof record.relation === "string") return `· ${record.relation}`;
+  }
+  return "";
+}
+
+function UserBlock({ block }: { block: ChatBlock }) {
+  if (block.kind === "text") {
+    const attachment = block.text.match(ATTACHMENT_TEXT_RE);
+    if (attachment) {
+      return (
+        <Chip
+          size="sm"
+          variant="flat"
+          color="secondary"
+          startContent={<Icon icon="solar:paperclip-outline" width={14} />}
+        >
+          {attachment[1]}
+        </Chip>
+      );
+    }
+    return <p className="whitespace-pre-wrap text-small">{block.text}</p>;
+  }
+  if (block.kind === "image") {
+    return (
+      <img
+        src={`data:${block.media_type};base64,${block.data}`}
+        alt="Attached image"
+        className="max-h-48 rounded-medium"
+      />
+    );
+  }
+  if (block.kind === "document") {
+    return (
+      <Chip
+        size="sm"
+        variant="flat"
+        color="secondary"
+        startContent={<Icon icon="solar:document-outline" width={14} />}
+      >
+        {block.name}
+      </Chip>
+    );
+  }
+  return null;
+}
+
+/** True when a user-role message only carries tool results (loop plumbing). */
+export function isToolResultMessage(message: ChatMessage): boolean {
+  return (
+    message.role === "user" &&
+    message.blocks.length > 0 &&
+    message.blocks.every((block) => block.kind === "tool_result")
+  );
+}
+
+export function MessageView({ message }: { message: ChatMessage }) {
+  if (isToolResultMessage(message)) {
+    return null; // tool activity is already shown via the assistant's chips
+  }
+
+  if (message.role === "user") {
+    return (
+      <div className="flex justify-end">
+        <div className="flex max-w-[75%] flex-col items-end gap-1 rounded-large bg-primary-50 px-4 py-2">
+          {message.blocks.map((block, i) => (
+            <UserBlock key={i} block={block} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex justify-start">
+      <div className="flex max-w-[85%] flex-col gap-2">
+        {message.blocks.map((block, i) => {
+          if (block.kind === "text") return <Markdown key={i} text={block.text} />;
+          if (block.kind === "tool_use") {
+            return (
+              <div key={i}>
+                <ToolChip name={block.name} detail={summarizeToolInput(block.input)} />
+              </div>
+            );
+          }
+          return null;
+        })}
+      </div>
+    </div>
+  );
+}
+
+export type LiveSegment =
+  | { type: "text"; text: string }
+  | { type: "tool"; id: string; name: string; status: "running" | "done" | "error" };
+
+export function LiveMessageView({ segments }: { segments: LiveSegment[] }) {
+  return (
+    <div className="flex justify-start">
+      <div className="flex max-w-[85%] flex-col gap-2">
+        {segments.map((segment, i) => {
+          if (segment.type === "text") return <Markdown key={i} text={segment.text} />;
+          return (
+            <div key={i} className="flex items-center gap-2">
+              <ToolChip name={segment.name} isError={segment.status === "error"} />
+              {segment.status === "running" && <Spinner size="sm" />}
+            </div>
+          );
+        })}
+        {segments.length === 0 && <Spinner size="sm" label="Thinking…" labelColor="foreground" />}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ai-chat/chat-message-view.tsx
+++ b/src/components/ai-chat/chat-message-view.tsx
@@ -1,6 +1,7 @@
+import { useState } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Chip, Spinner } from "@heroui/react";
+import { Button, Chip, Spinner, Tooltip } from "@heroui/react";
 import { Icon } from "@iconify/react";
 import type { ChatBlock, ChatMessage } from "@services/ai-chat-service";
 
@@ -133,7 +134,72 @@ export function isToolResultMessage(message: ChatMessage): boolean {
   );
 }
 
-export function MessageView({ message }: { message: ChatMessage }) {
+/** Concatenated text of an assistant message, for copying to the clipboard. */
+function assistantText(message: ChatMessage): string {
+  return message.blocks
+    .filter((block): block is Extract<ChatBlock, { kind: "text" }> => block.kind === "text")
+    .map((block) => block.text)
+    .join("\n\n")
+    .trim();
+}
+
+function MessageActions({ text, onRetry }: { text: string; onRetry?: () => void }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard access can fail silently; nothing actionable for the user.
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+      {text && (
+        <Tooltip content={copied ? "Copied" : "Copy"}>
+          <Button
+            isIconOnly
+            size="sm"
+            variant="light"
+            onPress={handleCopy}
+            aria-label="Copy response"
+          >
+            <Icon
+              icon={copied ? "solar:check-read-outline" : "solar:copy-outline"}
+              width={16}
+              className={copied ? "text-success" : "text-default-500"}
+            />
+          </Button>
+        </Tooltip>
+      )}
+      {onRetry && (
+        <Tooltip content="Retry">
+          <Button
+            isIconOnly
+            size="sm"
+            variant="light"
+            onPress={onRetry}
+            aria-label="Retry response"
+          >
+            <Icon icon="solar:refresh-outline" width={16} className="text-default-500" />
+          </Button>
+        </Tooltip>
+      )}
+    </div>
+  );
+}
+
+export function MessageView({
+  message,
+  onRetry,
+}: {
+  message: ChatMessage;
+  /** When provided, renders a Retry button that regenerates this response. */
+  onRetry?: () => void;
+}) {
   if (isToolResultMessage(message)) {
     return null; // tool activity is already shown via the assistant's chips
   }
@@ -151,7 +217,7 @@ export function MessageView({ message }: { message: ChatMessage }) {
   }
 
   return (
-    <div className="flex justify-start">
+    <div className="group flex justify-start">
       <div className="flex max-w-[85%] flex-col gap-2">
         {message.blocks.map((block, i) => {
           if (block.kind === "text") return <Markdown key={i} text={block.text} />;
@@ -164,6 +230,7 @@ export function MessageView({ message }: { message: ChatMessage }) {
           }
           return null;
         })}
+        <MessageActions text={assistantText(message)} onRetry={onRetry} />
       </div>
     </div>
   );

--- a/src/components/ai-chat/provider-settings-modal.tsx
+++ b/src/components/ai-chat/provider-settings-modal.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Select,
+  SelectItem,
+} from "@heroui/react";
+import {
+  PROVIDER_LABELS,
+  saveAiSettings,
+  type AiProvider,
+  type AiSettings,
+} from "@services/ai-chat-service";
+import { toast } from "@services/toast-service";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  settings: AiSettings;
+  onSaved: (settings: AiSettings) => void;
+}
+
+export function ProviderSettingsModal({ isOpen, onClose, settings, onSaved }: Props) {
+  const [draft, setDraft] = useState<AiSettings>(settings);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) setDraft(settings);
+  }, [isOpen, settings]);
+
+  const set = (patch: Partial<AiSettings>) => setDraft((d) => ({ ...d, ...patch }));
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await saveAiSettings(draft);
+      onSaved(draft);
+      toast.success("AI settings saved");
+      onClose();
+    } catch (error) {
+      toast.error("Failed to save AI settings", String(error));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg" scrollBehavior="inside">
+      <ModalContent>
+        <ModalHeader>AI Provider Settings</ModalHeader>
+        <ModalBody className="gap-4">
+          <p className="text-tiny text-default-500">
+            API keys are stored locally on this machine and sent only to the selected provider.
+          </p>
+          <Select
+            label="Default provider"
+            selectedKeys={[draft.default_provider]}
+            onSelectionChange={(keys) => {
+              const key = Array.from(keys)[0] as AiProvider | undefined;
+              if (key) set({ default_provider: key });
+            }}
+          >
+            {(Object.keys(PROVIDER_LABELS) as AiProvider[]).map((provider) => (
+              <SelectItem key={provider}>{PROVIDER_LABELS[provider]}</SelectItem>
+            ))}
+          </Select>
+
+          <div className="flex flex-col gap-2">
+            <p className="text-small font-semibold">Anthropic</p>
+            <Input
+              label="API key"
+              type="password"
+              value={draft.anthropic_api_key}
+              onValueChange={(v) => set({ anthropic_api_key: v })}
+              placeholder="sk-ant-…"
+            />
+            <Input
+              label="Model"
+              value={draft.anthropic_model}
+              onValueChange={(v) => set({ anthropic_model: v })}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <p className="text-small font-semibold">OpenAI</p>
+            <Input
+              label="API key"
+              type="password"
+              value={draft.openai_api_key}
+              onValueChange={(v) => set({ openai_api_key: v })}
+              placeholder="sk-…"
+            />
+            <Input
+              label="Model"
+              value={draft.openai_model}
+              onValueChange={(v) => set({ openai_model: v })}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <p className="text-small font-semibold">Google</p>
+            <Input
+              label="API key"
+              type="password"
+              value={draft.google_api_key}
+              onValueChange={(v) => set({ google_api_key: v })}
+              placeholder="AIza…"
+            />
+            <Input
+              label="Model"
+              value={draft.google_model}
+              onValueChange={(v) => set({ google_model: v })}
+            />
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="flat" onPress={onClose}>
+            Cancel
+          </Button>
+          <Button color="primary" onPress={handleSave} isLoading={saving}>
+            Save
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/components/ai-chat/provider-settings-modal.tsx
+++ b/src/components/ai-chat/provider-settings-modal.tsx
@@ -121,9 +121,9 @@ export function ProviderSettingsModal({ isOpen, onClose, settings, onSaved }: Pr
           <div className="flex flex-col gap-2">
             <p className="text-small font-semibold">LM Studio (local)</p>
             <p className="text-tiny text-default-500">
-              No API key needed. Start the LM Studio server (Developer tab), load a model, and enter
-              its model id below. Works with any OpenAI-compatible server, e.g. Ollama at
-              http://localhost:11434/v1.
+              Start the LM Studio server (Developer tab), load a model, and enter its model id
+              below. Works with any OpenAI-compatible server, e.g. Ollama. The /v1 path is added
+              automatically if you leave it off.
             </p>
             <Input
               label="Server URL"
@@ -136,6 +136,13 @@ export function ProviderSettingsModal({ isOpen, onClose, settings, onSaved }: Pr
               value={draft.lmstudio_model}
               onValueChange={(v) => set({ lmstudio_model: v })}
               placeholder="e.g. qwen/qwen3-32b — the model id shown in LM Studio"
+            />
+            <Input
+              label="API token (optional)"
+              type="password"
+              value={draft.lmstudio_api_key}
+              onValueChange={(v) => set({ lmstudio_api_key: v })}
+              description="Only needed if your server requires an API token (LM Studio: Developer → Server Settings)."
             />
           </div>
         </ModalBody>

--- a/src/components/ai-chat/provider-settings-modal.tsx
+++ b/src/components/ai-chat/provider-settings-modal.tsx
@@ -117,6 +117,27 @@ export function ProviderSettingsModal({ isOpen, onClose, settings, onSaved }: Pr
               onValueChange={(v) => set({ google_model: v })}
             />
           </div>
+
+          <div className="flex flex-col gap-2">
+            <p className="text-small font-semibold">LM Studio (local)</p>
+            <p className="text-tiny text-default-500">
+              No API key needed. Start the LM Studio server (Developer tab), load a model, and enter
+              its model id below. Works with any OpenAI-compatible server, e.g. Ollama at
+              http://localhost:11434/v1.
+            </p>
+            <Input
+              label="Server URL"
+              value={draft.lmstudio_base_url}
+              onValueChange={(v) => set({ lmstudio_base_url: v })}
+              placeholder="http://localhost:1234/v1"
+            />
+            <Input
+              label="Model"
+              value={draft.lmstudio_model}
+              onValueChange={(v) => set({ lmstudio_model: v })}
+              placeholder="e.g. qwen/qwen3-32b — the model id shown in LM Studio"
+            />
+          </div>
         </ModalBody>
         <ModalFooter>
           <Button variant="flat" onPress={onClose}>

--- a/src/features/sidebar/sidebar-items.tsx
+++ b/src/features/sidebar/sidebar-items.tsx
@@ -29,6 +29,11 @@ export const items: SidebarItem[] = [
     icon: "solar:magnifer-zoom-in-outline",
     title: "Deal Lookup",
   },
+  {
+    key: "ai-chat",
+    icon: "solar:chat-round-line-duotone",
+    title: "AI Chat",
+  },
 ];
 
 export const settingsItem: SidebarItem = {

--- a/src/pages/ai-chat.tsx
+++ b/src/pages/ai-chat.tsx
@@ -1,0 +1,460 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Button,
+  Chip,
+  Input,
+  ScrollShadow,
+  Select,
+  SelectItem,
+  Textarea,
+  Tooltip,
+} from "@heroui/react";
+import { Icon } from "@iconify/react";
+import { open } from "@tauri-apps/plugin-dialog";
+
+import {
+  apiKeyFor,
+  getAiSettings,
+  modelFor,
+  prepareChatAttachment,
+  PROVIDER_LABELS,
+  streamChat,
+  type AiChatEvent,
+  type AiProvider,
+  type AiSettings,
+  type ChatBlock,
+  type ChatMessage,
+  type PreparedAttachment,
+} from "@services/ai-chat-service";
+import {
+  appendMessages,
+  createConversation,
+  deleteConversation,
+  listConversations,
+  listMessages,
+  type Conversation,
+} from "@services/chat-store-service";
+import { toast } from "@services/toast-service";
+import {
+  LiveMessageView,
+  MessageView,
+  type LiveSegment,
+} from "@components/ai-chat/chat-message-view";
+import { ProviderSettingsModal } from "@components/ai-chat/provider-settings-modal";
+
+const ATTACHMENT_EXTENSIONS = [
+  "csv",
+  "tsv",
+  "txt",
+  "md",
+  "json",
+  "xlsx",
+  "xls",
+  "xlsm",
+  "xlsb",
+  "ods",
+  "pdf",
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+];
+
+function titleFrom(text: string, fallback: string): string {
+  const trimmed = text.trim().replace(/\s+/g, " ");
+  if (!trimmed) return fallback;
+  return trimmed.length > 60 ? `${trimmed.slice(0, 60)}…` : trimmed;
+}
+
+function AiChat() {
+  const [settings, setSettings] = useState<AiSettings | null>(null);
+  const [provider, setProvider] = useState<AiProvider>("anthropic");
+  const [model, setModel] = useState("");
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  const [input, setInput] = useState("");
+  const [attachments, setAttachments] = useState<PreparedAttachment[]>([]);
+  const [attaching, setAttaching] = useState(false);
+  const [streaming, setStreaming] = useState(false);
+  const [liveSegments, setLiveSegments] = useState<LiveSegment[]>([]);
+
+  // Persistence degrades gracefully until the chat tables exist in Supabase.
+  const persistenceBroken = useRef(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    getAiSettings()
+      .then((loaded) => {
+        setSettings(loaded);
+        setProvider(loaded.default_provider);
+        setModel(modelFor(loaded, loaded.default_provider));
+      })
+      .catch((error) => toast.error("Failed to load AI settings", String(error)));
+
+    listConversations()
+      .then(setConversations)
+      .catch(() => {
+        persistenceBroken.current = true;
+      });
+  }, []);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [messages, liveSegments]);
+
+  const warnPersistence = (error: unknown) => {
+    if (!persistenceBroken.current) {
+      persistenceBroken.current = true;
+      toast.warning(
+        "Chat history is not being saved",
+        `Conversations will work but won't persist: ${String(error)}`
+      );
+    }
+  };
+
+  const handleProviderChange = (next: AiProvider) => {
+    setProvider(next);
+    if (settings) setModel(modelFor(settings, next));
+  };
+
+  const handleNewChat = () => {
+    if (streaming) return;
+    setActiveId(null);
+    setMessages([]);
+  };
+
+  const handleSelectConversation = async (conversation: Conversation) => {
+    if (streaming || conversation.id === activeId) return;
+    setActiveId(conversation.id);
+    if (conversation.provider in PROVIDER_LABELS) {
+      setProvider(conversation.provider as AiProvider);
+    }
+    if (conversation.model) setModel(conversation.model);
+    try {
+      setMessages(await listMessages(conversation.id));
+    } catch (error) {
+      setMessages([]);
+      warnPersistence(error);
+    }
+  };
+
+  const handleDeleteConversation = async (id: string) => {
+    try {
+      await deleteConversation(id);
+      setConversations((prev) => prev.filter((c) => c.id !== id));
+      if (activeId === id) handleNewChat();
+    } catch (error) {
+      toast.error("Failed to delete conversation", String(error));
+    }
+  };
+
+  const handleAttach = async () => {
+    setAttaching(true);
+    try {
+      const selected = await open({
+        multiple: true,
+        filters: [{ name: "Documents & data", extensions: ATTACHMENT_EXTENSIONS }],
+      });
+      if (!selected) return;
+      const paths = Array.isArray(selected) ? selected : [selected];
+      for (const path of paths) {
+        const prepared = await prepareChatAttachment(path);
+        setAttachments((prev) => [...prev, prepared]);
+      }
+    } catch (error) {
+      toast.error("Could not attach file", String(error));
+    } finally {
+      setAttaching(false);
+    }
+  };
+
+  const onEvent = useCallback((event: AiChatEvent) => {
+    setLiveSegments((prev) => {
+      if (event.type === "text_delta") {
+        const last = prev[prev.length - 1];
+        if (last?.type === "text") {
+          return [...prev.slice(0, -1), { type: "text", text: last.text + event.text }];
+        }
+        return [...prev, { type: "text", text: event.text }];
+      }
+      if (event.type === "tool_call") {
+        return [...prev, { type: "tool", id: event.id, name: event.name, status: "running" }];
+      }
+      if (event.type === "tool_result") {
+        return prev.map((segment) =>
+          segment.type === "tool" && segment.id === event.id
+            ? { ...segment, status: event.is_error ? "error" : "done" }
+            : segment
+        );
+      }
+      return prev;
+    });
+  }, []);
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (streaming || (!text && attachments.length === 0)) return;
+    if (!settings || !apiKeyFor(settings, provider)) {
+      toast.warning(
+        "No API key configured",
+        `Add your ${PROVIDER_LABELS[provider]} API key in the AI settings first.`
+      );
+      setSettingsOpen(true);
+      return;
+    }
+    if (!model.trim()) {
+      toast.warning("No model set", "Enter a model id in the header first.");
+      return;
+    }
+
+    const blocks: ChatBlock[] = [
+      ...attachments.flatMap((attachment) => attachment.blocks),
+      ...(text ? [{ kind: "text", text } as ChatBlock] : []),
+    ];
+    const userMessage: ChatMessage = { role: "user", blocks };
+    const history = [...messages, userMessage];
+
+    setMessages(history);
+    setInput("");
+    setAttachments([]);
+    setStreaming(true);
+    setLiveSegments([]);
+
+    // Persist the user message (creating the conversation on first send).
+    let conversationId = activeId;
+    if (!persistenceBroken.current) {
+      try {
+        if (!conversationId) {
+          const conversation = await createConversation(
+            titleFrom(text, attachments[0]?.name ?? "New chat"),
+            provider,
+            model
+          );
+          conversationId = conversation.id;
+          setActiveId(conversation.id);
+          setConversations((prev) => [conversation, ...prev]);
+        }
+        await appendMessages(conversationId, [userMessage]);
+      } catch (error) {
+        warnPersistence(error);
+      }
+    }
+
+    try {
+      const newMessages = await streamChat({ provider, model, messages: history, onEvent });
+      setMessages([...history, ...newMessages]);
+      if (!persistenceBroken.current && conversationId) {
+        try {
+          await appendMessages(conversationId, newMessages);
+          setConversations((prev) => {
+            const bumped = prev.find((c) => c.id === conversationId);
+            if (!bumped) return prev;
+            return [bumped, ...prev.filter((c) => c.id !== conversationId)];
+          });
+        } catch (error) {
+          warnPersistence(error);
+        }
+      }
+    } catch (error) {
+      toast.error("AI request failed", String(error));
+    } finally {
+      setStreaming(false);
+      setLiveSegments([]);
+    }
+  };
+
+  const hasApiKey = settings ? Boolean(apiKeyFor(settings, provider)) : false;
+
+  return (
+    <div className="flex h-full gap-4">
+      {/* Conversation list */}
+      <div className="flex w-64 shrink-0 flex-col gap-2 border-r border-divider pr-4">
+        <Button
+          color="primary"
+          variant="flat"
+          startContent={<Icon icon="solar:pen-new-square-outline" width={18} />}
+          onPress={handleNewChat}
+          isDisabled={streaming}
+        >
+          New chat
+        </Button>
+        <ScrollShadow className="flex-1">
+          <div className="flex flex-col gap-1">
+            {conversations.map((conversation) => (
+              <div
+                key={conversation.id}
+                className={`group flex cursor-pointer items-center gap-1 rounded-medium px-2 py-2 text-small hover:bg-default-100 ${
+                  conversation.id === activeId ? "bg-default-100 font-medium" : ""
+                }`}
+                onClick={() => handleSelectConversation(conversation)}
+              >
+                <span className="flex-1 truncate">{conversation.title}</span>
+                <Button
+                  isIconOnly
+                  size="sm"
+                  variant="light"
+                  className="opacity-0 group-hover:opacity-100"
+                  onPress={() => handleDeleteConversation(conversation.id)}
+                  isDisabled={streaming}
+                  aria-label="Delete conversation"
+                >
+                  <Icon icon="solar:trash-bin-trash-outline" width={16} />
+                </Button>
+              </div>
+            ))}
+            {conversations.length === 0 && (
+              <p className="px-2 py-4 text-tiny text-default-400">No conversations yet.</p>
+            )}
+          </div>
+        </ScrollShadow>
+      </div>
+
+      {/* Chat area */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex items-center gap-2 pb-3">
+          <h1 className="flex-1 text-xl font-semibold">AI Chat</h1>
+          <Select
+            size="sm"
+            className="w-48"
+            aria-label="AI provider"
+            selectedKeys={[provider]}
+            onSelectionChange={(keys) => {
+              const key = Array.from(keys)[0] as AiProvider | undefined;
+              if (key) handleProviderChange(key);
+            }}
+            isDisabled={streaming}
+          >
+            {(Object.keys(PROVIDER_LABELS) as AiProvider[]).map((key) => (
+              <SelectItem key={key}>{PROVIDER_LABELS[key]}</SelectItem>
+            ))}
+          </Select>
+          <Input
+            size="sm"
+            className="w-52"
+            aria-label="Model"
+            value={model}
+            onValueChange={setModel}
+            isDisabled={streaming}
+          />
+          <Tooltip content="AI provider settings">
+            <Button
+              isIconOnly
+              size="sm"
+              variant="light"
+              onPress={() => setSettingsOpen(true)}
+              aria-label="AI settings"
+            >
+              <Icon icon="solar:settings-outline" width={20} />
+            </Button>
+          </Tooltip>
+        </div>
+
+        <ScrollShadow ref={scrollRef} className="flex-1 pr-2">
+          <div className="mx-auto flex max-w-3xl flex-col gap-4 pb-4">
+            {messages.length === 0 && !streaming && (
+              <div className="flex flex-col items-center gap-3 py-16 text-center">
+                <Icon
+                  icon="solar:chat-round-line-duotone"
+                  width={48}
+                  className="text-default-300"
+                />
+                <p className="text-default-500">
+                  Ask about your portfolios — deals, vintages, payments, allocations.
+                </p>
+                <p className="max-w-md text-tiny text-default-400">
+                  The assistant queries your Supabase data with read-only tools and can analyze CSV,
+                  Excel and PDF files you attach.
+                </p>
+                {!hasApiKey && (
+                  <Button size="sm" variant="flat" onPress={() => setSettingsOpen(true)}>
+                    Configure API keys
+                  </Button>
+                )}
+              </div>
+            )}
+            {messages.map((message, i) => (
+              <MessageView key={i} message={message} />
+            ))}
+            {streaming && <LiveMessageView segments={liveSegments} />}
+          </div>
+        </ScrollShadow>
+
+        {/* Composer */}
+        <div className="mx-auto w-full max-w-3xl pt-3">
+          {attachments.length > 0 && (
+            <div className="mb-2 flex flex-wrap gap-2">
+              {attachments.map((attachment, i) => (
+                <Chip
+                  key={i}
+                  size="sm"
+                  variant="flat"
+                  color="secondary"
+                  onClose={() => setAttachments((prev) => prev.filter((_, j) => j !== i))}
+                >
+                  {attachment.name}
+                </Chip>
+              ))}
+            </div>
+          )}
+          <div className="flex items-end gap-2">
+            <Tooltip content="Attach CSV, Excel, PDF or image files">
+              <Button
+                isIconOnly
+                variant="flat"
+                onPress={handleAttach}
+                isLoading={attaching}
+                isDisabled={streaming}
+                aria-label="Attach file"
+              >
+                <Icon icon="solar:paperclip-outline" width={20} />
+              </Button>
+            </Tooltip>
+            <Textarea
+              minRows={1}
+              maxRows={8}
+              placeholder="Ask about your portfolio data…"
+              value={input}
+              onValueChange={setInput}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSend();
+                }
+              }}
+              isDisabled={streaming}
+            />
+            <Button
+              isIconOnly
+              color="primary"
+              onPress={handleSend}
+              isLoading={streaming}
+              isDisabled={!input.trim() && attachments.length === 0}
+              aria-label="Send message"
+            >
+              <Icon icon="solar:plain-2-outline" width={20} />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {settings && (
+        <ProviderSettingsModal
+          isOpen={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+          settings={settings}
+          onSaved={(saved) => {
+            setSettings(saved);
+            setModel(modelFor(saved, provider));
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+export default AiChat;

--- a/src/pages/ai-chat.tsx
+++ b/src/pages/ai-chat.tsx
@@ -33,10 +33,12 @@ import {
   deleteConversation,
   listConversations,
   listMessages,
+  replaceMessages,
   type Conversation,
 } from "@services/chat-store-service";
 import { toast } from "@services/toast-service";
 import {
+  isToolResultMessage,
   LiveMessageView,
   MessageView,
   type LiveSegment,
@@ -197,16 +199,15 @@ function AiChat() {
     });
   }, []);
 
-  const handleSend = async () => {
-    const text = input.trim();
-    if (streaming || (!text && attachments.length === 0)) return;
+  /** Validates provider/model setup, surfacing a toast and returning false if not ready. */
+  const ensureConfigured = (): boolean => {
     if (!settings || (providerNeedsApiKey(provider) && !apiKeyFor(settings, provider))) {
       toast.warning(
         "No API key configured",
         `Add your ${PROVIDER_LABELS[provider]} API key in the AI settings first.`
       );
       setSettingsOpen(true);
-      return;
+      return false;
     }
     if (!model.trim()) {
       const hint =
@@ -215,8 +216,24 @@ function AiChat() {
           : "Enter a model id in the header first.";
       toast.warning("No model set", hint);
       if (provider === "lmstudio") setSettingsOpen(true);
-      return;
+      return false;
     }
+    return true;
+  };
+
+  /** Moves a conversation to the top of the list after a new turn. */
+  const bumpConversation = (id: string) => {
+    setConversations((prev) => {
+      const bumped = prev.find((c) => c.id === id);
+      if (!bumped) return prev;
+      return [bumped, ...prev.filter((c) => c.id !== id)];
+    });
+  };
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (streaming || (!text && attachments.length === 0)) return;
+    if (!ensureConfigured()) return;
 
     const blocks: ChatBlock[] = [
       ...attachments.flatMap((attachment) => attachment.blocks),
@@ -257,17 +274,58 @@ function AiChat() {
       if (!persistenceBroken.current && conversationId) {
         try {
           await appendMessages(conversationId, newMessages);
-          setConversations((prev) => {
-            const bumped = prev.find((c) => c.id === conversationId);
-            if (!bumped) return prev;
-            return [bumped, ...prev.filter((c) => c.id !== conversationId)];
-          });
+          bumpConversation(conversationId);
         } catch (error) {
           warnPersistence(error);
         }
       }
     } catch (error) {
       toast.error("AI request failed", String(error));
+    } finally {
+      setStreaming(false);
+      setLiveSegments([]);
+    }
+  };
+
+  /**
+   * Regenerates the assistant turn that produced `messages[index]`. Everything
+   * from the start of that turn onward is dropped and re-streamed from the
+   * user prompt that triggered it.
+   */
+  const handleRetry = async (index: number) => {
+    if (streaming || !ensureConfigured()) return;
+
+    // Walk back to the genuine user prompt that started this assistant turn,
+    // skipping the assistant messages and tool-result plumbing in between.
+    let cut = index;
+    while (cut > 0) {
+      const prev = messages[cut - 1];
+      if (prev.role === "user" && !isToolResultMessage(prev)) break;
+      cut--;
+    }
+    const history = messages.slice(0, cut);
+    if (history.length === 0) return;
+
+    const previousMessages = messages;
+    setMessages(history);
+    setStreaming(true);
+    setLiveSegments([]);
+
+    try {
+      const newMessages = await streamChat({ provider, model, messages: history, onEvent });
+      const finalMessages = [...history, ...newMessages];
+      setMessages(finalMessages);
+      if (!persistenceBroken.current && activeId) {
+        try {
+          await replaceMessages(activeId, finalMessages);
+          bumpConversation(activeId);
+        } catch (error) {
+          warnPersistence(error);
+        }
+      }
+    } catch (error) {
+      toast.error("AI request failed", String(error));
+      setMessages(previousMessages); // restore the response we tried to replace
     } finally {
       setStreaming(false);
       setLiveSegments([]);
@@ -386,7 +444,15 @@ function AiChat() {
               </div>
             )}
             {messages.map((message, i) => (
-              <MessageView key={i} message={message} />
+              <MessageView
+                key={i}
+                message={message}
+                onRetry={
+                  !streaming && message.role === "assistant" && i === messages.length - 1
+                    ? () => handleRetry(i)
+                    : undefined
+                }
+              />
             ))}
             {streaming && <LiveMessageView segments={liveSegments} />}
           </div>

--- a/src/pages/ai-chat.tsx
+++ b/src/pages/ai-chat.tsx
@@ -18,6 +18,7 @@ import {
   modelFor,
   prepareChatAttachment,
   PROVIDER_LABELS,
+  providerNeedsApiKey,
   streamChat,
   type AiChatEvent,
   type AiProvider,
@@ -199,7 +200,7 @@ function AiChat() {
   const handleSend = async () => {
     const text = input.trim();
     if (streaming || (!text && attachments.length === 0)) return;
-    if (!settings || !apiKeyFor(settings, provider)) {
+    if (!settings || (providerNeedsApiKey(provider) && !apiKeyFor(settings, provider))) {
       toast.warning(
         "No API key configured",
         `Add your ${PROVIDER_LABELS[provider]} API key in the AI settings first.`
@@ -208,7 +209,12 @@ function AiChat() {
       return;
     }
     if (!model.trim()) {
-      toast.warning("No model set", "Enter a model id in the header first.");
+      const hint =
+        provider === "lmstudio"
+          ? "Enter the model id loaded in LM Studio (settings or the header field)."
+          : "Enter a model id in the header first.";
+      toast.warning("No model set", hint);
+      if (provider === "lmstudio") setSettingsOpen(true);
       return;
     }
 
@@ -268,7 +274,9 @@ function AiChat() {
     }
   };
 
-  const hasApiKey = settings ? Boolean(apiKeyFor(settings, provider)) : false;
+  const needsSetup = settings
+    ? providerNeedsApiKey(provider) && !apiKeyFor(settings, provider)
+    : true;
 
   return (
     <div className="flex h-full gap-4">
@@ -370,7 +378,7 @@ function AiChat() {
                   The assistant queries your Supabase data with read-only tools and can analyze CSV,
                   Excel and PDF files you attach.
                 </p>
-                {!hasApiKey && (
+                {needsSetup && (
                   <Button size="sm" variant="flat" onPress={() => setSettingsOpen(true)}>
                     Configure API keys
                   </Button>

--- a/src/services/ai-chat-service.ts
+++ b/src/services/ai-chat-service.ts
@@ -48,6 +48,7 @@ export interface AiSettings {
   google_model: string;
   lmstudio_base_url: string;
   lmstudio_model: string;
+  lmstudio_api_key: string;
 }
 
 /** Live events streamed from Rust while a turn runs. */
@@ -78,7 +79,7 @@ export function apiKeyFor(settings: AiSettings, provider: AiProvider): string {
   if (provider === "anthropic") return settings.anthropic_api_key;
   if (provider === "openai") return settings.openai_api_key;
   if (provider === "google") return settings.google_api_key;
-  return "";
+  return settings.lmstudio_api_key;
 }
 
 export function modelFor(settings: AiSettings, provider: AiProvider): string {

--- a/src/services/ai-chat-service.ts
+++ b/src/services/ai-chat-service.ts
@@ -1,0 +1,112 @@
+/**
+ * Frontend wrapper for the Rust AI chat commands (`ai_chat_stream`,
+ * `get_ai_settings`, `save_ai_settings`, `prepare_chat_attachment`).
+ * Types here mirror `src-tauri/src/ai_chat/types.rs`.
+ */
+import { Channel, invoke } from "@tauri-apps/api/core";
+import { supabase } from "./supabase";
+
+export type AiProvider = "anthropic" | "openai" | "google";
+
+export const PROVIDER_LABELS: Record<AiProvider, string> = {
+  anthropic: "Anthropic (Claude)",
+  openai: "OpenAI",
+  google: "Google (Gemini)",
+};
+
+export type ChatBlock =
+  | { kind: "text"; text: string }
+  | { kind: "image"; media_type: string; data: string }
+  | { kind: "document"; media_type: string; data: string; name: string }
+  | { kind: "tool_use"; id: string; name: string; input: unknown }
+  | {
+      kind: "tool_result";
+      tool_use_id: string;
+      name: string;
+      content: string;
+      is_error: boolean;
+    };
+
+export interface ChatMessage {
+  role: "user" | "assistant";
+  blocks: ChatBlock[];
+}
+
+export interface AiSettings {
+  default_provider: AiProvider;
+  anthropic_api_key: string;
+  openai_api_key: string;
+  google_api_key: string;
+  anthropic_model: string;
+  openai_model: string;
+  google_model: string;
+}
+
+/** Live events streamed from Rust while a turn runs. */
+export type AiChatEvent =
+  | { type: "text_delta"; text: string }
+  | { type: "tool_call"; id: string; name: string; input: unknown }
+  | { type: "tool_result"; id: string; name: string; preview: string; is_error: boolean }
+  | { type: "turn_complete" };
+
+export interface PreparedAttachment {
+  name: string;
+  blocks: ChatBlock[];
+}
+
+export function getAiSettings(): Promise<AiSettings> {
+  return invoke<AiSettings>("get_ai_settings");
+}
+
+export function saveAiSettings(settings: AiSettings): Promise<void> {
+  return invoke("save_ai_settings", { settings });
+}
+
+export function prepareChatAttachment(path: string): Promise<PreparedAttachment> {
+  return invoke<PreparedAttachment>("prepare_chat_attachment", { path });
+}
+
+export function apiKeyFor(settings: AiSettings, provider: AiProvider): string {
+  if (provider === "anthropic") return settings.anthropic_api_key;
+  if (provider === "openai") return settings.openai_api_key;
+  return settings.google_api_key;
+}
+
+export function modelFor(settings: AiSettings, provider: AiProvider): string {
+  if (provider === "anthropic") return settings.anthropic_model;
+  if (provider === "openai") return settings.openai_model;
+  return settings.google_model;
+}
+
+/**
+ * Runs one user turn through the Rust agent loop. `onEvent` receives live
+ * streaming events; the resolved value is the canonical list of new messages
+ * (assistant turns + tool-result messages) to append to the conversation.
+ */
+export async function streamChat(params: {
+  provider: AiProvider;
+  model: string;
+  messages: ChatMessage[];
+  onEvent: (event: AiChatEvent) => void;
+}): Promise<ChatMessage[]> {
+  const { data } = await supabase.auth.getSession();
+  const accessToken = data.session?.access_token;
+  if (!accessToken) {
+    throw new Error("Not signed in — the AI assistant needs an active session to query data.");
+  }
+
+  const channel = new Channel<AiChatEvent>();
+  channel.onmessage = params.onEvent;
+
+  return invoke<ChatMessage[]>("ai_chat_stream", {
+    request: {
+      provider: params.provider,
+      model: params.model,
+      messages: params.messages,
+      supabase_url: import.meta.env.VITE_SUPABASE_URL,
+      supabase_anon_key: import.meta.env.VITE_SUPABASE_ANON_KEY,
+      supabase_access_token: accessToken,
+    },
+    onEvent: channel,
+  });
+}

--- a/src/services/ai-chat-service.ts
+++ b/src/services/ai-chat-service.ts
@@ -6,13 +6,19 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
 import { supabase } from "./supabase";
 
-export type AiProvider = "anthropic" | "openai" | "google";
+export type AiProvider = "anthropic" | "openai" | "google" | "lmstudio";
 
 export const PROVIDER_LABELS: Record<AiProvider, string> = {
   anthropic: "Anthropic (Claude)",
   openai: "OpenAI",
   google: "Google (Gemini)",
+  lmstudio: "LM Studio (local)",
 };
+
+/** Local servers don't authenticate; every cloud provider needs a key. */
+export function providerNeedsApiKey(provider: AiProvider): boolean {
+  return provider !== "lmstudio";
+}
 
 export type ChatBlock =
   | { kind: "text"; text: string }
@@ -40,6 +46,8 @@ export interface AiSettings {
   anthropic_model: string;
   openai_model: string;
   google_model: string;
+  lmstudio_base_url: string;
+  lmstudio_model: string;
 }
 
 /** Live events streamed from Rust while a turn runs. */
@@ -69,13 +77,15 @@ export function prepareChatAttachment(path: string): Promise<PreparedAttachment>
 export function apiKeyFor(settings: AiSettings, provider: AiProvider): string {
   if (provider === "anthropic") return settings.anthropic_api_key;
   if (provider === "openai") return settings.openai_api_key;
-  return settings.google_api_key;
+  if (provider === "google") return settings.google_api_key;
+  return "";
 }
 
 export function modelFor(settings: AiSettings, provider: AiProvider): string {
   if (provider === "anthropic") return settings.anthropic_model;
   if (provider === "openai") return settings.openai_model;
-  return settings.google_model;
+  if (provider === "google") return settings.google_model;
+  return settings.lmstudio_model;
 }
 
 /**

--- a/src/services/chat-store-service.ts
+++ b/src/services/chat-store-service.ts
@@ -84,3 +84,37 @@ export async function appendMessages(
     .update({ updated_at: new Date().toISOString() })
     .eq("id", conversationId);
 }
+
+/**
+ * Replaces the entire message history for a conversation. Used when a response
+ * is retried: the old assistant turn (and anything after it) is dropped and the
+ * regenerated turn takes its place. Timestamps are spaced by index so the
+ * `created_at` ordering read back by {@link listMessages} matches insertion order.
+ */
+export async function replaceMessages(
+  conversationId: string,
+  messages: ChatMessage[]
+): Promise<void> {
+  const { error: deleteError } = await supabase
+    .from("chat_messages")
+    .delete()
+    .eq("conversation_id", conversationId);
+  if (deleteError) throw new Error(`Failed to clear messages: ${deleteError.message}`);
+
+  if (messages.length > 0) {
+    const base = Date.now();
+    const rows = messages.map((message, i) => ({
+      conversation_id: conversationId,
+      role: message.role,
+      content: message.blocks as unknown as Json,
+      created_at: new Date(base + i).toISOString(),
+    }));
+    const { error } = await supabase.from("chat_messages").insert(rows);
+    if (error) throw new Error(`Failed to save messages: ${error.message}`);
+  }
+
+  await supabase
+    .from("chat_conversations")
+    .update({ updated_at: new Date().toISOString() })
+    .eq("id", conversationId);
+}

--- a/src/services/chat-store-service.ts
+++ b/src/services/chat-store-service.ts
@@ -1,0 +1,86 @@
+/**
+ * Supabase persistence for AI chat conversations. RLS keeps every
+ * conversation private to the user who created it.
+ */
+import { supabase } from "./supabase";
+import type { Json } from "./supabase.types";
+import type { ChatBlock, ChatMessage } from "./ai-chat-service";
+
+export interface Conversation {
+  id: string;
+  title: string;
+  provider: string;
+  model: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function listConversations(): Promise<Conversation[]> {
+  const { data, error } = await supabase
+    .from("chat_conversations")
+    .select("id, title, provider, model, created_at, updated_at")
+    .order("updated_at", { ascending: false });
+  if (error) throw new Error(`Failed to load conversations: ${error.message}`);
+  return data ?? [];
+}
+
+export async function createConversation(
+  title: string,
+  provider: string,
+  model: string
+): Promise<Conversation> {
+  const { data, error } = await supabase
+    .from("chat_conversations")
+    .insert({ title, provider, model })
+    .select("id, title, provider, model, created_at, updated_at")
+    .single();
+  if (error) throw new Error(`Failed to create conversation: ${error.message}`);
+  return data;
+}
+
+export async function updateConversation(
+  id: string,
+  patch: Partial<Pick<Conversation, "title" | "provider" | "model">>
+): Promise<void> {
+  const { error } = await supabase
+    .from("chat_conversations")
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq("id", id);
+  if (error) throw new Error(`Failed to update conversation: ${error.message}`);
+}
+
+export async function deleteConversation(id: string): Promise<void> {
+  const { error } = await supabase.from("chat_conversations").delete().eq("id", id);
+  if (error) throw new Error(`Failed to delete conversation: ${error.message}`);
+}
+
+export async function listMessages(conversationId: string): Promise<ChatMessage[]> {
+  const { data, error } = await supabase
+    .from("chat_messages")
+    .select("role, content, created_at")
+    .eq("conversation_id", conversationId)
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(`Failed to load messages: ${error.message}`);
+  return (data ?? []).map((row) => ({
+    role: row.role,
+    blocks: (row.content ?? []) as unknown as ChatBlock[],
+  }));
+}
+
+export async function appendMessages(
+  conversationId: string,
+  messages: ChatMessage[]
+): Promise<void> {
+  if (messages.length === 0) return;
+  const rows = messages.map((message) => ({
+    conversation_id: conversationId,
+    role: message.role,
+    content: message.blocks as unknown as Json,
+  }));
+  const { error } = await supabase.from("chat_messages").insert(rows);
+  if (error) throw new Error(`Failed to save messages: ${error.message}`);
+  await supabase
+    .from("chat_conversations")
+    .update({ updated_at: new Date().toISOString() })
+    .eq("id", conversationId);
+}

--- a/src/services/deal-explorer-service.ts
+++ b/src/services/deal-explorer-service.ts
@@ -215,7 +215,16 @@ export async function getDealRecords(): Promise<DealRecord[]> {
 // ---------------------------------------------------------------------------
 
 export type FilterOperator =
-  "contains" | "eq" | "neq" | "gt" | "gte" | "lt" | "lte" | "between" | "is_true" | "is_false";
+  | "contains"
+  | "eq"
+  | "neq"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte"
+  | "between"
+  | "is_true"
+  | "is_false";
 
 export const OPERATORS_BY_TYPE: Record<FieldType, FilterOperator[]> = {
   text: ["contains", "eq", "neq"],

--- a/src/services/supabase.types.ts
+++ b/src/services/supabase.types.ts
@@ -564,6 +564,68 @@ export interface Database {
           },
         ];
       };
+      chat_conversations: {
+        Row: {
+          id: string;
+          user_id: string;
+          title: string;
+          provider: string;
+          model: string;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id?: string;
+          title?: string;
+          provider?: string;
+          model?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          title?: string;
+          provider?: string;
+          model?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
+      chat_messages: {
+        Row: {
+          id: string;
+          conversation_id: string;
+          role: "user" | "assistant";
+          content: Json;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          conversation_id: string;
+          role: "user" | "assistant";
+          content: Json;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          conversation_id?: string;
+          role?: "user" | "assistant";
+          content?: Json;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "chat_messages_conversation_id_fkey";
+            columns: ["conversation_id"];
+            isOneToOne: false;
+            referencedRelation: "chat_conversations";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
     };
     Views: {
       deal_computed: {

--- a/supabase/migrations/20260713100000_ai_chat_tables.sql
+++ b/supabase/migrations/20260713100000_ai_chat_tables.sql
@@ -1,0 +1,57 @@
+-- AI chat persistence: conversations and their messages, private to the
+-- creating user (unlike portfolio tables, these are not shared via
+-- portfolio_access). Message content stores the frontend's block array
+-- (text / attachments / tool calls / tool results) as jsonb.
+
+create table public.chat_conversations (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  title text not null default 'New chat',
+  provider text not null default 'anthropic',
+  model text not null default '',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table public.chat_messages (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references public.chat_conversations (id) on delete cascade,
+  role text not null check (role in ('user', 'assistant')),
+  content jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create index chat_messages_conversation_idx
+  on public.chat_messages (conversation_id, created_at);
+
+create index chat_conversations_user_idx
+  on public.chat_conversations (user_id, updated_at desc);
+
+alter table public.chat_conversations enable row level security;
+alter table public.chat_messages enable row level security;
+
+create policy "Users manage own conversations"
+  on public.chat_conversations
+  for all
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+create policy "Users manage own conversation messages"
+  on public.chat_messages
+  for all
+  using (
+    exists (
+      select 1
+      from public.chat_conversations c
+      where c.id = conversation_id
+        and c.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.chat_conversations c
+      where c.id = conversation_id
+        and c.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary

Adds a provider-agnostic **AI Chat** page to Excelerate. The assistant answers questions about portfolio data (deals, vintages, payments, allocations) using read-only Supabase tools, and can analyze attached CSV/Excel/PDF/image files.

## What's included

- **Chat page & agent loop** — provider-agnostic chat UI backed by Rust commands (`ai_chat_stream`, `get_ai_settings`, `save_ai_settings`, `prepare_chat_attachment`), with live streaming of text, tool calls, and tool results. Conversations persist to new `chat_conversations` / `chat_messages` Supabase tables (RLS-scoped to the user).
- **Providers** — Anthropic (Claude), OpenAI, Google (Gemini), and LM Studio (local, OpenAI-compatible). LM Studio supports authenticated servers and base URLs with or without `/v1`.
- **File uploads** — attach CSV, TSV, Excel, JSON, PDF, and image files for the assistant to analyze.
- **Response actions** — each assistant response has hover **Copy** and **Retry** buttons; Retry regenerates the latest turn from the triggering user prompt (re-running tool calls) and replaces the stored turn.

## Test plan

- `npm run lint && npm run format:check && npm run build` all pass.
- Manually: send a prompt, stream a response, copy it, and retry it across the Anthropic and LM Studio providers.

> [!NOTE]
> The AI chat migration (`chat_conversations` / `chat_messages`) must be pushed to the target Supabase project before use; the page degrades gracefully (chat works without persistence) if the tables are absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)