### PR TITLE
perf: resolve react-doctor performance findings (#31)

### DIFF
--- a/src/components/deal-explorer/chart-builder.tsx
+++ b/src/components/deal-explorer/chart-builder.tsx
@@ -276,9 +276,9 @@ const ChartBuilder = ({
           singleKeySelect(
             "Aggregation",
             config.agg,
-            Object.entries(AGGREGATION_LABELS)
-              .filter(([key]) => key !== "count")
-              .map(([key, label]) => ({ key, label })),
+            Object.entries(AGGREGATION_LABELS).flatMap(([key, label]) =>
+              key === "count" ? [] : [{ key, label }]
+            ),
             (agg) => onConfigChange({ ...config, agg: agg as Aggregation }),
             "w-full sm:max-w-[130px]"
           )}

--- a/src/components/deal-explorer/explorer-table.tsx
+++ b/src/components/deal-explorer/explorer-table.tsx
@@ -74,17 +74,15 @@ const ExplorerTable = ({
   });
 
   // Keep registry order so the table layout is stable however columns are picked.
-  const columns = useMemo(
-    () => [
-      ...DEAL_FIELDS.filter((f) => visibleFields.includes(f.key as string)).map((f) => ({
-        key: f.key as string,
-        label: f.label,
-        type: f.type,
-      })),
+  const columns = useMemo(() => {
+    const visible = new Set(visibleFields);
+    return [
+      ...DEAL_FIELDS.flatMap((f) =>
+        visible.has(f.key as string) ? [{ key: f.key as string, label: f.label, type: f.type }] : []
+      ),
       { key: ACTIONS_KEY, label: "", type: "text" as FieldType },
-    ],
-    [visibleFields]
-  );
+    ];
+  }, [visibleFields]);
 
   const sorted = useMemo(() => {
     const key = String(sort.column) as keyof DealRecord;

--- a/src/components/toast-notification.tsx
+++ b/src/components/toast-notification.tsx
@@ -1,7 +1,7 @@
 import { LazyMotion, domAnimation, m } from "framer-motion";
 import { Card, CardBody, Button } from "@heroui/react";
 import { Icon } from "@iconify/react";
-import { Toast } from "@/contexts/toast-context";
+import { Toast } from "@/contexts/toast-context-value";
 
 interface ToastNotificationProps extends Toast {
   onClose: () => void;

--- a/src/components/toast-notification.tsx
+++ b/src/components/toast-notification.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion";
+import { LazyMotion, domAnimation, m } from "framer-motion";
 import { Card, CardBody, Button } from "@heroui/react";
 import { Icon } from "@iconify/react";
 import { Toast } from "@/contexts/toast-context";
@@ -37,33 +37,41 @@ export default function ToastNotification({
   const iconName = icons[type];
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: -20, scale: 0.95 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      exit={{ opacity: 0, x: 100, scale: 0.95 }}
-      transition={{ duration: 0.2, ease: "easeOut" }}
-      className="pointer-events-auto"
-    >
-      <Card className={`min-w-[320px] max-w-[400px] border-1 ${colors[type]} shadow-lg`} isBlurred>
-        <CardBody className="p-4">
-          <div className="flex items-start gap-3">
-            <Icon icon={iconName} className={`w-5 h-5 mt-0.5 flex-shrink-0 ${iconColors[type]}`} />
-            <div className="flex-1 min-w-0">
-              <p className="font-semibold text-sm">{title}</p>
-              {description && <p className="text-xs mt-1 opacity-90">{description}</p>}
+    <LazyMotion features={domAnimation}>
+      <m.div
+        initial={{ opacity: 0, y: -20, scale: 0.95 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        exit={{ opacity: 0, x: 100, scale: 0.95 }}
+        transition={{ duration: 0.2, ease: "easeOut" }}
+        className="pointer-events-auto"
+      >
+        <Card
+          className={`min-w-[320px] max-w-[400px] border-1 ${colors[type]} shadow-lg`}
+          isBlurred
+        >
+          <CardBody className="p-4">
+            <div className="flex items-start gap-3">
+              <Icon
+                icon={iconName}
+                className={`w-5 h-5 mt-0.5 flex-shrink-0 ${iconColors[type]}`}
+              />
+              <div className="flex-1 min-w-0">
+                <p className="font-semibold text-sm">{title}</p>
+                {description && <p className="text-xs mt-1 opacity-90">{description}</p>}
+              </div>
+              <Button
+                isIconOnly
+                size="sm"
+                variant="light"
+                onPress={onClose}
+                className="min-w-unit-6 w-unit-6 h-unit-6 -mr-1 -mt-1"
+              >
+                <Icon icon="heroicons:x-mark-20-solid" className="w-4 h-4" />
+              </Button>
             </div>
-            <Button
-              isIconOnly
-              size="sm"
-              variant="light"
-              onPress={onClose}
-              className="min-w-unit-6 w-unit-6 h-unit-6 -mr-1 -mt-1"
-            >
-              <Icon icon="heroicons:x-mark-20-solid" className="w-4 h-4" />
-            </Button>
-          </div>
-        </CardBody>
-      </Card>
-    </motion.div>
+          </CardBody>
+        </Card>
+      </m.div>
+    </LazyMotion>
   );
 }

--- a/src/contexts/release-notes-context-value.ts
+++ b/src/contexts/release-notes-context-value.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react";
+
+export interface ReleaseNotesContextType {
+  currentVersion: string;
+  openReleaseNotes: () => void;
+}
+
+export const ReleaseNotesContext = createContext<ReleaseNotesContextType | undefined>(undefined);
+
+export const useReleaseNotes = () => {
+  const context = useContext(ReleaseNotesContext);
+  if (!context) {
+    throw new Error("useReleaseNotes must be used within a ReleaseNotesProvider");
+  }
+  return context;
+};

--- a/src/contexts/release-notes-context.tsx
+++ b/src/contexts/release-notes-context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from "react";
 import { getVersion } from "@tauri-apps/api/app";
 import { getChangelogEntries, type ChangelogEntry } from "@utils/changelog";
 import { ReleaseNotesModal } from "@components/release-notes/release-notes-modal";
@@ -70,13 +70,18 @@ export const ReleaseNotesProvider: React.FC<ReleaseNotesProviderProps> = ({ chil
     if (currentVersion) localStorage.setItem(SEEN_VERSION_KEY, currentVersion);
   };
 
-  const openReleaseNotes = () => {
+  const openReleaseNotes = useCallback(() => {
     setEntries(getChangelogEntries());
     setIsOpen(true);
-  };
+  }, []);
+
+  const value = useMemo(
+    () => ({ currentVersion, openReleaseNotes }),
+    [currentVersion, openReleaseNotes]
+  );
 
   return (
-    <ReleaseNotesContext.Provider value={{ currentVersion, openReleaseNotes }}>
+    <ReleaseNotesContext.Provider value={value}>
       {children}
       <ReleaseNotesModal isOpen={isOpen} onClose={closeModal} entries={entries} />
     </ReleaseNotesContext.Provider>

--- a/src/contexts/release-notes-context.tsx
+++ b/src/contexts/release-notes-context.tsx
@@ -1,24 +1,10 @@
-import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from "react";
+import React, { useEffect, useState, useCallback, useMemo } from "react";
 import { getVersion } from "@tauri-apps/api/app";
 import { getChangelogEntries, type ChangelogEntry } from "@utils/changelog";
 import { ReleaseNotesModal } from "@components/release-notes/release-notes-modal";
+import { ReleaseNotesContext } from "./release-notes-context-value";
 
 const SEEN_VERSION_KEY = "excelerate:releaseNotesSeenVersion";
-
-interface ReleaseNotesContextType {
-  currentVersion: string;
-  openReleaseNotes: () => void;
-}
-
-const ReleaseNotesContext = createContext<ReleaseNotesContextType | undefined>(undefined);
-
-export const useReleaseNotes = () => {
-  const context = useContext(ReleaseNotesContext);
-  if (!context) {
-    throw new Error("useReleaseNotes must be used within a ReleaseNotesProvider");
-  }
-  return context;
-};
 
 interface ReleaseNotesProviderProps {
   children: React.ReactNode;

--- a/src/contexts/theme-context-value.ts
+++ b/src/contexts/theme-context-value.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+
+export type Theme = "light" | "dark";
+
+export interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+};

--- a/src/contexts/theme-context.tsx
+++ b/src/contexts/theme-context.tsx
@@ -1,21 +1,5 @@
-import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from "react";
-
-type Theme = "light" | "dark";
-
-interface ThemeContextType {
-  theme: Theme;
-  toggleTheme: () => void;
-}
-
-const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
-
-export const useTheme = () => {
-  const context = useContext(ThemeContext);
-  if (!context) {
-    throw new Error("useTheme must be used within a ThemeProvider");
-  }
-  return context;
-};
+import React, { useEffect, useState, useCallback, useMemo } from "react";
+import { ThemeContext, type Theme } from "./theme-context-value";
 
 interface ThemeProviderProps {
   children: React.ReactNode;

--- a/src/contexts/theme-context.tsx
+++ b/src/contexts/theme-context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from "react";
 
 type Theme = "light" | "dark";
 
@@ -51,10 +51,12 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
     return () => mediaQuery.removeEventListener("change", handleSystemChange);
   }, []);
 
-  const toggleTheme = () => {
+  const toggleTheme = useCallback(() => {
     // Simply toggle between light and dark
     setTheme((prev) => (prev === "dark" ? "light" : "dark"));
-  };
+  }, []);
 
-  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+  const value = useMemo(() => ({ theme, toggleTheme }), [theme, toggleTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 };

--- a/src/contexts/toast-context-value.ts
+++ b/src/contexts/toast-context-value.ts
@@ -1,0 +1,26 @@
+import { createContext, useContext } from "react";
+
+export type ToastType = "success" | "error" | "warning" | "info";
+
+export interface Toast {
+  id: string;
+  title: string;
+  description?: string;
+  type: ToastType;
+  duration?: number;
+}
+
+export interface ToastContextType {
+  showToast: (toast: Omit<Toast, "id">) => void;
+  hideToast: (id: string) => void;
+}
+
+export const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+};

--- a/src/contexts/toast-context.tsx
+++ b/src/contexts/toast-context.tsx
@@ -1,48 +1,35 @@
-import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from "react";
+import React, { useState, useCallback, useEffect, useMemo } from "react";
 import { AnimatePresence } from "framer-motion";
 import ToastNotification from "@components/toast-notification";
 import { toast } from "@services/toast-service";
-
-export type ToastType = "success" | "error" | "warning" | "info";
-
-export interface Toast {
-  id: string;
-  title: string;
-  description?: string;
-  type: ToastType;
-  duration?: number;
-}
-
-interface ToastContextType {
-  showToast: (toast: Omit<Toast, "id">) => void;
-  hideToast: (id: string) => void;
-}
-
-const ToastContext = createContext<ToastContextType | undefined>(undefined);
+import { ToastContext, type Toast } from "./toast-context-value";
 
 export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const showToast = useCallback((toast: Omit<Toast, "id">) => {
-    const id = Date.now().toString();
-    const newToast = { ...toast, id };
-
-    setToasts((prev) => [...prev, newToast]);
-
-    // Don't auto-dismiss error toasts - require manual dismissal
-    if (toast.type !== "error") {
-      const duration = toast.duration ?? 5000;
-      if (duration > 0) {
-        setTimeout(() => {
-          hideToast(id);
-        }, duration);
-      }
-    }
-  }, []);
-
   const hideToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((toast) => toast.id !== id));
   }, []);
+
+  const showToast = useCallback(
+    (toast: Omit<Toast, "id">) => {
+      const id = Date.now().toString();
+      const newToast = { ...toast, id };
+
+      setToasts((prev) => [...prev, newToast]);
+
+      // Don't auto-dismiss error toasts - require manual dismissal
+      if (toast.type !== "error") {
+        const duration = toast.duration ?? 5000;
+        if (duration > 0) {
+          setTimeout(() => {
+            hideToast(id);
+          }, duration);
+        }
+      }
+    },
+    [hideToast]
+  );
 
   useEffect(() => {
     toast.setToastFunction(showToast);
@@ -62,12 +49,4 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       </div>
     </ToastContext.Provider>
   );
-};
-
-export const useToast = () => {
-  const context = useContext(ToastContext);
-  if (!context) {
-    throw new Error("useToast must be used within a ToastProvider");
-  }
-  return context;
 };

--- a/src/contexts/toast-context.tsx
+++ b/src/contexts/toast-context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback, useEffect } from "react";
+import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from "react";
 import { AnimatePresence } from "framer-motion";
 import ToastNotification from "@components/toast-notification";
 import { toast } from "@services/toast-service";
@@ -48,8 +48,10 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     toast.setToastFunction(showToast);
   }, [showToast]);
 
+  const value = useMemo(() => ({ showToast, hideToast }), [showToast, hideToast]);
+
   return (
-    <ToastContext.Provider value={{ showToast, hideToast }}>
+    <ToastContext.Provider value={value}>
       {children}
       <div className="fixed top-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
         <AnimatePresence>

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -5,7 +5,7 @@ import { items, settingsItem } from "@features/sidebar/sidebar-items";
 import { UserMenu } from "@components/auth/user-menu";
 import { useEffect, useState, useRef } from "react";
 import { Icon } from "@iconify/react";
-import { useTheme } from "@/contexts/theme-context";
+import { useTheme } from "@/contexts/theme-context-value";
 
 function Layout() {
   const navigate = useNavigate();

--- a/src/pages/ai-chat.tsx
+++ b/src/pages/ai-chat.tsx
@@ -165,10 +165,10 @@ function AiChat() {
       });
       if (!selected) return;
       const paths = Array.isArray(selected) ? selected : [selected];
-      for (const path of paths) {
-        const prepared = await prepareChatAttachment(path);
-        setAttachments((prev) => [...prev, prepared]);
-      }
+      // The picks are independent, so prepare them together instead of
+      // awaiting each one in turn.
+      const prepared = await Promise.all(paths.map((path) => prepareChatAttachment(path)));
+      setAttachments((prev) => [...prev, ...prepared]);
     } catch (error) {
       toast.error("Could not attach file", String(error));
     } finally {

--- a/src/pages/deal-lookup.tsx
+++ b/src/pages/deal-lookup.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,
   Card,
@@ -110,8 +110,11 @@ function DealLookup() {
   const [unresolvedRows, setUnresolvedRows] = useState<UnresolvedPivotRow[]>([]);
   const [unresolvedLoading, setUnresolvedLoading] = useState(true);
   const [busyRowId, setBusyRowId] = useState<string | null>(null);
-  /** When set, the next saved deal also resolves this pivot row. */
-  const [pendingResolveRowId, setPendingResolveRowId] = useState<string | null>(null);
+  /**
+   * When set, the next saved deal also resolves this pivot row. A ref, not
+   * state: it is only ever read inside handlers, never rendered.
+   */
+  const pendingResolveRowIdRef = useRef<string | null>(null);
 
   const fetchLookups = useCallback(() => {
     getEditorLookups()
@@ -155,7 +158,7 @@ function DealLookup() {
   const openCreate = () => {
     setEditing(null);
     setCreateDefaults(null);
-    setPendingResolveRowId(null);
+    pendingResolveRowIdRef.current = null;
     setFormOpen(true);
   };
 
@@ -164,7 +167,7 @@ function DealLookup() {
       const values = await getDealFormValues(record.id);
       setEditing({ dealId: record.id, values });
       setCreateDefaults(null);
-      setPendingResolveRowId(null);
+      pendingResolveRowIdRef.current = null;
       setFormOpen(true);
     } catch (err) {
       showToast({
@@ -208,15 +211,16 @@ function DealLookup() {
       funderAdvanceId: row.advance_id ?? "",
       dateFunded: row.report_date,
     });
-    setPendingResolveRowId(row.row_id);
+    pendingResolveRowIdRef.current = row.row_id;
     setFormOpen(true);
   };
 
   const handleSaved = async (dealId: string) => {
     showToast({ title: editing != null ? "Deal updated" : "Deal created", type: "success" });
-    if (pendingResolveRowId != null) {
-      const row = unresolvedRows.find((r) => r.row_id === pendingResolveRowId);
-      setPendingResolveRowId(null);
+    const pendingRowId = pendingResolveRowIdRef.current;
+    if (pendingRowId != null) {
+      const row = unresolvedRows.find((r) => r.row_id === pendingRowId);
+      pendingResolveRowIdRef.current = null;
       if (row != null) {
         await resolveRow(row, dealId);
         fetchLookups();

--- a/src/pages/deal-lookup.tsx
+++ b/src/pages/deal-lookup.tsx
@@ -16,7 +16,7 @@ import {
   Tabs,
 } from "@heroui/react";
 import { Icon } from "@iconify/react";
-import { useToast } from "@/contexts/toast-context";
+import { useToast } from "@/contexts/toast-context-value";
 import { formatMoney } from "@services/analytics-service";
 import {
   applyFilters,

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,8 +1,8 @@
 import { InviteUser } from "@components/auth/invite-user";
 import { useAuth } from "@/contexts/auth-context";
 import { Card, CardBody, CardHeader, Select, SelectItem, Checkbox, Button } from "@heroui/react";
-import { useTheme } from "@/contexts/theme-context";
-import { useReleaseNotes } from "@/contexts/release-notes-context";
+import { useTheme } from "@/contexts/theme-context-value";
+import { useReleaseNotes } from "@/contexts/release-notes-context-value";
 import { Icon } from "@iconify/react";
 import { useState } from "react";
 

--- a/src/services/deal-explorer-service.ts
+++ b/src/services/deal-explorer-service.ts
@@ -99,8 +99,8 @@ export const DIMENSION_FIELDS = DEAL_FIELDS.filter((f) => f.dimension);
 export const NUMERIC_FIELDS = DEAL_FIELDS.filter(
   (f) => f.type === "number" || f.type === "money" || f.type === "percent"
 );
-export const DEFAULT_VISIBLE_FIELDS = DEAL_FIELDS.filter((f) => f.defaultVisible).map(
-  (f) => f.key as string
+export const DEFAULT_VISIBLE_FIELDS = DEAL_FIELDS.flatMap((f) =>
+  f.defaultVisible ? [f.key as string] : []
 );
 
 const moneyFormat = new Intl.NumberFormat("en-US", {
@@ -368,6 +368,14 @@ export function applyFilters(records: DealRecord[], filters: ExplorerFilters): D
   const needle = filters.search.trim().toLowerCase();
   const monthOf = (r: DealRecord) => r.vintage_month?.slice(0, 7) ?? null;
 
+  // Build Sets once so each record's membership check is O(1) instead of
+  // re-scanning the filter arrays for every deal.
+  const portfolios = new Set(filters.portfolios);
+  const funders = new Set(filters.funders);
+  const industries = new Set(filters.industries);
+  const states = new Set(filters.states);
+  const statuses = new Set(filters.statuses);
+
   return records.filter((r) => {
     if (needle) {
       const haystack = [r.merchant_name, r.funder_advance_id, r.advance_id, r.industry, r.state]
@@ -376,13 +384,11 @@ export function applyFilters(records: DealRecord[], filters: ExplorerFilters): D
         .toLowerCase();
       if (!haystack.includes(needle)) return false;
     }
-    if (filters.portfolios.length > 0 && !filters.portfolios.includes(r.portfolio_name ?? ""))
-      return false;
-    if (filters.funders.length > 0 && !filters.funders.includes(r.funder_name ?? "")) return false;
-    if (filters.industries.length > 0 && !filters.industries.includes(r.industry ?? ""))
-      return false;
-    if (filters.states.length > 0 && !filters.states.includes(r.state ?? "")) return false;
-    if (filters.statuses.length > 0 && !filters.statuses.includes(r.status)) return false;
+    if (portfolios.size > 0 && !portfolios.has(r.portfolio_name ?? "")) return false;
+    if (funders.size > 0 && !funders.has(r.funder_name ?? "")) return false;
+    if (industries.size > 0 && !industries.has(r.industry ?? "")) return false;
+    if (states.size > 0 && !states.has(r.state ?? "")) return false;
+    if (statuses.size > 0 && !statuses.has(r.status)) return false;
     const month = monthOf(r);
     if (filters.monthFrom != null && (month == null || month < filters.monthFrom)) return false;
     if (filters.monthTo != null && (month == null || month > filters.monthTo)) return false;
@@ -631,11 +637,10 @@ export function buildChartData(records: DealRecord[], config: ChartConfig): Char
 /** Pie slices from chart rows: one slice per category, top slices + "Other". */
 export function chartRowsToPie(data: ChartData, maxSlices = 11): { name: string; value: number }[] {
   const slices = data.rows
-    .map((row) => ({
-      name: row.category,
-      value: data.series.reduce((acc, s) => acc + Math.max(row[s] as number, 0), 0),
-    }))
-    .filter((s) => s.value > 0)
+    .flatMap((row) => {
+      const value = data.series.reduce((acc, s) => acc + Math.max(row[s] as number, 0), 0);
+      return value > 0 ? [{ name: row.category, value }] : [];
+    })
     .sort((a, b) => b.value - a.value);
   if (slices.length <= maxSlices) return slices;
   const rest = slices.slice(maxSlices).reduce((acc, s) => acc + s.value, 0);

--- a/src/services/toast-service.ts
+++ b/src/services/toast-service.ts
@@ -1,4 +1,4 @@
-import { Toast } from "@/contexts/toast-context";
+import { Toast } from "@/contexts/toast-context-value";
 
 type ShowToastFn = (toast: Omit<Toast, "id">) => void;
 

--- a/src/services/workbook-export-service.ts
+++ b/src/services/workbook-export-service.ts
@@ -262,8 +262,10 @@ export function buildFunderSheets(inputs: FunderSheetInputs): FunderSheetExport[
         // The unique (deal_id, payment_date) constraint guarantees one cell
         // per date, so the sparse pairs never collide.
         const payments: [number, number][] = dealPayments
-          .map((p): [number, number] => [dateIndex.get(p.payment_date) ?? -1, p.net])
-          .filter(([idx]) => idx >= 0)
+          .flatMap((p): [number, number][] => {
+            const idx = dateIndex.get(p.payment_date) ?? -1;
+            return idx >= 0 ? [[idx, p.net]] : [];
+          })
           .sort((a, b) => a[0] - b[0]);
         return {
           date_funded: deal.date_funded,
@@ -335,9 +337,10 @@ export function buildRtrExport(
   }
   return {
     dates,
-    funders: funderOrder
-      .filter((f) => valuesByFunder.has(f.id))
-      .map((f) => ({ name: f.name, values: valuesByFunder.get(f.id)! })),
+    funders: funderOrder.flatMap((f) => {
+      const values = valuesByFunder.get(f.id);
+      return values ? [{ name: f.name, values }] : [];
+    }),
   };
 }
 
@@ -472,17 +475,17 @@ async function fetchWorkbookData(portfolioName: string): Promise<WorkbookExportD
     list.push(v);
     vintagesByFunder.set(v.funder_id, list);
   }
-  const vintageSheets = funderSheets
-    .map((sheet) => {
-      const funder = funders.find((f) => (f.sheet_name ?? f.name) === sheet.sheet_name);
-      const rows = funder ? (vintagesByFunder.get(funder.id) ?? []) : [];
-      return { sheet_name: `${sheet.sheet_name}-P`, rows: rows.map(vintageRow) };
-    })
-    .filter((sheet) => sheet.rows.length > 0);
+  const vintageSheets = funderSheets.flatMap((sheet) => {
+    const funder = funders.find((f) => (f.sheet_name ?? f.name) === sheet.sheet_name);
+    const rows = funder ? (vintagesByFunder.get(funder.id) ?? []) : [];
+    if (rows.length === 0) return [];
+    return [{ sheet_name: `${sheet.sheet_name}-P`, rows: rows.map(vintageRow) }];
+  });
 
-  const funderOrder = funders
-    .filter((f) => funderSheets.some((s) => s.sheet_name === (f.sheet_name ?? f.name)))
-    .map((f) => ({ id: f.id, name: f.name }));
+  const sheetNames = new Set(funderSheets.map((s) => s.sheet_name));
+  const funderOrder = funders.flatMap((f) =>
+    sheetNames.has(f.sheet_name ?? f.name) ? [{ id: f.id, name: f.name }] : []
+  );
 
   const funderNameById = new Map(funders.map((f) => [f.id, f.name]));
 

--- a/src/services/workbook-import-service.ts
+++ b/src/services/workbook-import-service.ts
@@ -179,21 +179,14 @@ export class WorkbookImportService {
     const results = new Map<string, SheetImportResult>();
     const total = preview.sheets.length;
     for (const [index, sheetPreview] of preview.sheets.entries()) {
-      onProgress?.({
-        phase: "importing",
-        index,
-        total,
-        sheetName: sheetPreview.sheet.sheet_name,
-      });
+      const sheetName = sheetPreview.sheet.sheet_name;
+      onProgress?.({ phase: "importing", index, total, sheetName });
+      // Sequential by design (see doc comment): each sheet is its own transaction
+      // and progress is reported per sheet, so parallelising would break both.
+      // react-doctor-disable-next-line react-doctor/async-await-in-loop
       const result = await this.importSheet(preview.portfolioId, sheetPreview);
-      results.set(sheetPreview.sheet.sheet_name, result);
-      onProgress?.({
-        phase: "done",
-        index,
-        total,
-        sheetName: sheetPreview.sheet.sheet_name,
-        result,
-      });
+      results.set(sheetName, result);
+      onProgress?.({ phase: "done", index, total, sheetName, result });
     }
     return results;
   }


### PR DESCRIPTION
Closes #31. Part of #34 (React Doctor baseline).

Resolves the **src/** Performance findings from the React Doctor baseline. `pro-examples/` findings (all `prefer-dynamic-import` there + every `js-hoist-intl`) are left untouched per the repo do-not-touch convention — the same approach the prior a11y PR (#38) took.

## Changes by rule

- **`js-combine-iterations` ×8** — fold `.map().filter()` chains into single-pass `.flatMap()` in `deal-explorer-service`, `workbook-export-service`, `explorer-table`, and `chart-builder`.
- **`js-set-map-lookups` ×6** — build `Set`s once for `applyFilters` membership checks and the `explorer-table` column filter instead of re-scanning arrays per record; also drops an O(n·m) `.some()` in the funder export.
- **`jsx-no-constructed-context-values` ×3** — memoize the theme/toast/release-notes provider values (and their handlers) so consumers stop re-rendering every render.
- **`async-await-in-loop` ×2** — parallelize independent chat-attachment prepares with `Promise.all`. The `WorkbookImportService.importAll` loop stays sequential **by design** (one transaction per sheet + per-sheet progress reporting, as its doc comment states) and is suppressed with an inline `react-doctor-disable-next-line` + justification.
- **`js-cache-property-access` ×1** — hoist `sheetPreview.sheet.sheet_name` in `importAll`.
- **`use-lazy-motion` ×1** — swap framer-motion `motion` for `LazyMotion` + `m` in the toast notification.
- **`rerender-state-only-in-handlers` ×1** — move deal-lookup's `pendingResolveRowId` to a `useRef`; it is only read inside handlers, never rendered.

## Deliberately not done

- **`prefer-dynamic-import` (recharts) in 2 src files** (`dashboard/charts.tsx`, `deal-explorer/chart-builder.tsx`) — left eager. This is a Tauri desktop app (local bundle, no network page-load), so code-splitting recharts gives marginal startup benefit while adding Suspense fallbacks and a brief chart loading state.

## Verification

- `react-doctor` reports **0 remaining findings** in `src/` for all rules addressed here.
- `npm run lint` (0 errors, warnings under the 17 cap), `npm run format:check`, and `npm run build` all pass. No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)