### PR TITLE
feat: release notes modal on update + settings button

### DIFF
--- a/src/components/release-notes/release-notes-modal.tsx
+++ b/src/components/release-notes/release-notes-modal.tsx
@@ -1,0 +1,48 @@
+import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from "@heroui/react";
+import type { ChangelogEntry } from "@utils/changelog";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  entries: ChangelogEntry[];
+}
+
+export function ReleaseNotesModal({ isOpen, onClose, entries }: Props) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg" scrollBehavior="inside">
+      <ModalContent>
+        <ModalHeader>What&rsquo;s new in Excelerate</ModalHeader>
+        <ModalBody className="gap-6 pb-6">
+          {entries.length === 0 && (
+            <p className="text-sm text-default-500">No release notes available.</p>
+          )}
+          {entries.map((entry) => (
+            <div key={entry.version} className="space-y-3">
+              <div className="flex items-baseline gap-2">
+                <h3 className="text-lg font-semibold">v{entry.version}</h3>
+                <span className="text-tiny text-default-500">{entry.date}</span>
+              </div>
+              {entry.sections.map((section) => (
+                <div key={section.heading}>
+                  <p className="text-small font-semibold text-default-600 mb-1">
+                    {section.heading}
+                  </p>
+                  <ul className="list-disc list-inside space-y-1 text-small text-default-600">
+                    {section.items.map((item, i) => (
+                      <li key={i}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          ))}
+        </ModalBody>
+        <ModalFooter>
+          <Button color="primary" onPress={onClose}>
+            Got it
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/contexts/release-notes-context.tsx
+++ b/src/contexts/release-notes-context.tsx
@@ -1,0 +1,84 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { getVersion } from "@tauri-apps/api/app";
+import { getChangelogEntries, type ChangelogEntry } from "@utils/changelog";
+import { ReleaseNotesModal } from "@components/release-notes/release-notes-modal";
+
+const SEEN_VERSION_KEY = "excelerate:releaseNotesSeenVersion";
+
+interface ReleaseNotesContextType {
+  currentVersion: string;
+  openReleaseNotes: () => void;
+}
+
+const ReleaseNotesContext = createContext<ReleaseNotesContextType | undefined>(undefined);
+
+export const useReleaseNotes = () => {
+  const context = useContext(ReleaseNotesContext);
+  if (!context) {
+    throw new Error("useReleaseNotes must be used within a ReleaseNotesProvider");
+  }
+  return context;
+};
+
+interface ReleaseNotesProviderProps {
+  children: React.ReactNode;
+}
+
+export const ReleaseNotesProvider: React.FC<ReleaseNotesProviderProps> = ({ children }) => {
+  const [currentVersion, setCurrentVersion] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  const [entries, setEntries] = useState<ChangelogEntry[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getVersion()
+      .then((version) => {
+        if (cancelled) return;
+        setCurrentVersion(version);
+
+        const seenVersion = localStorage.getItem(SEEN_VERSION_KEY);
+
+        // First launch ever: nothing to announce, just record the baseline.
+        if (seenVersion === null) {
+          localStorage.setItem(SEEN_VERSION_KEY, version);
+          return;
+        }
+
+        if (seenVersion === version) return;
+
+        const allEntries = getChangelogEntries();
+        const seenIndex = allEntries.findIndex((e) => e.version === seenVersion);
+        const unseen = seenIndex === -1 ? allEntries.slice(0, 1) : allEntries.slice(0, seenIndex);
+
+        if (unseen.length > 0) {
+          setEntries(unseen);
+          setIsOpen(true);
+        }
+      })
+      .catch(() => {
+        // Not running inside Tauri (e.g. plain browser dev server) — skip.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const closeModal = () => {
+    setIsOpen(false);
+    if (currentVersion) localStorage.setItem(SEEN_VERSION_KEY, currentVersion);
+  };
+
+  const openReleaseNotes = () => {
+    setEntries(getChangelogEntries());
+    setIsOpen(true);
+  };
+
+  return (
+    <ReleaseNotesContext.Provider value={{ currentVersion, openReleaseNotes }}>
+      {children}
+      <ReleaseNotesModal isOpen={isOpen} onClose={closeModal} entries={entries} />
+    </ReleaseNotesContext.Provider>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { HeroUIProvider } from "@heroui/react";
 import { AuthProvider } from "@/contexts/auth-context";
 import { ToastProvider } from "@/contexts/toast-context";
 import { ThemeProvider } from "@/contexts/theme-context";
+import { ReleaseNotesProvider } from "@/contexts/release-notes-context";
 import App from "./app";
 import "./index.css";
 
@@ -33,9 +34,11 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
       <HeroUIProvider>
         <ToastProvider>
           <AuthProvider>
-            <main className="text-foreground bg-background">
-              <App />
-            </main>
+            <ReleaseNotesProvider>
+              <main className="text-foreground bg-background">
+                <App />
+              </main>
+            </ReleaseNotesProvider>
           </AuthProvider>
         </ToastProvider>
       </HeroUIProvider>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -2,12 +2,14 @@ import { InviteUser } from "@components/auth/invite-user";
 import { useAuth } from "@/contexts/auth-context";
 import { Card, CardBody, CardHeader, Select, SelectItem, Checkbox, Button } from "@heroui/react";
 import { useTheme } from "@/contexts/theme-context";
+import { useReleaseNotes } from "@/contexts/release-notes-context";
 import { Icon } from "@iconify/react";
 import { useState } from "react";
 
 function Settings() {
   const { profile } = useAuth();
   const { theme, toggleTheme } = useTheme();
+  const { currentVersion, openReleaseNotes } = useReleaseNotes();
   const [exportFormat, setExportFormat] = useState("csv");
   const [autoSave, setAutoSave] = useState(false);
 
@@ -89,7 +91,17 @@ function Settings() {
           </CardHeader>
           <CardBody>
             <div className="space-y-2 text-sm text-default-600">
-              <p>Version: 0.1.0</p>
+              <div className="flex items-center gap-2">
+                <p>Version: {currentVersion || "—"}</p>
+                <Button
+                  size="sm"
+                  variant="light"
+                  startContent={<Icon icon="heroicons:sparkles" width={16} />}
+                  onPress={openReleaseNotes}
+                >
+                  Release Notes
+                </Button>
+              </div>
               <p>Excelerate</p>
             </div>
           </CardBody>

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -1,0 +1,57 @@
+import changelogRaw from "../../CHANGELOG.md?raw";
+
+export interface ChangelogSection {
+  heading: string;
+  items: string[];
+}
+
+export interface ChangelogEntry {
+  version: string;
+  date: string;
+  sections: ChangelogSection[];
+}
+
+const VERSION_HEADER_RE = /^## \[([^\]]+)\]\([^)]*\)\s*\(([^)]+)\)/;
+const SECTION_HEADER_RE = /^### (.+)/;
+const COMMIT_LINK_RE = /\s*\(\[[0-9a-f]{6,}\]\([^)]*\)\)\s*$/;
+const SCOPE_PREFIX_RE = /^\*\*([^*]+)\*\*\s*/;
+
+function stripCommitLink(line: string): string {
+  return line.replace(COMMIT_LINK_RE, "").replace(SCOPE_PREFIX_RE, "$1 ").trim();
+}
+
+export function parseChangelog(raw: string): ChangelogEntry[] {
+  const entries: ChangelogEntry[] = [];
+  const versionBlocks = raw.split(/\n(?=## \[)/g);
+
+  for (const block of versionBlocks) {
+    const headerMatch = block.match(VERSION_HEADER_RE);
+    if (!headerMatch) continue;
+    const [, version, date] = headerMatch;
+
+    const sections: ChangelogSection[] = [];
+    const sectionBlocks = block.split(/\n(?=### )/g).slice(1);
+
+    for (const sectionBlock of sectionBlocks) {
+      const sectionHeaderMatch = sectionBlock.match(SECTION_HEADER_RE);
+      if (!sectionHeaderMatch) continue;
+
+      const items = sectionBlock
+        .split("\n")
+        .filter((line) => line.trim().startsWith("* "))
+        .map((line) => stripCommitLink(line.trim().slice(2)));
+
+      if (items.length > 0) {
+        sections.push({ heading: sectionHeaderMatch[1].trim(), items });
+      }
+    }
+
+    entries.push({ version, date, sections });
+  }
+
+  return entries;
+}
+
+export function getChangelogEntries(): ChangelogEntry[] {
+  return parseChangelog(changelogRaw);
+}


### PR DESCRIPTION
## Summary
- Auto-shows a "What's new" modal the first time the app is opened after an update, built from `CHANGELOG.md` parsed into per-version entries (bundled at build time via Vite `?raw`, no new deps)
- Tracks the last-seen version in `localStorage`; fresh installs are recorded silently without popping the modal, and updates show notes for every version skipped since the last seen one
- Settings page now displays the live app version (via Tauri's `getVersion()`, replacing the hardcoded `0.1.0`) with a "Release Notes" button to reopen the same modal on demand

## Test plan
- [x] `npm run lint` — 13/17 warnings, no errors
- [x] `npm run format:check` — clean
- [x] `npm run build` — TS + Vite build succeed
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` — clean (no Rust changes)
- [x] Verified changelog parser output against the real `CHANGELOG.md` (version/date/section extraction, commit-link and `**scope:**` stripping)
- [ ] Manual check in `npm run tauri dev`: modal auto-opens after bumping the stored "seen" version below the current app version, and the Settings "Release Notes" button reopens it

🤖 Generated with [Claude Code](https://claude.com/claude-code)