### PR TITLE
ci: fix release pipeline (PAT for release-please, drop npm cache, manual dispatch)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,10 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          # A PAT (not the default GITHUB_TOKEN) so the published release
+          # fires the `release` workflow — events created by GITHUB_TOKEN
+          # do not trigger other workflows.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: release
 on:
   release:
     types: [published]
+  # Manual fallback: attach installers to an existing release (runs the
+  # workflow from the selected branch instead of the tag's commit).
+  workflow_dispatch:
+    inputs:
+      release_id:
+        description: "ID of an existing GitHub release to attach installers to"
+        required: true
 
 permissions:
   contents: write
@@ -46,7 +53,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -91,5 +97,5 @@ jobs:
           # WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }} # base64-encoded .pfx
           # WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
         with:
-          releaseId: ${{ github.event.release.id }}
+          releaseId: ${{ github.event.release.id || inputs.release_id }}
           args: ${{ matrix.args }}


### PR DESCRIPTION
## Why the v1.0.0 release workflow never ran

1. **release-please published the release with the default `GITHUB_TOKEN`** — GitHub never fires workflow triggers for events created by that token, so `release.yml` (`on: release: published`) was never triggered. Fixed by passing the `RELEASE_PLEASE_TOKEN` PAT secret to the release-please action.
2. **`cache: npm` in setup-node requires a committed `package-lock.json`**, which is gitignored in this repo — all three build jobs failed at setup. Dropped the cache option (matches `ci.yml`).

Also adds a `workflow_dispatch` trigger with a `release_id` input so installers can be built and attached to an existing release without re-publishing it (release-event runs use the workflow file at the tag's commit, so a fixed workflow on main can't be re-fired for an old tag any other way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)