### PR TITLE
fix(react-doctor): resolve bug-level warnings (#30)

### DIFF
--- a/src/components/ai-chat/chat-message-view.tsx
+++ b/src/components/ai-chat/chat-message-view.tsx
@@ -126,6 +126,18 @@ function UserBlock({ block }: { block: ChatBlock }) {
   return null;
 }
 
+function AssistantBlock({ block }: { block: ChatBlock }) {
+  if (block.kind === "text") return <Markdown text={block.text} />;
+  if (block.kind === "tool_use") {
+    return (
+      <div>
+        <ToolChip name={block.name} detail={summarizeToolInput(block.input)} />
+      </div>
+    );
+  }
+  return null;
+}
+
 /** Concatenated text of an assistant message, for copying to the clipboard. */
 function assistantText(message: ChatMessage): string {
   return message.blocks
@@ -201,6 +213,7 @@ export function MessageView({
       <div className="flex justify-end">
         <div className="flex max-w-[75%] flex-col items-end gap-1 rounded-large bg-primary-50 px-4 py-2">
           {message.blocks.map((block, i) => (
+            // react-doctor-disable-next-line react-doctor/no-array-index-as-key -- a message's blocks are fixed at creation and never reorder or filter, so the position is a stable key
             <UserBlock key={i} block={block} />
           ))}
         </div>
@@ -211,17 +224,10 @@ export function MessageView({
   return (
     <div className="group flex justify-start">
       <div className="flex max-w-[85%] flex-col gap-2">
-        {message.blocks.map((block, i) => {
-          if (block.kind === "text") return <Markdown key={i} text={block.text} />;
-          if (block.kind === "tool_use") {
-            return (
-              <div key={i}>
-                <ToolChip name={block.name} detail={summarizeToolInput(block.input)} />
-              </div>
-            );
-          }
-          return null;
-        })}
+        {message.blocks.map((block, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key -- a message's blocks are fixed at creation and never reorder or filter, so the position is a stable key
+          <AssistantBlock key={i} block={block} />
+        ))}
         <MessageActions text={assistantText(message)} onRetry={onRetry} />
       </div>
     </div>
@@ -232,19 +238,24 @@ export type LiveSegment =
   | { type: "text"; text: string }
   | { type: "tool"; id: string; name: string; status: "running" | "done" | "error" };
 
+function LiveSegmentItem({ segment }: { segment: LiveSegment }) {
+  if (segment.type === "text") return <Markdown text={segment.text} />;
+  return (
+    <div className="flex items-center gap-2">
+      <ToolChip name={segment.name} isError={segment.status === "error"} />
+      {segment.status === "running" && <Spinner size="sm" />}
+    </div>
+  );
+}
+
 export function LiveMessageView({ segments }: { segments: LiveSegment[] }) {
   return (
     <div className="flex justify-start">
       <div className="flex max-w-[85%] flex-col gap-2">
-        {segments.map((segment, i) => {
-          if (segment.type === "text") return <Markdown key={i} text={segment.text} />;
-          return (
-            <div key={i} className="flex items-center gap-2">
-              <ToolChip name={segment.name} isError={segment.status === "error"} />
-              {segment.status === "running" && <Spinner size="sm" />}
-            </div>
-          );
-        })}
+        {segments.map((segment, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key -- streamed segments are appended in order and never reorder or filter, so the position is a stable key
+          <LiveSegmentItem key={i} segment={segment} />
+        ))}
         {segments.length === 0 && <Spinner size="sm" label="Thinking…" labelColor="foreground" />}
       </div>
     </div>

--- a/src/components/auth/invite-user.tsx
+++ b/src/components/auth/invite-user.tsx
@@ -3,6 +3,7 @@ import { Button, Input, Card, CardBody, CardHeader, Select, SelectItem } from "@
 import { useAuth } from "@/contexts/auth-context";
 import { AuthService } from "@services/auth-service";
 
+// react-doctor-disable-next-line react-doctor/prefer-useReducer -- these hold largely independent concerns (form fields, per-field validation errors, async submit status) that change at different times, so a single reducer would not improve consistency
 export function InviteUser() {
   const { profile } = useAuth();
   const [email, setEmail] = useState("");

--- a/src/components/dashboard/charts.tsx
+++ b/src/components/dashboard/charts.tsx
@@ -328,8 +328,8 @@ export const AllocationPieCard = ({
                   if (!payload || payload.length === 0) return null;
                   return (
                     <div className="rounded-medium bg-background text-tiny shadow-small p-2">
-                      {payload.map((entry, index) => (
-                        <div key={index} className="flex items-center gap-x-2">
+                      {payload.map((entry) => (
+                        <div key={entry.name} className="flex items-center gap-x-2">
                           <div
                             className="h-2 w-2 rounded-full"
                             style={{ backgroundColor: entry.payload.fill }}

--- a/src/components/date/monthly-date-picker.tsx
+++ b/src/components/date/monthly-date-picker.tsx
@@ -1,77 +1,47 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React from "react";
 import { DatePicker } from "@heroui/react";
-import {
-  CalendarDate,
-  getLocalTimeZone,
-  today,
-  DateValue,
-  ZonedDateTime,
-  toZoned,
-  toCalendarDate,
-} from "@internationalized/date";
+import { getLocalTimeZone, today, DateValue } from "@internationalized/date";
+import { getMostRecentCompletedMonth } from "@utils/report-month";
 
 interface MonthlyDatePickerProps {
-  onDateChange?: (date: DateValue | null) => void;
+  value: DateValue | null;
+  onDateChange: (date: DateValue | null) => void;
   label?: string;
   description?: string;
   className?: string;
 }
 
 const MonthlyDatePicker: React.FC<MonthlyDatePickerProps> = ({
+  value,
   onDateChange,
   label = "Select Month",
   description = "Choose a report month",
   className,
 }) => {
-  const getMostRecentCompletedMonth = (): CalendarDate => {
-    const todayDate = today(getLocalTimeZone());
-    // Use previous month (most recently completed)
-    const firstOfThisMonth = new CalendarDate(todayDate.year, todayDate.month, 1);
-    const prevMonth = firstOfThisMonth.subtract({ months: 1 });
-    // Return last day of that month
-    const firstOfNextMonth = prevMonth.add({ months: 1 });
-    return firstOfNextMonth.subtract({ days: 1 });
-  };
-
-  const initialDate = toZoned(getMostRecentCompletedMonth(), getLocalTimeZone());
-  const [selectedDate, setSelectedDate] = useState<ZonedDateTime | null>(initialDate);
-
-  useEffect(() => {
-    if (initialDate && onDateChange) {
-      onDateChange(toCalendarDate(initialDate));
-    }
-  }, []);
-
   const isDateUnavailable = (date: DateValue): boolean => {
-    // Only allow last day of each month
+    // Only allow the last day of each month.
     const jsDate = date.toDate(getLocalTimeZone());
     const nextDay = new Date(jsDate);
     nextDay.setDate(jsDate.getDate() + 1);
     return nextDay.getMonth() === jsDate.getMonth();
   };
 
-  const handleDateChange = (date: ZonedDateTime | null) => {
+  const handleDateChange = (date: DateValue | null) => {
     if (date && !isDateUnavailable(date)) {
-      setSelectedDate(date);
-      onDateChange?.(toCalendarDate(date));
+      onDateChange(date);
     }
   };
 
-  const minDate = useMemo((): DateValue => {
-    return today(getLocalTimeZone()).subtract({ years: 2 });
-  }, []);
-
-  // Max = last day of previous month (no future months)
-  const maxDate = useMemo((): DateValue => {
-    return getMostRecentCompletedMonth();
-  }, []);
+  const minDate: DateValue = today(getLocalTimeZone()).subtract({ years: 2 });
+  // Max = last day of previous month (no future months).
+  const maxDate: DateValue = getMostRecentCompletedMonth();
 
   return (
     <div className={`w-full ${className || ""}`}>
       <DatePicker
         label={label}
         description={description}
-        value={selectedDate}
+        value={value}
         onChange={handleDateChange}
         isDateUnavailable={isDateUnavailable}
         minValue={minDate}

--- a/src/components/deal-explorer/chart-builder.tsx
+++ b/src/components/deal-explorer/chart-builder.tsx
@@ -133,8 +133,8 @@ const ChartBuilder = ({
                   const total = pieSlices.reduce((acc, s) => acc + s.value, 0);
                   return (
                     <div className="rounded-medium bg-background text-tiny shadow-small p-2">
-                      {payload.map((entry, index) => (
-                        <div key={index} className="flex items-center gap-x-2">
+                      {payload.map((entry) => (
+                        <div key={entry.name} className="flex items-center gap-x-2">
                           <span
                             className="h-2 w-2 rounded-full"
                             style={{ backgroundColor: entry.payload.fill }}

--- a/src/components/deal-explorer/pivot-builder.tsx
+++ b/src/components/deal-explorer/pivot-builder.tsx
@@ -133,7 +133,7 @@ const PivotBuilder = ({
                   </td>
                   {row.values.map((value, index) => (
                     <td
-                      key={index}
+                      key={pivot.colLabels[index]}
                       className="text-right px-2 py-1.5 border-b border-divider whitespace-nowrap tabular-nums"
                     >
                       {format(value)}
@@ -147,7 +147,10 @@ const PivotBuilder = ({
               <tr className="font-semibold">
                 <td className="px-2 py-2">Total</td>
                 {pivot.colTotals.map((value, index) => (
-                  <td key={index} className="text-right px-2 py-2 whitespace-nowrap tabular-nums">
+                  <td
+                    key={pivot.colLabels[index]}
+                    className="text-right px-2 py-2 whitespace-nowrap tabular-nums"
+                  >
                     {format(value)}
                   </td>
                 ))}

--- a/src/components/portfolio/base-portfolio.tsx
+++ b/src/components/portfolio/base-portfolio.tsx
@@ -7,7 +7,8 @@ import FunderUploadSection, { FunderData } from "./funder-upload-section";
 
 interface BasePortfolioProps {
   portfolioName: string;
-  onDateChange?: (date: DateValue | null) => void;
+  selectedDate: DateValue | null;
+  onDateChange: (date: DateValue | null) => void;
   monthlyFunders?: FunderData[];
   onMonthlyFunderUpload?: (funderName: string, file: File) => void;
   onMonthlyClearFile?: (funderName: string) => void;
@@ -20,6 +21,7 @@ interface BasePortfolioProps {
 
 const BasePortfolio: React.FC<BasePortfolioProps> = ({
   portfolioName,
+  selectedDate,
   onDateChange,
   monthlyFunders,
   onMonthlyFunderUpload,
@@ -47,6 +49,7 @@ const BasePortfolio: React.FC<BasePortfolioProps> = ({
             <MonthlyDatePicker
               label="Report Month"
               description="Select the month for this portfolio report"
+              value={selectedDate}
               onDateChange={onDateChange}
             />
           </div>

--- a/src/components/portfolio/workbook-import-wizard.tsx
+++ b/src/components/portfolio/workbook-import-wizard.tsx
@@ -241,8 +241,8 @@ export function WorkbookImportWizard({ portfolioName }: WorkbookImportWizardProp
                           {allWarnings.length} parser warning{allWarnings.length === 1 ? "" : "s"}
                         </p>
                         <ul className="text-xs text-warning-700 list-disc pl-4 max-h-24 overflow-y-auto">
-                          {allWarnings.map((w, i) => (
-                            <li key={i}>{w}</li>
+                          {allWarnings.map((w) => (
+                            <li key={w}>{w}</li>
                           ))}
                         </ul>
                       </div>

--- a/src/components/release-notes/release-notes-modal.tsx
+++ b/src/components/release-notes/release-notes-modal.tsx
@@ -28,8 +28,8 @@ export function ReleaseNotesModal({ isOpen, onClose, entries }: Props) {
                     {section.heading}
                   </p>
                   <ul className="list-disc list-inside space-y-1 text-small text-default-600">
-                    {section.items.map((item, i) => (
-                      <li key={i}>{item}</li>
+                    {section.items.map((item) => (
+                      <li key={item}>{item}</li>
                     ))}
                   </ul>
                 </div>

--- a/src/features/sidebar/sidebar.tsx
+++ b/src/features/sidebar/sidebar.tsx
@@ -80,180 +80,175 @@ const Sidebar = React.forwardRef<HTMLElement, SidebarProps>(
       }),
     };
 
-    const renderNestItem = React.useCallback(
-      (item: SidebarItem) => {
-        const isNestType =
-          item.items && item.items?.length > 0 && item?.type === SidebarItemType.Nest;
+    // Plain render helpers (not useCallback): renderNestItem and renderItem are
+    // mutually recursive, so neither can list the other in a dependency array
+    // without a use-before-declaration cycle. They are invoked inline during
+    // render rather than passed to memoized children, so memoizing them buys
+    // nothing anyway.
+    const renderNestItem = (item: SidebarItem) => {
+      const isNestType =
+        item.items && item.items?.length > 0 && item?.type === SidebarItemType.Nest;
 
-        if (isNestType) {
-          // Is a nest type item , so we need to remove the href
-          delete item.href;
-        }
+      if (isNestType) {
+        // Is a nest type item , so we need to remove the href
+        delete item.href;
+      }
 
-        const { key, ...itemProps } = item;
+      const { key, ...itemProps } = item;
 
-        return (
-          <ListboxItem
-            key={key}
-            {...itemProps}
-            classNames={{
-              base: cn(
-                {
-                  "h-auto p-0": !isCompact && isNestType,
-                },
-                {
-                  "inline-block w-11": isCompact && isNestType,
+      return (
+        <ListboxItem
+          key={key}
+          {...itemProps}
+          classNames={{
+            base: cn(
+              {
+                "h-auto p-0": !isCompact && isNestType,
+              },
+              {
+                "inline-block w-11": isCompact && isNestType,
+              }
+            ),
+          }}
+          endContent={isCompact || isNestType || hideEndContent ? null : (item.endContent ?? null)}
+          startContent={
+            isCompact || isNestType ? null : item.icon ? (
+              <Icon
+                className={cn(
+                  "text-default-500 group-data-[selected=true]:text-foreground",
+                  iconClassName
+                )}
+                icon={item.icon}
+                width={24}
+              />
+            ) : (
+              (item.startContent ?? null)
+            )
+          }
+          title={isCompact || isNestType ? null : item.title}
+        >
+          {isCompact ? (
+            <Tooltip content={item.title} placement="right">
+              <div className="flex w-full items-center justify-center">
+                {item.icon ? (
+                  <Icon
+                    className={cn(
+                      "text-default-500 group-data-[selected=true]:text-foreground",
+                      iconClassName
+                    )}
+                    icon={item.icon}
+                    width={24}
+                  />
+                ) : (
+                  (item.startContent ?? null)
+                )}
+              </div>
+            </Tooltip>
+          ) : null}
+          {!isCompact && isNestType ? (
+            <Accordion className={"p-0"}>
+              <AccordionItem
+                key={item.key}
+                aria-label={item.title}
+                classNames={{
+                  heading: "pr-3",
+                  trigger: "p-0",
+                  content: "py-0 pl-4",
+                }}
+                title={
+                  item.icon ? (
+                    <div className={"flex h-11 items-center gap-2 px-2 py-1.5"}>
+                      <Icon
+                        className={cn(
+                          "text-default-500 group-data-[selected=true]:text-foreground",
+                          iconClassName
+                        )}
+                        icon={item.icon}
+                        width={24}
+                      />
+                      <span className="text-small text-default-500 group-data-[selected=true]:text-foreground font-medium">
+                        {item.title}
+                      </span>
+                    </div>
+                  ) : (
+                    (item.startContent ?? null)
+                  )
                 }
-              ),
-            }}
-            endContent={
-              isCompact || isNestType || hideEndContent ? null : (item.endContent ?? null)
-            }
-            startContent={
-              isCompact || isNestType ? null : item.icon ? (
-                <Icon
-                  className={cn(
-                    "text-default-500 group-data-[selected=true]:text-foreground",
-                    iconClassName
-                  )}
-                  icon={item.icon}
-                  width={24}
-                />
-              ) : (
-                (item.startContent ?? null)
-              )
-            }
-            title={isCompact || isNestType ? null : item.title}
-          >
-            {isCompact ? (
-              <Tooltip content={item.title} placement="right">
-                <div className="flex w-full items-center justify-center">
-                  {item.icon ? (
-                    <Icon
-                      className={cn(
-                        "text-default-500 group-data-[selected=true]:text-foreground",
-                        iconClassName
-                      )}
-                      icon={item.icon}
-                      width={24}
-                    />
-                  ) : (
-                    (item.startContent ?? null)
-                  )}
-                </div>
-              </Tooltip>
-            ) : null}
-            {!isCompact && isNestType ? (
-              <Accordion className={"p-0"}>
-                <AccordionItem
-                  key={item.key}
-                  aria-label={item.title}
-                  classNames={{
-                    heading: "pr-3",
-                    trigger: "p-0",
-                    content: "py-0 pl-4",
-                  }}
-                  title={
-                    item.icon ? (
-                      <div className={"flex h-11 items-center gap-2 px-2 py-1.5"}>
-                        <Icon
-                          className={cn(
-                            "text-default-500 group-data-[selected=true]:text-foreground",
-                            iconClassName
-                          )}
-                          icon={item.icon}
-                          width={24}
-                        />
-                        <span className="text-small text-default-500 group-data-[selected=true]:text-foreground font-medium">
-                          {item.title}
-                        </span>
-                      </div>
-                    ) : (
-                      (item.startContent ?? null)
-                    )
-                  }
-                >
-                  {item.items && item.items?.length > 0 ? (
-                    <Listbox
-                      className={"mt-0.5"}
-                      classNames={{
-                        list: cn("border-l border-default-200 pl-4"),
-                      }}
-                      items={item.items}
-                      variant="flat"
-                    >
-                      {item.items.map(renderItem)}
-                    </Listbox>
-                  ) : (
-                    renderItem(item)
-                  )}
-                </AccordionItem>
-              </Accordion>
-            ) : null}
-          </ListboxItem>
-        );
-      },
+              >
+                {item.items && item.items?.length > 0 ? (
+                  <Listbox
+                    className={"mt-0.5"}
+                    classNames={{
+                      list: cn("border-l border-default-200 pl-4"),
+                    }}
+                    items={item.items}
+                    variant="flat"
+                  >
+                    {item.items.map(renderItem)}
+                  </Listbox>
+                ) : (
+                  renderItem(item)
+                )}
+              </AccordionItem>
+            </Accordion>
+          ) : null}
+        </ListboxItem>
+      );
+    };
 
-      [isCompact, hideEndContent, iconClassName, items]
-    );
+    const renderItem = (item: SidebarItem) => {
+      const isNestType =
+        item.items && item.items?.length > 0 && item?.type === SidebarItemType.Nest;
 
-    const renderItem = React.useCallback(
-      (item: SidebarItem) => {
-        const isNestType =
-          item.items && item.items?.length > 0 && item?.type === SidebarItemType.Nest;
+      if (isNestType) {
+        return renderNestItem(item);
+      }
 
-        if (isNestType) {
-          return renderNestItem(item);
-        }
+      const { key, ...itemProps } = item;
 
-        const { key, ...itemProps } = item;
-
-        return (
-          <ListboxItem
-            key={key}
-            {...itemProps}
-            endContent={isCompact || hideEndContent ? null : (item.endContent ?? null)}
-            startContent={
-              isCompact ? null : item.icon ? (
-                <Icon
-                  className={cn(
-                    "text-default-500 group-data-[selected=true]:text-foreground",
-                    iconClassName
-                  )}
-                  icon={item.icon}
-                  width={24}
-                />
-              ) : (
-                (item.startContent ?? null)
-              )
-            }
-            textValue={item.title}
-            title={isCompact ? null : item.title}
-          >
-            {isCompact ? (
-              <Tooltip content={item.title} placement="right">
-                <div className="flex w-full items-center justify-center">
-                  {item.icon ? (
-                    <Icon
-                      className={cn(
-                        "text-default-500 group-data-[selected=true]:text-foreground",
-                        iconClassName
-                      )}
-                      icon={item.icon}
-                      width={24}
-                    />
-                  ) : (
-                    (item.startContent ?? null)
-                  )}
-                </div>
-              </Tooltip>
-            ) : null}
-          </ListboxItem>
-        );
-      },
-
-      [isCompact, hideEndContent, iconClassName, itemClasses?.base]
-    );
+      return (
+        <ListboxItem
+          key={key}
+          {...itemProps}
+          endContent={isCompact || hideEndContent ? null : (item.endContent ?? null)}
+          startContent={
+            isCompact ? null : item.icon ? (
+              <Icon
+                className={cn(
+                  "text-default-500 group-data-[selected=true]:text-foreground",
+                  iconClassName
+                )}
+                icon={item.icon}
+                width={24}
+              />
+            ) : (
+              (item.startContent ?? null)
+            )
+          }
+          textValue={item.title}
+          title={isCompact ? null : item.title}
+        >
+          {isCompact ? (
+            <Tooltip content={item.title} placement="right">
+              <div className="flex w-full items-center justify-center">
+                {item.icon ? (
+                  <Icon
+                    className={cn(
+                      "text-default-500 group-data-[selected=true]:text-foreground",
+                      iconClassName
+                    )}
+                    icon={item.icon}
+                    width={24}
+                  />
+                ) : (
+                  (item.startContent ?? null)
+                )}
+              </div>
+            </Tooltip>
+          ) : null}
+        </ListboxItem>
+      );
+    };
 
     return (
       <Listbox

--- a/src/pages/ai-chat.tsx
+++ b/src/pages/ai-chat.tsx
@@ -70,6 +70,15 @@ function titleFrom(text: string, fallback: string): string {
   return trimmed.length > 60 ? `${trimmed.slice(0, 60)}…` : trimmed;
 }
 
+/**
+ * A prepared attachment plus a client-generated id, so the pending-attachment
+ * chips have a stable key while the user adds and removes them before sending.
+ */
+interface LocalAttachment extends PreparedAttachment {
+  id: string;
+}
+
+// react-doctor-disable-next-line react-doctor/prefer-useReducer -- these hold largely independent concerns (settings, conversation list, active messages, composer input, attachments, streaming status) that change at different times, so a single reducer would not improve consistency
 function AiChat() {
   const [settings, setSettings] = useState<AiSettings | null>(null);
   const [provider, setProvider] = useState<AiProvider>("anthropic");
@@ -81,7 +90,7 @@ function AiChat() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
 
   const [input, setInput] = useState("");
-  const [attachments, setAttachments] = useState<PreparedAttachment[]>([]);
+  const [attachments, setAttachments] = useState<LocalAttachment[]>([]);
   const [attaching, setAttaching] = useState(false);
   const [streaming, setStreaming] = useState(false);
   const [liveSegments, setLiveSegments] = useState<LiveSegment[]>([]);
@@ -168,7 +177,11 @@ function AiChat() {
       // The picks are independent, so prepare them together instead of
       // awaiting each one in turn.
       const prepared = await Promise.all(paths.map((path) => prepareChatAttachment(path)));
-      setAttachments((prev) => [...prev, ...prepared]);
+      const withIds: LocalAttachment[] = prepared.map((attachment) => ({
+        ...attachment,
+        id: crypto.randomUUID(),
+      }));
+      setAttachments((prev) => [...prev, ...withIds]);
     } catch (error) {
       toast.error("Could not attach file", String(error));
     } finally {
@@ -449,6 +462,7 @@ function AiChat() {
               </div>
             )}
             {messages.map((message, i) => (
+              // react-doctor-disable-next-line react-doctor/no-array-index-as-key -- the conversation log is append-only and only ever truncated from the end (retry), so it never reorders or filters mid-list
               <MessageView
                 key={i}
                 message={message}
@@ -467,13 +481,15 @@ function AiChat() {
         <div className="mx-auto w-full max-w-3xl pt-3">
           {attachments.length > 0 && (
             <div className="mb-2 flex flex-wrap gap-2">
-              {attachments.map((attachment, i) => (
+              {attachments.map((attachment) => (
                 <Chip
-                  key={i}
+                  key={attachment.id}
                   size="sm"
                   variant="flat"
                   color="secondary"
-                  onClose={() => setAttachments((prev) => prev.filter((_, j) => j !== i))}
+                  onClose={() =>
+                    setAttachments((prev) => prev.filter((a) => a.id !== attachment.id))
+                  }
                 >
                   {attachment.name}
                 </Chip>

--- a/src/pages/alder-portfolio.tsx
+++ b/src/pages/alder-portfolio.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { DateValue } from "@internationalized/date";
 import BasePortfolio from "@components/portfolio/base-portfolio";
+import { getMostRecentCompletedMonth } from "@utils/report-month";
 import { FunderData } from "@components/portfolio/funder-upload-section";
 import PivotSyncService, { CloudUploadInfo, uiFunderName } from "@services/pivot-sync-service";
 import WorkbookExportService from "@services/workbook-export-service";
@@ -71,7 +72,7 @@ const monthlyFunderList: FunderData[] = [
 
 function AlderPortfolio() {
   const [monthlyFiles, setMonthlyFiles] = useState<Record<string, File>>({});
-  const [selectedDate, setSelectedDate] = useState<DateValue | null>(null);
+  const [selectedDate, setSelectedDate] = useState<DateValue | null>(getMostRecentCompletedMonth);
   const [funderUploads, setFunderUploads] = useState<CloudUploadInfo[]>([]);
   const [isExporting, setIsExporting] = useState(false);
   const { monthlyErrorStates, setFunderErrorState } = useFileErrorState();
@@ -101,16 +102,21 @@ function AlderPortfolio() {
     }
   }, []);
 
+  // Load the default month's uploads once on mount. Later changes are handled
+  // synchronously in handleDateChange, so no effect reacts to selectedDate.
   useEffect(() => {
-    if (!selectedDate) {
+    refreshUploads(getMostRecentCompletedMonth().toString());
+  }, [refreshUploads]);
+
+  const handleDateChange = (date: DateValue | null) => {
+    setSelectedDate(date);
+    if (date) {
+      refreshUploads(date.toString());
+    } else {
       setFunderUploads([]);
       setMonthlyFiles({});
-      return;
     }
-    refreshUploads(selectedDate.toString());
-  }, [selectedDate, refreshUploads]);
-
-  const handleDateChange = (date: DateValue | null) => setSelectedDate(date);
+  };
 
   const handleMonthlyFunderUpload = async (funderName: string, file: File) => {
     if (!selectedDate) return;
@@ -193,6 +199,7 @@ function AlderPortfolio() {
     <>
       <BasePortfolio
         portfolioName={PORTFOLIO}
+        selectedDate={selectedDate}
         onDateChange={handleDateChange}
         monthlyFunders={monthlyFunderList}
         onMonthlyFunderUpload={handleMonthlyFunderUpload}

--- a/src/pages/deal-lookup.tsx
+++ b/src/pages/deal-lookup.tsx
@@ -58,7 +58,9 @@ const EMPTY_LOOKUPS: EditorLookups = {
   merchants: [],
 };
 
-const VIEWS_STORAGE_KEY = "excelerate.deal-lookup.views";
+// Versioned so a future change to the SavedView shape can bump the suffix and
+// ignore incompatible saved data instead of crashing on parse.
+const VIEWS_STORAGE_KEY = "excelerate.deal-lookup.views:v1";
 
 interface SavedView {
   id: string;
@@ -81,6 +83,7 @@ function loadSavedViews(): SavedView[] {
 const uniqueSorted = (values: (string | null)[]): string[] =>
   [...new Set(values.filter((v): v is string => v != null && v !== ""))].sort();
 
+// react-doctor-disable-next-line react-doctor/prefer-useReducer -- these hold largely independent concerns (records, load status, filters, visible fields, pivot/chart config, saved views) that change at different times, so a single reducer would not improve consistency
 function DealLookup() {
   const { showToast } = useToast();
   const [records, setRecords] = useState<DealRecord[]>([]);

--- a/src/pages/white-rabbit-portfolio.tsx
+++ b/src/pages/white-rabbit-portfolio.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { DateValue } from "@internationalized/date";
 import BasePortfolio from "@components/portfolio/base-portfolio";
+import { getMostRecentCompletedMonth } from "@utils/report-month";
 import { FunderData } from "@components/portfolio/funder-upload-section";
 import PivotSyncService, { CloudUploadInfo, uiFunderName } from "@services/pivot-sync-service";
 import WorkbookExportService from "@services/workbook-export-service";
@@ -65,7 +66,7 @@ const monthlyFunderList: FunderData[] = [
 
 function WhiteRabbitPortfolio() {
   const [monthlyFiles, setMonthlyFiles] = useState<Record<string, File>>({});
-  const [selectedDate, setSelectedDate] = useState<DateValue | null>(null);
+  const [selectedDate, setSelectedDate] = useState<DateValue | null>(getMostRecentCompletedMonth);
   const [funderUploads, setFunderUploads] = useState<CloudUploadInfo[]>([]);
   const [isExporting, setIsExporting] = useState(false);
   const { monthlyErrorStates, setFunderErrorState } = useFileErrorState();
@@ -95,16 +96,21 @@ function WhiteRabbitPortfolio() {
     }
   }, []);
 
+  // Load the default month's uploads once on mount. Later changes are handled
+  // synchronously in handleDateChange, so no effect reacts to selectedDate.
   useEffect(() => {
-    if (!selectedDate) {
+    refreshUploads(getMostRecentCompletedMonth().toString());
+  }, [refreshUploads]);
+
+  const handleDateChange = (date: DateValue | null) => {
+    setSelectedDate(date);
+    if (date) {
+      refreshUploads(date.toString());
+    } else {
       setFunderUploads([]);
       setMonthlyFiles({});
-      return;
     }
-    refreshUploads(selectedDate.toString());
-  }, [selectedDate, refreshUploads]);
-
-  const handleDateChange = (date: DateValue | null) => setSelectedDate(date);
+  };
 
   const handleMonthlyFunderUpload = async (funderName: string, file: File) => {
     if (!selectedDate) return;
@@ -187,6 +193,7 @@ function WhiteRabbitPortfolio() {
     <>
       <BasePortfolio
         portfolioName={PORTFOLIO}
+        selectedDate={selectedDate}
         onDateChange={handleDateChange}
         monthlyFunders={monthlyFunderList}
         onMonthlyFunderUpload={handleMonthlyFunderUpload}

--- a/src/services/pivot-sync-service.ts
+++ b/src/services/pivot-sync-service.ts
@@ -211,8 +211,10 @@ export class PivotSyncService {
     file: File,
     reportDate: string
   ): Promise<CloudSyncPreview> {
-    const portfolioId = await this.getPortfolioId(portfolioName);
-    const funderId = await this.getFunderId(funderName);
+    const [portfolioId, funderId] = await Promise.all([
+      this.getPortfolioId(portfolioName),
+      this.getFunderId(funderName),
+    ]);
 
     const storagePath = `${portfolioId}/${funderId}/${reportDate}/${file.name}`;
     const { error: storageError } = await supabase.storage
@@ -386,8 +388,10 @@ export class PivotSyncService {
     uiFunderName: string,
     reportDate: string
   ): Promise<boolean> {
-    const portfolioId = await this.getPortfolioId(portfolioName);
-    const funderId = await this.getFunderId(uiFunderName);
+    const [portfolioId, funderId] = await Promise.all([
+      this.getPortfolioId(portfolioName),
+      this.getFunderId(uiFunderName),
+    ]);
     const { count, error } = await supabase
       .from("funder_uploads")
       .select("id", { count: "exact", head: true })

--- a/src/utils/report-month.ts
+++ b/src/utils/report-month.ts
@@ -1,0 +1,13 @@
+import { CalendarDate, getLocalTimeZone, today } from "@internationalized/date";
+
+/**
+ * The most recently completed month, represented by its last calendar day.
+ * This is the default report month used by the portfolio pages and the monthly
+ * date picker.
+ */
+export const getMostRecentCompletedMonth = (): CalendarDate => {
+  const todayDate = today(getLocalTimeZone());
+  const firstOfThisMonth = new CalendarDate(todayDate.year, todayDate.month, 1);
+  // Last day of the previous month.
+  return firstOfThisMonth.subtract({ days: 1 });
+};


### PR DESCRIPTION
Resolves #30 — the React Doctor "Bugs (warnings)" baseline.

Scope: the in-scope `src/` findings only. `pro-examples/` (46 `no-array-index-as-key` + 2 `button-has-type`) is excluded per CLAUDE.md's **Do NOT Touch** list, consistent with the earlier react-doctor PRs (#37/#38/#39).

## What changed

**`no-array-index-as-key` (13)**
- Natural stable ids where available: pie-tooltip `entry.name` (`charts`, `chart-builder`), `pivot.colLabels[index]` (`pivot-builder`), changelog item text (`release-notes-modal`), parser warning text (`workbook-import-wizard`).
- Pending chat **attachments** get a client-generated `id` so their chips have a stable key across add/remove — the one genuinely filterable list.
- The chat message list, per-message blocks, and streamed live segments are **append-only** (only ever truncated from the end), so index is a stable key. Suppressed with a documented rationale; blocks/segments were extracted into small keyed components (`AssistantBlock`, `LiveSegmentItem`) so there's a single suppression per list.

**`exhaustive-deps` (3) + `no-pass-data-to-parent` (1)**
- `MonthlyDatePicker` is now **controlled** — the parent owns the selected date. The default-month helper moved to `@utils/report-month`, removing the mount effect that pushed the default up to the parent (and a double source of truth).
- The vendored sidebar's mutually-recursive `renderItem`/`renderNestItem` `useCallback`s are now plain functions: they're invoked inline during render (never passed to memoized children), so memoizing buys nothing, and the cross-dependency can't be declared without a use-before-declaration cycle.

**`no-chain-state-updates` (4)**
- Portfolio pages (`alder`, `white-rabbit`) set/clear upload state directly in the date-change handler and fetch the default month once on mount, instead of an effect reacting to `selectedDate`.

**`server-sequential-independent-await` (2)**
- `getPortfolioId`/`getFunderId` now run under `Promise.all` in `pivot-sync-service`.

**`client-localstorage-no-version` (1)**
- Versioned the deal-lookup saved-views key (`:v1`).

**`prefer-useReducer` (3)** — suppressed with rationale
- `invite-user`, `ai-chat`, and `deal-lookup` hold largely independent state that changes at different times, so a single reducer wouldn't improve consistency. Happy to revisit if you'd prefer the refactor.

## Verification
- `npm run lint` (3 pre-existing warnings, unrelated), `npm run format:check`, `npm run build` all pass.
- react-doctor: **0** remaining `src/` findings for every rule listed in #30; no new findings introduced in touched files; score 42 → 44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)