### PR TITLE
chore!: use standard semver bumps for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,8 +6,8 @@
       "package-name": "excelerate",
       "include-v-in-tag": true,
       "include-component-in-tag": false,
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
+      "bump-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": false,
       "draft": false,
       "prerelease": false,
       "extra-files": [


### PR DESCRIPTION
## Summary
- Set `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` to `false` in `release-please-config.json` so Release Please follows standard semver regardless of the pre-1.0 major version: `feat:` bumps minor, breaking changes bump major.
- Marked as a breaking change so this release moves 0.1.2 → 1.0.0.

## Test plan
- [ ] Merge to main and confirm the Release Please PR proposes `1.0.0`
- [ ] Confirm a subsequent `feat:`-only commit proposes a minor bump (e.g. `1.1.0`)