### PR TITLE
fix(rls): restrict funders/industries lookup-table writes to admins

### DIFF
--- a/supabase/migrations/20260713110000_restrict_lookup_table_writes.sql
+++ b/supabase/migrations/20260713110000_restrict_lookup_table_writes.sql
@@ -1,0 +1,46 @@
+-- Security: restrict writes to the funders and industries lookup tables.
+--
+-- These tables were created (20260331050000 / 20260331030000) with permissive
+-- "any authenticated user can INSERT" policies, and add_update_policies
+-- (20260331060000) added equally permissive UPDATE policies. Phase 1
+-- (20260710013532) tightened the portfolio-scoped tables but deliberately left
+-- the lookup tables open.
+--
+-- In practice the app only ever SELECTs funders/industries; both tables are
+-- seeded through migrations (phase1_portfolio_funder_config /
+-- phase1_seed_industries), which run as superuser and bypass RLS. So gating
+-- runtime writes behind is_admin() closes the finding (React Doctor issue #28)
+-- without affecting any app flow. SELECT stays open to all authenticated users.
+--
+-- (states, the third lookup table, already has no write policy at all — RLS
+-- default-deny — so it needs no change.)
+
+-- industries: replace permissive INSERT/UPDATE with admin-only
+DROP POLICY "Authenticated users can insert industries" ON industries;
+DROP POLICY "Authenticated users can update industries" ON industries;
+
+CREATE POLICY "Admins can insert industries"
+  ON industries FOR INSERT
+  TO authenticated
+  WITH CHECK (is_admin());
+
+CREATE POLICY "Admins can update industries"
+  ON industries FOR UPDATE
+  TO authenticated
+  USING (is_admin())
+  WITH CHECK (is_admin());
+
+-- funders: replace permissive INSERT/UPDATE with admin-only
+DROP POLICY "Authenticated users can insert funders" ON funders;
+DROP POLICY "Authenticated users can update funders" ON funders;
+
+CREATE POLICY "Admins can insert funders"
+  ON funders FOR INSERT
+  TO authenticated
+  WITH CHECK (is_admin());
+
+CREATE POLICY "Admins can update funders"
+  ON funders FOR UPDATE
+  TO authenticated
+  USING (is_admin())
+  WITH CHECK (is_admin());


### PR DESCRIPTION
Closes #28.

## Context

React Doctor flagged 7 permissive Supabase RLS write policies. Reviewing each against the live schema:

**5 of 7 were already remediated.** Phase 1 (`20260710013532_phase1_portfolio_access_rls.sql`) dropped the permissive `WITH CHECK (true)` policies on **portfolios, portfolio_funders, deals, and merchants** and replaced them with `is_admin()` / `has_portfolio_access()` gates. React Doctor still flags the historical migration files because it evaluates each `.sql` statically and can't see that a later migration superseded those policies. These stay as baseline — CI gates only on newly-introduced issues per PR, so they don't block anything.

**2 were genuinely still live:** `funders` and `industries` had permissive INSERT (and UPDATE, from `20260331060000_add_update_policies.sql`) policies. The frontend only ever **SELECTs** these tables — both are seeded via migrations (which run as superuser and bypass RLS) — so no app flow writes them at runtime.

## Change

New migration `20260713110000_restrict_lookup_table_writes.sql`:
- Drops the permissive INSERT/UPDATE policies on `funders` and `industries`
- Re-adds INSERT/UPDATE gated behind `is_admin()` (matching the `portfolios` pattern from Phase 1)
- SELECT stays open to all authenticated users

`states` (the third lookup table) needs no change — it already has no write policy, so RLS denies all writes by default.

## Verification

- `npm run db:reset:local` applies all migrations cleanly, including the new one
- `pg_policies` confirms the result: SELECT `true`, INSERT/UPDATE `is_admin()` on both tables
- No `supabase.types.ts` change (policies only, no schema change); no TS/Rust touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)