### PR TITLE
refactor(react-doctor): split 5 giant components (#42)

### DIFF
--- a/src/components/portfolio/file-upload.tsx
+++ b/src/components/portfolio/file-upload.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useRef, useEffect } from "react";
+import React from "react";
 import { Button } from "@heroui/react";
 import { Icon } from "@iconify/react";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
-import { readFile } from "@tauri-apps/plugin-fs";
+import { useFileUpload } from "@/hooks/use-file-upload";
 
 interface FileUploadProps {
   onFileUpload?: (file: File) => void;
@@ -26,6 +25,143 @@ const preventDragDefault = (e: React.DragEvent) => {
   e.stopPropagation();
 };
 
+interface FileDropZoneProps {
+  className: string;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  dropZoneRef: React.RefObject<HTMLDivElement>;
+  acceptString: string;
+  fileTypeDisplay: string;
+  isDragging: boolean;
+  hasError: boolean;
+  errorMessage?: string;
+  label: string;
+  description: string;
+  maxSizeKB: number;
+  uploadId: string;
+  onFileSelect: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onTriggerFileSelect: () => void;
+}
+
+// Empty-state drop target shown before a file is chosen.
+const FileDropZone: React.FC<FileDropZoneProps> = ({
+  className,
+  fileInputRef,
+  dropZoneRef,
+  acceptString,
+  fileTypeDisplay,
+  isDragging,
+  hasError,
+  errorMessage,
+  label,
+  description,
+  maxSizeKB,
+  uploadId,
+  onFileSelect,
+  onTriggerFileSelect,
+}) => (
+  <div className={className}>
+    {/* Hidden file input */}
+    <input
+      ref={fileInputRef}
+      type="file"
+      accept={acceptString}
+      onChange={onFileSelect}
+      className="hidden"
+    />
+
+    <div
+      ref={dropZoneRef}
+      className={`
+        border-2 border-dashed rounded-lg p-6
+        transition-all duration-200 cursor-pointer
+        ${
+          hasError
+            ? "border-danger bg-danger/5"
+            : isDragging
+              ? "border-primary bg-primary/5"
+              : "border-default-300 hover:border-primary hover:bg-default-100"
+        }
+      `}
+      onDragEnter={preventDragDefault}
+      onDragLeave={preventDragDefault}
+      onDragOver={preventDragDefault}
+      onDrop={preventDragDefault}
+      onClick={onTriggerFileSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onTriggerFileSelect();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      data-upload-id={uploadId}
+    >
+      <div className="flex flex-col items-center justify-center space-y-2">
+        <Icon
+          icon="material-symbols:upload-rounded"
+          className={`w-8 h-8 ${hasError ? "text-danger" : "text-default-400"}`}
+        />
+        <div className="text-center">
+          <p className={`text-sm font-medium ${hasError ? "text-danger" : "text-foreground"}`}>
+            {label}
+          </p>
+          <p className={`text-xs mt-1 ${hasError ? "text-danger" : "text-default-500"}`}>
+            {hasError && errorMessage ? errorMessage : description}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <p className="text-xs text-default-400 mt-2">
+      Maximum file size: {(maxSizeKB / 1024).toFixed(0)}MB. Supported formats: {fileTypeDisplay}
+    </p>
+  </div>
+);
+
+interface SelectedFileCardProps {
+  className: string;
+  file: File;
+  hasError: boolean;
+  errorMessage?: string;
+  onClear: () => void;
+}
+
+// Filled-state card shown once a valid file is selected.
+const SelectedFileCard: React.FC<SelectedFileCardProps> = ({
+  className,
+  file,
+  hasError,
+  errorMessage,
+  onClear,
+}) => (
+  <div className={className}>
+    <div
+      className={`border rounded-lg p-3 ${hasError ? "border-danger bg-danger/5" : "border-default-300 bg-default-100"}`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          <Icon icon="vscode-icons:file-type-excel" className="w-6 h-6 flex-shrink-0" />
+          <div className="min-w-0 flex-1 overflow-hidden">
+            <p
+              className={`text-sm font-medium truncate ${hasError ? "text-danger" : "text-foreground"}`}
+              title={file.name}
+            >
+              {file.name}
+            </p>
+            <p className={`text-xs ${hasError ? "text-danger" : "text-default-500"}`}>
+              {hasError && errorMessage ? errorMessage : `${(file.size / 1024).toFixed(1)} KB`}
+            </p>
+          </div>
+        </div>
+        <Button isIconOnly color="danger" variant="light" size="sm" onPress={onClear}>
+          <Icon icon="material-symbols:close-rounded" className="w-3 h-3" />
+        </Button>
+      </div>
+    </div>
+  </div>
+);
+
 const FileUpload: React.FC<FileUploadProps> = ({
   onFileUpload,
   acceptedTypes = [
@@ -43,225 +179,23 @@ const FileUpload: React.FC<FileUploadProps> = ({
   hasError = false,
   errorMessage,
 }) => {
-  const [localSelectedFile, setLocalSelectedFile] = useState<File | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  // const dragCounter = useRef(0);
-  const dropZoneRef = useRef<HTMLDivElement>(null);
-  const isHoveredRef = useRef(false);
-  const onFileUploadRef = useRef(onFileUpload);
-  const listenerRegisteredRef = useRef(false);
-
-  // Use prop file if provided, otherwise use local state
-  const currentFile = selectedFile ?? localSelectedFile;
-
-  // Keep the ref up to date with the latest callback
-  useEffect(() => {
-    onFileUploadRef.current = onFileUpload;
-  }, [onFileUpload]);
-
-  // Handle file drop from Tauri
-  const handleTauriFileDrop = async (filePath: string) => {
-    console.warn(`[FileUpload-${uploadId}] handleTauriFileDrop called with:`, filePath);
-    try {
-      // Extract file name from path
-      const fileName = filePath.split(/[\\/]/).pop() || "file";
-
-      // Check if file has valid extension
-      const hasValidExtension = acceptedExtensions.some((ext) =>
-        fileName.toLowerCase().endsWith(ext.toLowerCase())
-      );
-
-      if (!hasValidExtension) {
-        console.error(
-          `Invalid file extension: ${fileName}. Expected: ${acceptedExtensions.join(", ")}`
-        );
-        return;
-      }
-
-      // Read the file content
-      const fileContent = await readFile(filePath);
-
-      // Create a File object from the content
-      const file = new File([fileContent], fileName, {
-        type: fileName.endsWith(".xlsx")
-          ? "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-          : "application/vnd.ms-excel",
-      });
-
-      // Check file size
-      if (file.size > maxSizeKB * 1024) {
-        console.error(
-          `File too large: ${(file.size / 1024).toFixed(1)}KB. Maximum: ${maxSizeKB}KB`
-        );
-        return;
-      }
-
-      console.warn(
-        `[FileUpload-${uploadId}] File created from Tauri drop:`,
-        file.name,
-        "Size:",
-        file.size
-      );
-
-      // Update state and call handler
-      if (selectedFile === undefined) {
-        setLocalSelectedFile(file);
-      }
-      console.warn(`[FileUpload-${uploadId}] Calling onFileUploadRef.current`);
-      onFileUploadRef.current?.(file);
-    } catch (error) {
-      console.error("Failed to process Tauri file drop:", error);
-    }
-  };
-
-  // Keep a stable ref to the latest handler so the listener below can register
-  // once and still call the current closure (deps otherwise force re-registration).
-  const handleTauriFileDropRef = useRef(handleTauriFileDrop);
-  useEffect(() => {
-    handleTauriFileDropRef.current = handleTauriFileDrop;
+  const {
+    currentFile,
+    isDragging,
+    fileInputRef,
+    dropZoneRef,
+    handleFileSelect,
+    clearFile,
+    triggerFileSelect,
+  } = useFileUpload({
+    onFileUpload,
+    acceptedTypes,
+    acceptedExtensions,
+    maxSizeKB,
+    selectedFile,
+    onClearFile,
+    uploadId,
   });
-
-  // Handle Tauri-specific drag and drop events
-  useEffect(() => {
-    let unlisten: (() => void) | undefined;
-
-    const setupTauriDragDrop = async () => {
-      // Prevent multiple registrations
-      if (listenerRegisteredRef.current) {
-        console.warn(`[FileUpload-${uploadId}] Listener already registered, skipping`);
-        return;
-      }
-
-      try {
-        console.warn(`[FileUpload-${uploadId}] Setting up Tauri drag drop listener`);
-        listenerRegisteredRef.current = true;
-        // Listen for Tauri drag and drop events
-        unlisten = await getCurrentWebview().onDragDropEvent((event) => {
-          // Only process if this specific drop zone is being hovered
-          if (!dropZoneRef.current) return;
-
-          const hasPosition = (
-            payload: unknown
-          ): payload is { position: { x: number; y: number } } => {
-            if (typeof payload !== "object" || payload === null) return false;
-            const pos = (payload as { position?: unknown }).position;
-            return (
-              typeof pos === "object" &&
-              pos !== null &&
-              typeof (pos as { x?: unknown }).x === "number" &&
-              typeof (pos as { y?: unknown }).y === "number"
-            );
-          };
-
-          // Check if the drop zone is being hovered
-          const rect = dropZoneRef.current.getBoundingClientRect();
-          const isOverDropZone =
-            hasPosition(event.payload) &&
-            event.payload.position.x >= rect.left &&
-            event.payload.position.x <= rect.right &&
-            event.payload.position.y >= rect.top &&
-            event.payload.position.y <= rect.bottom;
-
-          if (event.payload.type === "over") {
-            // Only show dragging state if over this specific drop zone
-            if (isOverDropZone) {
-              setIsDragging(true);
-              isHoveredRef.current = true;
-            } else {
-              setIsDragging(false);
-              isHoveredRef.current = false;
-            }
-          } else if (event.payload.type === "drop") {
-            // Only process drop if it's over this specific drop zone
-            if (isHoveredRef.current || isOverDropZone) {
-              console.warn(`Files dropped on ${uploadId}:`, event.payload.paths);
-
-              // Process the first file
-              if (event.payload.paths && event.payload.paths.length > 0) {
-                const filePath = event.payload.paths[0];
-                console.warn(`Processing file for ${uploadId}:`, filePath);
-                handleTauriFileDropRef.current(filePath);
-              }
-            }
-            setIsDragging(false);
-            isHoveredRef.current = false;
-          } else {
-            // Drag cancelled
-            setIsDragging(false);
-            isHoveredRef.current = false;
-          }
-        });
-      } catch (error) {
-        console.error("Failed to setup Tauri drag drop:", error);
-      }
-    };
-
-    setupTauriDragDrop();
-
-    // Cleanup
-    return () => {
-      console.warn(`[FileUpload-${uploadId}] Cleaning up Tauri drag drop listener`);
-      if (unlisten) {
-        unlisten();
-        listenerRegisteredRef.current = false;
-      }
-    };
-  }, [uploadId]); // Register once per drop zone; dynamic values are read via refs
-
-  // Check if file is valid based on props
-  const isValidFile = (file: File): boolean => {
-    // Check extension first as it's more reliable
-    const isValidExtension = acceptedExtensions.some((ext) =>
-      file.name.toLowerCase().endsWith(ext.toLowerCase())
-    );
-
-    // Check MIME type (can be empty for some files)
-    const isValidType = !file.type || acceptedTypes.some((type) => file.type === type);
-
-    // Check file size
-    const isValidSize = file.size <= maxSizeKB * 1024;
-
-    console.warn("Validation:", {
-      extension: isValidExtension,
-      type: isValidType,
-      size: isValidSize,
-      fileName: file.name,
-      fileType: file.type || "no type",
-      fileSize: file.size,
-    });
-
-    // Accept if extension is valid AND size is valid
-    // Type check is optional since some systems don't set it correctly
-    return isValidExtension && isValidSize;
-  };
-
-  // Handle file selection
-  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file && isValidFile(file)) {
-      if (selectedFile === undefined) {
-        setLocalSelectedFile(file);
-      }
-      onFileUploadRef.current?.(file);
-    }
-  };
-
-  // Clear file - FIXED
-  const clearFile = () => {
-    if (selectedFile === undefined) {
-      setLocalSelectedFile(null);
-    }
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-    onClearFile?.();
-  };
-
-  // Trigger file input click
-  const triggerFileSelect = () => {
-    fileInputRef.current?.click();
-  };
 
   // Generate accept string for input
   const acceptString = [...acceptedTypes, ...acceptedExtensions].join(",");
@@ -271,95 +205,33 @@ const FileUpload: React.FC<FileUploadProps> = ({
 
   if (!currentFile) {
     return (
-      <div className={className}>
-        {/* Hidden file input */}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept={acceptString}
-          onChange={handleFileSelect}
-          className="hidden"
-        />
-
-        <div
-          ref={dropZoneRef}
-          className={`
-            border-2 border-dashed rounded-lg p-6
-            transition-all duration-200 cursor-pointer
-            ${
-              hasError
-                ? "border-danger bg-danger/5"
-                : isDragging
-                  ? "border-primary bg-primary/5"
-                  : "border-default-300 hover:border-primary hover:bg-default-100"
-            }
-          `}
-          onDragEnter={preventDragDefault}
-          onDragLeave={preventDragDefault}
-          onDragOver={preventDragDefault}
-          onDrop={preventDragDefault}
-          onClick={triggerFileSelect}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              triggerFileSelect();
-            }
-          }}
-          role="button"
-          tabIndex={0}
-          data-upload-id={uploadId}
-        >
-          <div className="flex flex-col items-center justify-center space-y-2">
-            <Icon
-              icon="material-symbols:upload-rounded"
-              className={`w-8 h-8 ${hasError ? "text-danger" : "text-default-400"}`}
-            />
-            <div className="text-center">
-              <p className={`text-sm font-medium ${hasError ? "text-danger" : "text-foreground"}`}>
-                {label}
-              </p>
-              <p className={`text-xs mt-1 ${hasError ? "text-danger" : "text-default-500"}`}>
-                {hasError && errorMessage ? errorMessage : description}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <p className="text-xs text-default-400 mt-2">
-          Maximum file size: {(maxSizeKB / 1024).toFixed(0)}MB. Supported formats: {fileTypeDisplay}
-        </p>
-      </div>
+      <FileDropZone
+        className={className}
+        fileInputRef={fileInputRef}
+        dropZoneRef={dropZoneRef}
+        acceptString={acceptString}
+        fileTypeDisplay={fileTypeDisplay}
+        isDragging={isDragging}
+        hasError={hasError}
+        errorMessage={errorMessage}
+        label={label}
+        description={description}
+        maxSizeKB={maxSizeKB}
+        uploadId={uploadId}
+        onFileSelect={handleFileSelect}
+        onTriggerFileSelect={triggerFileSelect}
+      />
     );
   }
 
   return (
-    <div className={className}>
-      <div
-        className={`border rounded-lg p-3 ${hasError ? "border-danger bg-danger/5" : "border-default-300 bg-default-100"}`}
-      >
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 min-w-0 flex-1">
-            <Icon icon="vscode-icons:file-type-excel" className="w-6 h-6 flex-shrink-0" />
-            <div className="min-w-0 flex-1 overflow-hidden">
-              <p
-                className={`text-sm font-medium truncate ${hasError ? "text-danger" : "text-foreground"}`}
-                title={currentFile.name}
-              >
-                {currentFile.name}
-              </p>
-              <p className={`text-xs ${hasError ? "text-danger" : "text-default-500"}`}>
-                {hasError && errorMessage
-                  ? errorMessage
-                  : `${(currentFile.size / 1024).toFixed(1)} KB`}
-              </p>
-            </div>
-          </div>
-          <Button isIconOnly color="danger" variant="light" size="sm" onPress={clearFile}>
-            <Icon icon="material-symbols:close-rounded" className="w-3 h-3" />
-          </Button>
-        </div>
-      </div>
-    </div>
+    <SelectedFileCard
+      className={className}
+      file={currentFile}
+      hasError={hasError}
+      errorMessage={errorMessage}
+      onClear={clearFile}
+    />
   );
 };
 

--- a/src/components/portfolio/workbook-import-wizard.tsx
+++ b/src/components/portfolio/workbook-import-wizard.tsx
@@ -32,6 +32,157 @@ const money = (value: number) =>
 
 const pct = (value: number | null) => (value === null ? "—" : `${(value * 100).toFixed(1)}%`);
 
+interface ImportPreviewBodyProps {
+  preview: WorkbookImportPreview;
+  totalDeals: number;
+  totalPayments: number;
+  totalNet: number;
+  allWarnings: string[];
+}
+
+// "preview" step: parsed per-sheet counts shown before anything is written.
+function ImportPreviewBody({
+  preview,
+  totalDeals,
+  totalPayments,
+  totalNet,
+  allWarnings,
+}: ImportPreviewBodyProps) {
+  return (
+    <>
+      <Table aria-label="Parsed funder sheets" isStriped removeWrapper>
+        <TableHeader>
+          <TableColumn>SHEET</TableColumn>
+          <TableColumn>FUNDER</TableColumn>
+          <TableColumn align="end">MGMT FEE</TableColumn>
+          <TableColumn align="end">DEALS</TableColumn>
+          <TableColumn align="end">PAYMENTS</TableColumn>
+          <TableColumn align="end">NET RTR TOTAL</TableColumn>
+        </TableHeader>
+        <TableBody>
+          {preview.sheets.map((s) => (
+            <TableRow key={s.sheet.sheet_name}>
+              <TableCell className="font-mono text-sm">{s.sheet.sheet_name}</TableCell>
+              <TableCell className="font-medium">{s.funderName}</TableCell>
+              <TableCell className="text-right font-mono text-sm">
+                {pct(s.sheet.management_fee_rate)}
+                {s.currentFeeRate !== null &&
+                  s.sheet.management_fee_rate !== null &&
+                  s.currentFeeRate !== s.sheet.management_fee_rate && (
+                    <span className="text-warning-600"> (was {pct(s.currentFeeRate)})</span>
+                  )}
+              </TableCell>
+              <TableCell className="text-right font-mono text-sm">{s.sheet.deals.length}</TableCell>
+              <TableCell className="text-right font-mono text-sm">
+                {s.sheet.payment_count}
+              </TableCell>
+              <TableCell className="text-right font-mono text-sm">
+                {money(s.sheet.total_net_payments)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <div className="flex items-center gap-4 text-sm font-medium px-1">
+        <span>Total: {totalDeals} deals</span>
+        <span>{totalPayments} payments</span>
+        <span>{money(totalNet)} net RTR</span>
+      </div>
+
+      {preview.missingSheets.length > 0 && (
+        <p className="text-xs text-default-500">
+          Not in this workbook: {preview.missingSheets.join(", ")}
+        </p>
+      )}
+      {allWarnings.length > 0 && (
+        <div className="p-3 bg-warning-50 border border-warning-200 rounded-lg">
+          <p className="text-sm font-medium text-warning-700 mb-1">
+            {allWarnings.length} parser warning{allWarnings.length === 1 ? "" : "s"}
+          </p>
+          <ul className="text-xs text-warning-700 list-disc pl-4 max-h-24 overflow-y-auto">
+            {allWarnings.map((w) => (
+              <li key={w}>{w}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+}
+
+interface ImportSummaryBodyProps {
+  results: Map<string, SheetImportResult>;
+  unmatchedIndustries: string[];
+  unmatchedStates: string[];
+  error: string | null;
+}
+
+// "summary" step: per-sheet import results plus any unmatched lookups.
+function ImportSummaryBody({
+  results,
+  unmatchedIndustries,
+  unmatchedStates,
+  error,
+}: ImportSummaryBodyProps) {
+  return (
+    <>
+      <Table aria-label="Import results" isStriped removeWrapper>
+        <TableHeader>
+          <TableColumn>SHEET</TableColumn>
+          <TableColumn align="end">DEALS</TableColumn>
+          <TableColumn align="end">MERCHANTS</TableColumn>
+          <TableColumn align="end">PAYMENTS</TableColumn>
+          <TableColumn align="end">NET WRITTEN</TableColumn>
+          <TableColumn align="end">SKIPPED</TableColumn>
+        </TableHeader>
+        <TableBody>
+          {[...results.entries()].map(([sheetName, r]) => (
+            <TableRow key={sheetName}>
+              <TableCell className="font-mono text-sm">{sheetName}</TableCell>
+              <TableCell className="text-right font-mono text-sm">{r.deals_imported}</TableCell>
+              <TableCell className="text-right font-mono text-sm">{r.merchants_upserted}</TableCell>
+              <TableCell className="text-right font-mono text-sm">{r.payments_inserted}</TableCell>
+              <TableCell className="text-right font-mono text-sm">
+                {money(r.payments_net_inserted)}
+              </TableCell>
+              <TableCell className="text-right font-mono text-sm">
+                {r.rows_skipped + r.duplicate_rows_dropped || ""}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {(unmatchedIndustries.length > 0 || unmatchedStates.length > 0) && (
+        <div className="p-3 bg-default-100 rounded-lg text-xs text-default-600 space-y-2">
+          {unmatchedIndustries.length > 0 && (
+            <p>
+              <span className="font-medium">{unmatchedIndustries.length} industries</span> had no
+              match in the lookup table (merchants imported without an industry):{" "}
+              {unmatchedIndustries.slice(0, 12).join(", ")}
+              {unmatchedIndustries.length > 12 && " …"}
+            </p>
+          )}
+          {unmatchedStates.length > 0 && (
+            <p>
+              <span className="font-medium">{unmatchedStates.length} states</span> unmatched:{" "}
+              {unmatchedStates.slice(0, 12).join(", ")}
+              {unmatchedStates.length > 12 && " …"}
+            </p>
+          )}
+        </div>
+      )}
+      {!error && (
+        <div className="flex items-center gap-2 text-success-600 text-sm">
+          <Icon icon="material-symbols:check-circle" className="w-5 h-5" />
+          Workbook imported. Monthly funder uploads take it from here.
+        </div>
+      )}
+    </>
+  );
+}
+
 /**
  * Phase 3 one-time onboarding: parse a portfolio workbook locally (Rust),
  * preview per-sheet deal/payment counts, then import each funder sheet into
@@ -182,72 +333,13 @@ export function WorkbookImportWizard({ portfolioName }: WorkbookImportWizardProp
                 )}
 
                 {step === "preview" && preview && (
-                  <>
-                    <Table aria-label="Parsed funder sheets" isStriped removeWrapper>
-                      <TableHeader>
-                        <TableColumn>SHEET</TableColumn>
-                        <TableColumn>FUNDER</TableColumn>
-                        <TableColumn align="end">MGMT FEE</TableColumn>
-                        <TableColumn align="end">DEALS</TableColumn>
-                        <TableColumn align="end">PAYMENTS</TableColumn>
-                        <TableColumn align="end">NET RTR TOTAL</TableColumn>
-                      </TableHeader>
-                      <TableBody>
-                        {preview.sheets.map((s) => (
-                          <TableRow key={s.sheet.sheet_name}>
-                            <TableCell className="font-mono text-sm">
-                              {s.sheet.sheet_name}
-                            </TableCell>
-                            <TableCell className="font-medium">{s.funderName}</TableCell>
-                            <TableCell className="text-right font-mono text-sm">
-                              {pct(s.sheet.management_fee_rate)}
-                              {s.currentFeeRate !== null &&
-                                s.sheet.management_fee_rate !== null &&
-                                s.currentFeeRate !== s.sheet.management_fee_rate && (
-                                  <span className="text-warning-600">
-                                    {" "}
-                                    (was {pct(s.currentFeeRate)})
-                                  </span>
-                                )}
-                            </TableCell>
-                            <TableCell className="text-right font-mono text-sm">
-                              {s.sheet.deals.length}
-                            </TableCell>
-                            <TableCell className="text-right font-mono text-sm">
-                              {s.sheet.payment_count}
-                            </TableCell>
-                            <TableCell className="text-right font-mono text-sm">
-                              {money(s.sheet.total_net_payments)}
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-
-                    <div className="flex items-center gap-4 text-sm font-medium px-1">
-                      <span>Total: {totalDeals} deals</span>
-                      <span>{totalPayments} payments</span>
-                      <span>{money(totalNet)} net RTR</span>
-                    </div>
-
-                    {preview.missingSheets.length > 0 && (
-                      <p className="text-xs text-default-500">
-                        Not in this workbook: {preview.missingSheets.join(", ")}
-                      </p>
-                    )}
-                    {allWarnings.length > 0 && (
-                      <div className="p-3 bg-warning-50 border border-warning-200 rounded-lg">
-                        <p className="text-sm font-medium text-warning-700 mb-1">
-                          {allWarnings.length} parser warning{allWarnings.length === 1 ? "" : "s"}
-                        </p>
-                        <ul className="text-xs text-warning-700 list-disc pl-4 max-h-24 overflow-y-auto">
-                          {allWarnings.map((w) => (
-                            <li key={w}>{w}</li>
-                          ))}
-                        </ul>
-                      </div>
-                    )}
-                  </>
+                  <ImportPreviewBody
+                    preview={preview}
+                    totalDeals={totalDeals}
+                    totalPayments={totalPayments}
+                    totalNet={totalNet}
+                    allWarnings={allWarnings}
+                  />
                 )}
 
                 {step === "importing" && preview && (
@@ -266,68 +358,12 @@ export function WorkbookImportWizard({ portfolioName }: WorkbookImportWizardProp
                 )}
 
                 {step === "summary" && (
-                  <>
-                    <Table aria-label="Import results" isStriped removeWrapper>
-                      <TableHeader>
-                        <TableColumn>SHEET</TableColumn>
-                        <TableColumn align="end">DEALS</TableColumn>
-                        <TableColumn align="end">MERCHANTS</TableColumn>
-                        <TableColumn align="end">PAYMENTS</TableColumn>
-                        <TableColumn align="end">NET WRITTEN</TableColumn>
-                        <TableColumn align="end">SKIPPED</TableColumn>
-                      </TableHeader>
-                      <TableBody>
-                        {[...results.entries()].map(([sheetName, r]) => (
-                          <TableRow key={sheetName}>
-                            <TableCell className="font-mono text-sm">{sheetName}</TableCell>
-                            <TableCell className="text-right font-mono text-sm">
-                              {r.deals_imported}
-                            </TableCell>
-                            <TableCell className="text-right font-mono text-sm">
-                              {r.merchants_upserted}
-                            </TableCell>
-                            <TableCell className="text-right font-mono text-sm">
-                              {r.payments_inserted}
-                            </TableCell>
-                            <TableCell className="text-right font-mono text-sm">
-                              {money(r.payments_net_inserted)}
-                            </TableCell>
-                            <TableCell className="text-right font-mono text-sm">
-                              {r.rows_skipped + r.duplicate_rows_dropped || ""}
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-
-                    {(unmatchedIndustries.length > 0 || unmatchedStates.length > 0) && (
-                      <div className="p-3 bg-default-100 rounded-lg text-xs text-default-600 space-y-2">
-                        {unmatchedIndustries.length > 0 && (
-                          <p>
-                            <span className="font-medium">
-                              {unmatchedIndustries.length} industries
-                            </span>{" "}
-                            had no match in the lookup table (merchants imported without an
-                            industry): {unmatchedIndustries.slice(0, 12).join(", ")}
-                            {unmatchedIndustries.length > 12 && " …"}
-                          </p>
-                        )}
-                        {unmatchedStates.length > 0 && (
-                          <p>
-                            <span className="font-medium">{unmatchedStates.length} states</span>{" "}
-                            unmatched: {unmatchedStates.slice(0, 12).join(", ")}
-                            {unmatchedStates.length > 12 && " …"}
-                          </p>
-                        )}
-                      </div>
-                    )}
-                    {!error && (
-                      <div className="flex items-center gap-2 text-success-600 text-sm">
-                        <Icon icon="material-symbols:check-circle" className="w-5 h-5" />
-                        Workbook imported. Monthly funder uploads take it from here.
-                      </div>
-                    )}
-                  </>
+                  <ImportSummaryBody
+                    results={results}
+                    unmatchedIndustries={unmatchedIndustries}
+                    unmatchedStates={unmatchedStates}
+                    error={error}
+                  />
                 )}
               </ModalBody>
               <ModalFooter>

--- a/src/hooks/use-ai-chat.ts
+++ b/src/hooks/use-ai-chat.ts
@@ -1,0 +1,378 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+
+import {
+  apiKeyFor,
+  getAiSettings,
+  modelFor,
+  prepareChatAttachment,
+  PROVIDER_LABELS,
+  providerNeedsApiKey,
+  streamChat,
+  type AiChatEvent,
+  type AiProvider,
+  type AiSettings,
+  type ChatBlock,
+  type ChatMessage,
+  type PreparedAttachment,
+} from "@services/ai-chat-service";
+import {
+  appendMessages,
+  createConversation,
+  deleteConversation,
+  listConversations,
+  listMessages,
+  replaceMessages,
+  type Conversation,
+} from "@services/chat-store-service";
+import { toast } from "@services/toast-service";
+import { type LiveSegment } from "@components/ai-chat/chat-message-view";
+import { isToolResultMessage } from "@components/ai-chat/message-utils";
+
+const ATTACHMENT_EXTENSIONS = [
+  "csv",
+  "tsv",
+  "txt",
+  "md",
+  "json",
+  "xlsx",
+  "xls",
+  "xlsm",
+  "xlsb",
+  "ods",
+  "pdf",
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+];
+
+function titleFrom(text: string, fallback: string): string {
+  const trimmed = text.trim().replace(/\s+/g, " ");
+  if (!trimmed) return fallback;
+  return trimmed.length > 60 ? `${trimmed.slice(0, 60)}…` : trimmed;
+}
+
+/**
+ * A prepared attachment plus a client-generated id, so the pending-attachment
+ * chips have a stable key while the user adds and removes them before sending.
+ */
+interface LocalAttachment extends PreparedAttachment {
+  id: string;
+}
+
+/**
+ * Owns all AI-chat state and side effects: settings, the conversation list,
+ * the active message thread, the composer, attachments, and streaming. Kept
+ * out of the page component so the page is pure presentation.
+ */
+// react-doctor-disable-next-line react-doctor/prefer-useReducer -- these hold largely independent concerns (settings, conversation list, active messages, composer input, attachments, streaming status) that change at different times, so a single reducer would not improve consistency
+export function useAiChat() {
+  const [settings, setSettings] = useState<AiSettings | null>(null);
+  const [provider, setProvider] = useState<AiProvider>("anthropic");
+  const [model, setModel] = useState("");
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  const [input, setInput] = useState("");
+  const [attachments, setAttachments] = useState<LocalAttachment[]>([]);
+  const [attaching, setAttaching] = useState(false);
+  const [streaming, setStreaming] = useState(false);
+  const [liveSegments, setLiveSegments] = useState<LiveSegment[]>([]);
+
+  // Persistence degrades gracefully until the chat tables exist in Supabase.
+  const persistenceBroken = useRef(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    getAiSettings()
+      .then((loaded) => {
+        setSettings(loaded);
+        setProvider(loaded.default_provider);
+        setModel(modelFor(loaded, loaded.default_provider));
+      })
+      .catch((error) => toast.error("Failed to load AI settings", String(error)));
+
+    listConversations()
+      .then(setConversations)
+      .catch(() => {
+        persistenceBroken.current = true;
+      });
+  }, []);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [messages, liveSegments]);
+
+  const warnPersistence = (error: unknown) => {
+    if (!persistenceBroken.current) {
+      persistenceBroken.current = true;
+      toast.warning(
+        "Chat history is not being saved",
+        `Conversations will work but won't persist: ${String(error)}`
+      );
+    }
+  };
+
+  const handleProviderChange = (next: AiProvider) => {
+    setProvider(next);
+    if (settings) setModel(modelFor(settings, next));
+  };
+
+  const handleNewChat = () => {
+    if (streaming) return;
+    setActiveId(null);
+    setMessages([]);
+  };
+
+  const handleSelectConversation = async (conversation: Conversation) => {
+    if (streaming || conversation.id === activeId) return;
+    setActiveId(conversation.id);
+    if (conversation.provider in PROVIDER_LABELS) {
+      setProvider(conversation.provider as AiProvider);
+    }
+    if (conversation.model) setModel(conversation.model);
+    try {
+      setMessages(await listMessages(conversation.id));
+    } catch (error) {
+      setMessages([]);
+      warnPersistence(error);
+    }
+  };
+
+  const handleDeleteConversation = async (id: string) => {
+    try {
+      await deleteConversation(id);
+      setConversations((prev) => prev.filter((c) => c.id !== id));
+      if (activeId === id) handleNewChat();
+    } catch (error) {
+      toast.error("Failed to delete conversation", String(error));
+    }
+  };
+
+  const handleAttach = async () => {
+    setAttaching(true);
+    try {
+      const selected = await open({
+        multiple: true,
+        filters: [{ name: "Documents & data", extensions: ATTACHMENT_EXTENSIONS }],
+      });
+      if (!selected) return;
+      const paths = Array.isArray(selected) ? selected : [selected];
+      // The picks are independent, so prepare them together instead of
+      // awaiting each one in turn.
+      const prepared = await Promise.all(paths.map((path) => prepareChatAttachment(path)));
+      const withIds: LocalAttachment[] = prepared.map((attachment) => ({
+        ...attachment,
+        id: crypto.randomUUID(),
+      }));
+      setAttachments((prev) => [...prev, ...withIds]);
+    } catch (error) {
+      toast.error("Could not attach file", String(error));
+    } finally {
+      setAttaching(false);
+    }
+  };
+
+  const removeAttachment = (id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id));
+  };
+
+  const onEvent = useCallback((event: AiChatEvent) => {
+    setLiveSegments((prev) => {
+      if (event.type === "text_delta") {
+        const last = prev[prev.length - 1];
+        if (last?.type === "text") {
+          return [...prev.slice(0, -1), { type: "text", text: last.text + event.text }];
+        }
+        return [...prev, { type: "text", text: event.text }];
+      }
+      if (event.type === "tool_call") {
+        return [...prev, { type: "tool", id: event.id, name: event.name, status: "running" }];
+      }
+      if (event.type === "tool_result") {
+        return prev.map((segment) =>
+          segment.type === "tool" && segment.id === event.id
+            ? { ...segment, status: event.is_error ? "error" : "done" }
+            : segment
+        );
+      }
+      return prev;
+    });
+  }, []);
+
+  /** Validates provider/model setup, surfacing a toast and returning false if not ready. */
+  const ensureConfigured = (): boolean => {
+    if (!settings || (providerNeedsApiKey(provider) && !apiKeyFor(settings, provider))) {
+      toast.warning(
+        "No API key configured",
+        `Add your ${PROVIDER_LABELS[provider]} API key in the AI settings first.`
+      );
+      setSettingsOpen(true);
+      return false;
+    }
+    if (!model.trim()) {
+      const hint =
+        provider === "lmstudio"
+          ? "Enter the model id loaded in LM Studio (settings or the header field)."
+          : "Enter a model id in the header first.";
+      toast.warning("No model set", hint);
+      if (provider === "lmstudio") setSettingsOpen(true);
+      return false;
+    }
+    return true;
+  };
+
+  /** Moves a conversation to the top of the list after a new turn. */
+  const bumpConversation = (id: string) => {
+    setConversations((prev) => {
+      const bumped = prev.find((c) => c.id === id);
+      if (!bumped) return prev;
+      return [bumped, ...prev.filter((c) => c.id !== id)];
+    });
+  };
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (streaming || (!text && attachments.length === 0)) return;
+    if (!ensureConfigured()) return;
+
+    const blocks: ChatBlock[] = [
+      ...attachments.flatMap((attachment) => attachment.blocks),
+      ...(text ? [{ kind: "text", text } as ChatBlock] : []),
+    ];
+    const userMessage: ChatMessage = { role: "user", blocks };
+    const history = [...messages, userMessage];
+
+    setMessages(history);
+    setInput("");
+    setAttachments([]);
+    setStreaming(true);
+    setLiveSegments([]);
+
+    // Persist the user message (creating the conversation on first send).
+    let conversationId = activeId;
+    if (!persistenceBroken.current) {
+      try {
+        if (!conversationId) {
+          const conversation = await createConversation(
+            titleFrom(text, attachments[0]?.name ?? "New chat"),
+            provider,
+            model
+          );
+          conversationId = conversation.id;
+          setActiveId(conversation.id);
+          setConversations((prev) => [conversation, ...prev]);
+        }
+        await appendMessages(conversationId, [userMessage]);
+      } catch (error) {
+        warnPersistence(error);
+      }
+    }
+
+    try {
+      const newMessages = await streamChat({ provider, model, messages: history, onEvent });
+      setMessages([...history, ...newMessages]);
+      if (!persistenceBroken.current && conversationId) {
+        try {
+          await appendMessages(conversationId, newMessages);
+          bumpConversation(conversationId);
+        } catch (error) {
+          warnPersistence(error);
+        }
+      }
+    } catch (error) {
+      toast.error("AI request failed", String(error));
+    } finally {
+      setStreaming(false);
+      setLiveSegments([]);
+    }
+  };
+
+  /**
+   * Regenerates the assistant turn that produced `messages[index]`. Everything
+   * from the start of that turn onward is dropped and re-streamed from the
+   * user prompt that triggered it.
+   */
+  const handleRetry = async (index: number) => {
+    if (streaming || !ensureConfigured()) return;
+
+    // Walk back to the genuine user prompt that started this assistant turn,
+    // skipping the assistant messages and tool-result plumbing in between.
+    let cut = index;
+    while (cut > 0) {
+      const prev = messages[cut - 1];
+      if (prev.role === "user" && !isToolResultMessage(prev)) break;
+      cut--;
+    }
+    const history = messages.slice(0, cut);
+    if (history.length === 0) return;
+
+    const previousMessages = messages;
+    setMessages(history);
+    setStreaming(true);
+    setLiveSegments([]);
+
+    try {
+      const newMessages = await streamChat({ provider, model, messages: history, onEvent });
+      const finalMessages = [...history, ...newMessages];
+      setMessages(finalMessages);
+      if (!persistenceBroken.current && activeId) {
+        try {
+          await replaceMessages(activeId, finalMessages);
+          bumpConversation(activeId);
+        } catch (error) {
+          warnPersistence(error);
+        }
+      }
+    } catch (error) {
+      toast.error("AI request failed", String(error));
+      setMessages(previousMessages); // restore the response we tried to replace
+    } finally {
+      setStreaming(false);
+      setLiveSegments([]);
+    }
+  };
+
+  const onSettingsSaved = (saved: AiSettings) => {
+    setSettings(saved);
+    setModel(modelFor(saved, provider));
+  };
+
+  const needsSetup = settings
+    ? providerNeedsApiKey(provider) && !apiKeyFor(settings, provider)
+    : true;
+
+  return {
+    settings,
+    provider,
+    model,
+    setModel,
+    settingsOpen,
+    setSettingsOpen,
+    conversations,
+    activeId,
+    messages,
+    input,
+    setInput,
+    attachments,
+    removeAttachment,
+    attaching,
+    streaming,
+    liveSegments,
+    scrollRef,
+    needsSetup,
+    handleProviderChange,
+    handleNewChat,
+    handleSelectConversation,
+    handleDeleteConversation,
+    handleAttach,
+    handleSend,
+    handleRetry,
+    onSettingsSaved,
+  };
+}

--- a/src/hooks/use-dashboard-analytics.ts
+++ b/src/hooks/use-dashboard-analytics.ts
@@ -1,0 +1,273 @@
+import { useState, useEffect, useMemo } from "react";
+import {
+  listPortfolios,
+  getPortfolioAnalytics,
+  getFunderDeals,
+  computeKpis,
+  aggregateMonthlyByVintage,
+  buildAllocationsByMonth,
+  normalizeStacked,
+  latestMonthAllocation,
+  currentAllocation,
+  buildCommissionsByMonth,
+  buildRtrSeries,
+  buildVintagePerformance,
+  formatMoney,
+  formatPct,
+  type PortfolioOption,
+  type PortfolioSelection,
+  type PortfolioAnalytics,
+  type MonthlyStatsRow,
+  type FunderDealRow,
+} from "@services/analytics-service";
+
+/**
+ * Owns the dashboard's data loading (portfolios, analytics, funder drill-down)
+ * and every derived series/KPI the charts render. Keeping this out of the page
+ * component leaves it as pure presentation.
+ */
+export function useDashboardAnalytics() {
+  const [portfolios, setPortfolios] = useState<PortfolioOption[]>([]);
+  const [selection, setSelection] = useState<PortfolioSelection | null>(null);
+  const [analytics, setAnalytics] = useState<PortfolioAnalytics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Funder drill-down (set by clicking a funder in a legend / pie / bar)
+  const [funderId, setFunderId] = useState<number | null>(null);
+  const [deals, setDeals] = useState<FunderDealRow[]>([]);
+  const [dealsLoading, setDealsLoading] = useState(false);
+  const [dealsError, setDealsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listPortfolios()
+      .then((list) => {
+        setPortfolios(list);
+        setSelection((current) => current ?? (list.length > 0 ? "all" : null));
+        if (list.length === 0) {
+          setLoading(false);
+          setError("No portfolios are shared with your account.");
+        }
+      })
+      .catch((err) => {
+        setLoading(false);
+        setError(err instanceof Error ? err.message : "Failed to load portfolios");
+      });
+  }, []);
+
+  useEffect(() => {
+    if (selection == null) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getPortfolioAnalytics(selection)
+      .then((data) => {
+        if (!cancelled) setAnalytics(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load analytics");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selection]);
+
+  useEffect(() => {
+    if (funderId == null || selection == null) {
+      setDeals([]);
+      setDealsError(null);
+      return;
+    }
+    let cancelled = false;
+    setDealsLoading(true);
+    setDealsError(null);
+    getFunderDeals(selection, funderId)
+      .then((rows) => {
+        if (!cancelled) setDeals(rows);
+      })
+      .catch((err) => {
+        if (!cancelled) setDealsError(err instanceof Error ? err.message : "Failed to load deals");
+      })
+      .finally(() => {
+        if (!cancelled) setDealsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [funderId, selection]);
+
+  const funderIdsByName = useMemo(
+    () =>
+      new Map(Object.entries(analytics?.funderNames ?? {}).map(([id, name]) => [name, Number(id)])),
+    [analytics]
+  );
+
+  const handleFunderClick = (funderName: string) => {
+    const id = funderIdsByName.get(funderName);
+    if (id != null) setFunderId(id);
+  };
+
+  const funderName = funderId != null ? (analytics?.funderNames[funderId] ?? null) : null;
+  const scopeLabel =
+    selection === "all"
+      ? "All Portfolios"
+      : (portfolios.find((p) => p.id === selection)?.name ?? "");
+
+  // Vintage-month rows for the current scope. The combined view and the funder
+  // view can both have several source rows per month, so collapse them first.
+  const monthlyRows = useMemo<MonthlyStatsRow[]>(() => {
+    if (!analytics) return [];
+    if (funderId != null)
+      return aggregateMonthlyByVintage(analytics.vintages.filter((v) => v.funder_id === funderId));
+    if (selection === "all") return aggregateMonthlyByVintage(analytics.monthly);
+    return analytics.monthly;
+  }, [analytics, selection, funderId]);
+
+  const vintagesInScope = useMemo(() => {
+    if (!analytics) return [];
+    return funderId != null
+      ? analytics.vintages.filter((v) => v.funder_id === funderId)
+      : analytics.vintages;
+  }, [analytics, funderId]);
+
+  const rtrInScope = useMemo(() => {
+    if (!analytics) return [];
+    return funderId != null ? analytics.rtr.filter((r) => r.funder_id === funderId) : analytics.rtr;
+  }, [analytics, funderId]);
+
+  const kpis = useMemo(() => computeKpis(monthlyRows), [monthlyRows]);
+  const allocations = useMemo(
+    () => buildAllocationsByMonth(vintagesInScope, analytics?.funderNames ?? {}),
+    [vintagesInScope, analytics]
+  );
+  const allocationsPct = useMemo(() => normalizeStacked(allocations), [allocations]);
+  const latestVintage = useMemo(
+    () => latestMonthAllocation(vintagesInScope, analytics?.funderNames ?? {}),
+    [vintagesInScope, analytics]
+  );
+  const currentAlloc = useMemo(
+    () => currentAllocation(analytics?.allocations ?? [], analytics?.funderNames ?? {}),
+    [analytics]
+  );
+  const commissions = useMemo(() => buildCommissionsByMonth(monthlyRows), [monthlyRows]);
+  const rtrSeries = useMemo(
+    () => buildRtrSeries(rtrInScope, analytics?.funderNames ?? {}),
+    [rtrInScope, analytics]
+  );
+  const performance = useMemo(() => buildVintagePerformance(monthlyRows), [monthlyRows]);
+
+  // Snapshot cards for the funder drill-down, from funder_allocation_current.
+  // In the "all" scope a funder has one row per portfolio, so sum / re-weight.
+  const funderSnapshot = useMemo(() => {
+    if (funderId == null || !analytics) return null;
+    const rows = analytics.allocations.filter((a) => a.funder_id === funderId);
+    const initial = rows.reduce((acc, r) => acc + (r.initial_cost_basis ?? 0), 0);
+    const current = rows.reduce((acc, r) => acc + (r.current_cost_basis ?? 0), 0);
+    const received = rows.reduce((acc, r) => acc + (r.rtr_received ?? 0), 0);
+    const totalCurrent = analytics.allocations.reduce(
+      (acc, r) => acc + Math.max(r.current_cost_basis ?? 0, 0),
+      0
+    );
+    return {
+      initial,
+      current,
+      received,
+      share: totalCurrent > 0 ? Math.max(current, 0) / totalCurrent : 0,
+    };
+  }, [analytics, funderId]);
+
+  const hasData = monthlyRows.length > 0;
+
+  const kpiCards = [
+    {
+      title: "Dollars at Work",
+      value: formatMoney(kpis.dollarsAtWork),
+      subtitle: `${kpis.dealCount.toLocaleString()} deals`,
+      icon: "solar:dollar-bold",
+    },
+    {
+      title: "Cost Basis",
+      value: formatMoney(kpis.costBasis),
+      subtitle: "participation + commissions",
+      icon: "solar:wallet-money-bold",
+    },
+    {
+      title: "Net RTR Outstanding",
+      value: formatMoney(kpis.netRtrOutstanding),
+      subtitle: "after bad debt",
+      icon: "solar:hourglass-bold",
+    },
+    {
+      title: "Principal / Profit Returned",
+      value: `${formatMoney(kpis.principalReturned)} / ${formatMoney(kpis.profitReturned)}`,
+      subtitle: `${formatMoney(kpis.principalReturned + kpis.profitReturned)} total received`,
+      icon: "solar:round-transfer-diagonal-bold",
+    },
+    {
+      title: "Lifetime Return",
+      value: formatPct(kpis.lifetimeReturn),
+      subtitle: "RTR received / cost basis − 1",
+      icon: "solar:chart-2-bold",
+      tone: kpis.lifetimeReturn >= 0 ? ("success" as const) : ("danger" as const),
+    },
+    {
+      title: "Bad Debt",
+      value: formatPct(kpis.badDebtPct),
+      subtitle: "of initial net RTR",
+      icon: "solar:danger-triangle-bold",
+      tone: kpis.badDebtPct > 0.05 ? ("danger" as const) : ("success" as const),
+    },
+    ...(funderSnapshot
+      ? [
+          {
+            title: "Current Cost Basis",
+            value: formatMoney(funderSnapshot.current),
+            subtitle: `of ${formatMoney(funderSnapshot.initial)} initial`,
+            icon: "solar:money-bag-bold",
+          },
+          {
+            title: "RTR Received (snapshot)",
+            value: formatMoney(funderSnapshot.received),
+            subtitle: "current allocation view",
+            icon: "solar:round-double-alt-arrow-down-bold",
+          },
+          {
+            title: "Share of Current Allocation",
+            value: formatPct(funderSnapshot.share),
+            subtitle: `within ${scopeLabel.toLowerCase()}`,
+            icon: "solar:pie-chart-2-bold",
+          },
+        ]
+      : []),
+  ];
+
+  const onFunderClick = funderId == null ? handleFunderClick : undefined;
+
+  return {
+    portfolios,
+    selection,
+    setSelection,
+    funderId,
+    setFunderId,
+    funderName,
+    scopeLabel,
+    loading,
+    error,
+    hasData,
+    kpiCards,
+    allocations,
+    allocationsPct,
+    latestVintage,
+    currentAlloc,
+    commissions,
+    rtrSeries,
+    performance,
+    deals,
+    dealsLoading,
+    dealsError,
+    onFunderClick,
+  };
+}

--- a/src/hooks/use-deal-lookup.ts
+++ b/src/hooks/use-deal-lookup.ts
@@ -1,0 +1,386 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useToast } from "@/contexts/toast-context-value";
+import { formatMoney } from "@services/analytics-service";
+import {
+  applyFilters,
+  getDealRecords,
+  pivotToCsv,
+  recordsToCsv,
+  saveCsvFile,
+  DEFAULT_CHART_CONFIG,
+  DEFAULT_PIVOT_CONFIG,
+  DEFAULT_VISIBLE_FIELDS,
+  EMPTY_FILTERS,
+  type ChartConfig,
+  type DealRecord,
+  type ExplorerFilters,
+  type PivotConfig,
+  type PivotData,
+} from "@services/deal-explorer-service";
+import {
+  deleteDeal,
+  getDealFormValues,
+  getEditorLookups,
+  EMPTY_DEAL_FORM,
+  type DealFormValues,
+  type EditorLookups,
+} from "@services/deal-editor-service";
+import PivotSyncService, { type UnresolvedPivotRow } from "@services/pivot-sync-service";
+import { type FilterOptions } from "@components/deal-explorer/filter-panel";
+
+const EMPTY_LOOKUPS: EditorLookups = {
+  portfolios: [],
+  funders: [],
+  industries: [],
+  states: [],
+  merchants: [],
+};
+
+// Versioned so a future change to the SavedView shape can bump the suffix and
+// ignore incompatible saved data instead of crashing on parse.
+const VIEWS_STORAGE_KEY = "excelerate.deal-lookup.views:v1";
+
+export interface SavedView {
+  id: string;
+  name: string;
+  filters: ExplorerFilters;
+  visibleFields: string[];
+  pivot: PivotConfig;
+  chart: ChartConfig;
+}
+
+function loadSavedViews(): SavedView[] {
+  try {
+    const raw = localStorage.getItem(VIEWS_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as SavedView[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const uniqueSorted = (values: (string | null)[]): string[] =>
+  [...new Set(values.filter((v): v is string => v != null && v !== ""))].sort();
+
+/**
+ * Owns all deal-lookup state and side effects: records, filters, visible
+ * fields, pivot/chart config, saved views, deal CRUD, and unmatched-row
+ * reconciliation. Kept out of the page component so the page is presentation.
+ */
+// react-doctor-disable-next-line react-doctor/prefer-useReducer -- these hold largely independent concerns (records, load status, filters, visible fields, pivot/chart config, saved views) that change at different times, so a single reducer would not improve consistency
+export function useDealLookup() {
+  const { showToast } = useToast();
+  const [records, setRecords] = useState<DealRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [filters, setFilters] = useState<ExplorerFilters>(EMPTY_FILTERS);
+  const [visibleFields, setVisibleFields] = useState<string[]>(DEFAULT_VISIBLE_FIELDS);
+  const [pivotConfig, setPivotConfig] = useState<PivotConfig>(DEFAULT_PIVOT_CONFIG);
+  const [chartConfig, setChartConfig] = useState<ChartConfig>(DEFAULT_CHART_CONFIG);
+
+  const [savedViews, setSavedViews] = useState<SavedView[]>(loadSavedViews);
+  const [activeViewId, setActiveViewId] = useState<string | null>(null);
+  const [viewName, setViewName] = useState("");
+  const [saveModalOpen, setSaveModalOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
+
+  // Deal CRUD
+  const [lookups, setLookups] = useState<EditorLookups>(EMPTY_LOOKUPS);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<{ dealId: string; values: DealFormValues } | null>(null);
+  const [createDefaults, setCreateDefaults] = useState<DealFormValues | null>(null);
+  const [deleting, setDeleting] = useState<DealRecord | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+
+  // Unmatched pivot-row reconciliation
+  const [unresolvedRows, setUnresolvedRows] = useState<UnresolvedPivotRow[]>([]);
+  const [unresolvedLoading, setUnresolvedLoading] = useState(true);
+  const [busyRowId, setBusyRowId] = useState<string | null>(null);
+  /**
+   * When set, the next saved deal also resolves this pivot row. A ref, not
+   * state: it is only ever read inside handlers, never rendered.
+   */
+  const pendingResolveRowIdRef = useRef<string | null>(null);
+
+  const fetchLookups = useCallback(() => {
+    getEditorLookups()
+      .then(setLookups)
+      .catch((err) =>
+        showToast({
+          title: "Failed to load deal form lookups",
+          description: err instanceof Error ? err.message : String(err),
+          type: "error",
+        })
+      );
+  }, [showToast]);
+
+  const fetchRecords = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    getDealRecords()
+      .then(setRecords)
+      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load deals"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const fetchUnresolved = useCallback(() => {
+    setUnresolvedLoading(true);
+    PivotSyncService.listUnresolvedRows()
+      .then(setUnresolvedRows)
+      .catch((err) =>
+        showToast({
+          title: "Failed to load unmatched pivot rows",
+          description: err instanceof Error ? err.message : String(err),
+          type: "error",
+        })
+      )
+      .finally(() => setUnresolvedLoading(false));
+  }, [showToast]);
+
+  useEffect(fetchRecords, [fetchRecords]);
+  useEffect(fetchLookups, [fetchLookups]);
+  useEffect(fetchUnresolved, [fetchUnresolved]);
+
+  const openCreate = () => {
+    setEditing(null);
+    setCreateDefaults(null);
+    pendingResolveRowIdRef.current = null;
+    setFormOpen(true);
+  };
+
+  const openEdit = async (record: DealRecord) => {
+    try {
+      const values = await getDealFormValues(record.id);
+      setEditing({ dealId: record.id, values });
+      setCreateDefaults(null);
+      pendingResolveRowIdRef.current = null;
+      setFormOpen(true);
+    } catch (err) {
+      showToast({
+        title: "Failed to load deal",
+        description: err instanceof Error ? err.message : String(err),
+        type: "error",
+      });
+    }
+  };
+
+  const resolveRow = async (row: UnresolvedPivotRow, dealId: string) => {
+    setBusyRowId(row.row_id);
+    try {
+      await PivotSyncService.resolveRow(row.row_id, dealId);
+      showToast({
+        title: "Pivot row resolved",
+        description: `${row.merchant_name} — payment written for ${row.report_date}`,
+        type: "success",
+      });
+      fetchRecords();
+      fetchUnresolved();
+    } catch (err) {
+      showToast({
+        title: "Failed to resolve pivot row",
+        description: err instanceof Error ? err.message : String(err),
+        type: "error",
+      });
+    } finally {
+      setBusyRowId(null);
+    }
+  };
+
+  /** "New deal" from an unmatched row: prefill the form, resolve after save. */
+  const createDealFromRow = (row: UnresolvedPivotRow) => {
+    setEditing(null);
+    setCreateDefaults({
+      ...EMPTY_DEAL_FORM,
+      portfolioId: row.portfolio_id,
+      funderId: row.funder_id,
+      merchantName: row.merchant_name,
+      funderAdvanceId: row.advance_id ?? "",
+      dateFunded: row.report_date,
+    });
+    pendingResolveRowIdRef.current = row.row_id;
+    setFormOpen(true);
+  };
+
+  const handleSaved = async (dealId: string) => {
+    showToast({ title: editing != null ? "Deal updated" : "Deal created", type: "success" });
+    const pendingRowId = pendingResolveRowIdRef.current;
+    if (pendingRowId != null) {
+      const row = unresolvedRows.find((r) => r.row_id === pendingRowId);
+      pendingResolveRowIdRef.current = null;
+      if (row != null) {
+        await resolveRow(row, dealId);
+        fetchLookups();
+        return; // resolveRow already refetched records
+      }
+    }
+    fetchRecords();
+    fetchLookups(); // a save may have added or renamed a merchant
+  };
+
+  const confirmDelete = async () => {
+    if (deleting == null) return;
+    setDeleteBusy(true);
+    try {
+      await deleteDeal(deleting.id);
+      showToast({
+        title: "Deal deleted",
+        description: deleting.merchant_name ?? deleting.funder_advance_id ?? deleting.id,
+        type: "success",
+      });
+      setDeleting(null);
+      fetchRecords();
+    } catch (err) {
+      showToast({
+        title: "Delete failed",
+        description: err instanceof Error ? err.message : String(err),
+        type: "error",
+      });
+    } finally {
+      setDeleteBusy(false);
+    }
+  };
+
+  const options = useMemo<FilterOptions>(
+    () => ({
+      portfolios: uniqueSorted(records.map((r) => r.portfolio_name)),
+      funders: uniqueSorted(records.map((r) => r.funder_name)),
+      industries: uniqueSorted(records.map((r) => r.industry)),
+      states: uniqueSorted(records.map((r) => r.state)),
+      months: uniqueSorted(records.map((r) => r.vintage_month?.slice(0, 7) ?? null)),
+    }),
+    [records]
+  );
+
+  const filtered = useMemo(() => applyFilters(records, filters), [records, filters]);
+
+  const summary = useMemo(() => {
+    const sum = (pick: (r: DealRecord) => number | null) =>
+      filtered.reduce((acc, r) => acc + (pick(r) ?? 0), 0);
+    return {
+      funded: sum((r) => r.total_amount_funded),
+      costBasis: sum((r) => r.cost_basis),
+      netReceived: sum((r) => r.total_net_received),
+      balance: sum((r) => r.net_rtr_balance),
+    };
+  }, [filtered]);
+
+  const persistViews = (views: SavedView[]) => {
+    setSavedViews(views);
+    localStorage.setItem(VIEWS_STORAGE_KEY, JSON.stringify(views));
+  };
+
+  const saveCurrentView = () => {
+    const name = viewName.trim();
+    if (!name) return;
+    const view: SavedView = {
+      id: `view-${Date.now()}`,
+      name,
+      filters,
+      visibleFields,
+      pivot: pivotConfig,
+      chart: chartConfig,
+    };
+    persistViews([...savedViews, view]);
+    setActiveViewId(view.id);
+    setViewName("");
+    setSaveModalOpen(false);
+    showToast({ title: `View "${name}" saved`, type: "success" });
+  };
+
+  const applyView = (view: SavedView) => {
+    // Merge over defaults so views saved before new filters/configs still load.
+    setFilters({ ...EMPTY_FILTERS, ...view.filters });
+    setVisibleFields(view.visibleFields.length > 0 ? view.visibleFields : DEFAULT_VISIBLE_FIELDS);
+    setPivotConfig({ ...DEFAULT_PIVOT_CONFIG, ...view.pivot });
+    setChartConfig({ ...DEFAULT_CHART_CONFIG, ...view.chart });
+    setActiveViewId(view.id);
+  };
+
+  const deleteActiveView = () => {
+    if (activeViewId == null) return;
+    const view = savedViews.find((v) => v.id === activeViewId);
+    persistViews(savedViews.filter((v) => v.id !== activeViewId));
+    setActiveViewId(null);
+    if (view) showToast({ title: `View "${view.name}" deleted`, type: "info" });
+  };
+
+  const exportCsv = async (defaultName: string, csv: string) => {
+    setExporting(true);
+    try {
+      const path = await saveCsvFile(defaultName, csv);
+      if (path != null) {
+        showToast({ title: "Export complete", description: path, type: "success" });
+      }
+    } catch (err) {
+      showToast({
+        title: "Export failed",
+        description: err instanceof Error ? err.message : String(err),
+        type: "error",
+      });
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const exportTable = () =>
+    exportCsv(`deals-${today()}.csv`, recordsToCsv(filtered, visibleFields));
+  const exportPivot = (pivot: PivotData) =>
+    exportCsv(`deal-pivot-${today()}.csv`, pivotToCsv(pivot));
+
+  const summaryCards = [
+    { label: "Deals", value: filtered.length.toLocaleString() },
+    { label: "Amount Funded", value: formatMoney(summary.funded) },
+    { label: "Cost Basis", value: formatMoney(summary.costBasis) },
+    { label: "Net Received", value: formatMoney(summary.netReceived) },
+    { label: "Net RTR Balance", value: formatMoney(summary.balance) },
+  ];
+
+  return {
+    records,
+    loading,
+    error,
+    filters,
+    setFilters,
+    visibleFields,
+    setVisibleFields,
+    pivotConfig,
+    setPivotConfig,
+    chartConfig,
+    setChartConfig,
+    savedViews,
+    activeViewId,
+    viewName,
+    setViewName,
+    saveModalOpen,
+    setSaveModalOpen,
+    exporting,
+    lookups,
+    formOpen,
+    setFormOpen,
+    editing,
+    createDefaults,
+    deleting,
+    setDeleting,
+    deleteBusy,
+    unresolvedRows,
+    unresolvedLoading,
+    busyRowId,
+    options,
+    filtered,
+    summaryCards,
+    fetchRecords,
+    openCreate,
+    openEdit,
+    resolveRow,
+    createDealFromRow,
+    handleSaved,
+    confirmDelete,
+    saveCurrentView,
+    applyView,
+    deleteActiveView,
+    exportTable,
+    exportPivot,
+  };
+}

--- a/src/hooks/use-file-upload.ts
+++ b/src/hooks/use-file-upload.ts
@@ -1,0 +1,268 @@
+import { useEffect, useRef, useState } from "react";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { readFile } from "@tauri-apps/plugin-fs";
+
+interface UseFileUploadOptions {
+  onFileUpload?: (file: File) => void;
+  acceptedTypes: string[];
+  acceptedExtensions: string[];
+  maxSizeKB: number;
+  selectedFile?: File | null;
+  onClearFile?: () => void;
+  uploadId: string;
+}
+
+interface UseFileUploadResult {
+  currentFile: File | null;
+  isDragging: boolean;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  dropZoneRef: React.RefObject<HTMLDivElement>;
+  handleFileSelect: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  clearFile: () => void;
+  triggerFileSelect: () => void;
+}
+
+/**
+ * Encapsulates the stateful file-selection logic for FileUpload: local vs
+ * controlled file state, extension/size validation, and the Tauri
+ * drag-and-drop listener. Keeping this out of the component keeps the render
+ * focused on presentation.
+ */
+export function useFileUpload({
+  onFileUpload,
+  acceptedTypes,
+  acceptedExtensions,
+  maxSizeKB,
+  selectedFile = null,
+  onClearFile,
+  uploadId,
+}: UseFileUploadOptions): UseFileUploadResult {
+  const [localSelectedFile, setLocalSelectedFile] = useState<File | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const dropZoneRef = useRef<HTMLDivElement>(null);
+  const isHoveredRef = useRef(false);
+  const onFileUploadRef = useRef(onFileUpload);
+  const listenerRegisteredRef = useRef(false);
+
+  // Use prop file if provided, otherwise use local state
+  const currentFile = selectedFile ?? localSelectedFile;
+
+  // Keep the ref up to date with the latest callback
+  useEffect(() => {
+    onFileUploadRef.current = onFileUpload;
+  }, [onFileUpload]);
+
+  // Handle file drop from Tauri
+  const handleTauriFileDrop = async (filePath: string) => {
+    console.warn(`[FileUpload-${uploadId}] handleTauriFileDrop called with:`, filePath);
+    try {
+      // Extract file name from path
+      const fileName = filePath.split(/[\\/]/).pop() || "file";
+
+      // Check if file has valid extension
+      const hasValidExtension = acceptedExtensions.some((ext) =>
+        fileName.toLowerCase().endsWith(ext.toLowerCase())
+      );
+
+      if (!hasValidExtension) {
+        console.error(
+          `Invalid file extension: ${fileName}. Expected: ${acceptedExtensions.join(", ")}`
+        );
+        return;
+      }
+
+      // Read the file content
+      const fileContent = await readFile(filePath);
+
+      // Create a File object from the content
+      const file = new File([fileContent], fileName, {
+        type: fileName.endsWith(".xlsx")
+          ? "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          : "application/vnd.ms-excel",
+      });
+
+      // Check file size
+      if (file.size > maxSizeKB * 1024) {
+        console.error(
+          `File too large: ${(file.size / 1024).toFixed(1)}KB. Maximum: ${maxSizeKB}KB`
+        );
+        return;
+      }
+
+      console.warn(
+        `[FileUpload-${uploadId}] File created from Tauri drop:`,
+        file.name,
+        "Size:",
+        file.size
+      );
+
+      // Update state and call handler
+      if (selectedFile === undefined) {
+        setLocalSelectedFile(file);
+      }
+      console.warn(`[FileUpload-${uploadId}] Calling onFileUploadRef.current`);
+      onFileUploadRef.current?.(file);
+    } catch (error) {
+      console.error("Failed to process Tauri file drop:", error);
+    }
+  };
+
+  // Keep a stable ref to the latest handler so the listener below can register
+  // once and still call the current closure (deps otherwise force re-registration).
+  const handleTauriFileDropRef = useRef(handleTauriFileDrop);
+  useEffect(() => {
+    handleTauriFileDropRef.current = handleTauriFileDrop;
+  });
+
+  // Handle Tauri-specific drag and drop events
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+
+    const setupTauriDragDrop = async () => {
+      // Prevent multiple registrations
+      if (listenerRegisteredRef.current) {
+        console.warn(`[FileUpload-${uploadId}] Listener already registered, skipping`);
+        return;
+      }
+
+      try {
+        console.warn(`[FileUpload-${uploadId}] Setting up Tauri drag drop listener`);
+        listenerRegisteredRef.current = true;
+        // Listen for Tauri drag and drop events
+        unlisten = await getCurrentWebview().onDragDropEvent((event) => {
+          // Only process if this specific drop zone is being hovered
+          if (!dropZoneRef.current) return;
+
+          const hasPosition = (
+            payload: unknown
+          ): payload is { position: { x: number; y: number } } => {
+            if (typeof payload !== "object" || payload === null) return false;
+            const pos = (payload as { position?: unknown }).position;
+            return (
+              typeof pos === "object" &&
+              pos !== null &&
+              typeof (pos as { x?: unknown }).x === "number" &&
+              typeof (pos as { y?: unknown }).y === "number"
+            );
+          };
+
+          // Check if the drop zone is being hovered
+          const rect = dropZoneRef.current.getBoundingClientRect();
+          const isOverDropZone =
+            hasPosition(event.payload) &&
+            event.payload.position.x >= rect.left &&
+            event.payload.position.x <= rect.right &&
+            event.payload.position.y >= rect.top &&
+            event.payload.position.y <= rect.bottom;
+
+          if (event.payload.type === "over") {
+            // Only show dragging state if over this specific drop zone
+            if (isOverDropZone) {
+              setIsDragging(true);
+              isHoveredRef.current = true;
+            } else {
+              setIsDragging(false);
+              isHoveredRef.current = false;
+            }
+          } else if (event.payload.type === "drop") {
+            // Only process drop if it's over this specific drop zone
+            if (isHoveredRef.current || isOverDropZone) {
+              console.warn(`Files dropped on ${uploadId}:`, event.payload.paths);
+
+              // Process the first file
+              if (event.payload.paths && event.payload.paths.length > 0) {
+                const filePath = event.payload.paths[0];
+                console.warn(`Processing file for ${uploadId}:`, filePath);
+                handleTauriFileDropRef.current(filePath);
+              }
+            }
+            setIsDragging(false);
+            isHoveredRef.current = false;
+          } else {
+            // Drag cancelled
+            setIsDragging(false);
+            isHoveredRef.current = false;
+          }
+        });
+      } catch (error) {
+        console.error("Failed to setup Tauri drag drop:", error);
+      }
+    };
+
+    setupTauriDragDrop();
+
+    // Cleanup
+    return () => {
+      console.warn(`[FileUpload-${uploadId}] Cleaning up Tauri drag drop listener`);
+      if (unlisten) {
+        unlisten();
+        listenerRegisteredRef.current = false;
+      }
+    };
+  }, [uploadId]); // Register once per drop zone; dynamic values are read via refs
+
+  // Check if file is valid based on props
+  const isValidFile = (file: File): boolean => {
+    // Check extension first as it's more reliable
+    const isValidExtension = acceptedExtensions.some((ext) =>
+      file.name.toLowerCase().endsWith(ext.toLowerCase())
+    );
+
+    // Check MIME type (can be empty for some files)
+    const isValidType = !file.type || acceptedTypes.some((type) => file.type === type);
+
+    // Check file size
+    const isValidSize = file.size <= maxSizeKB * 1024;
+
+    console.warn("Validation:", {
+      extension: isValidExtension,
+      type: isValidType,
+      size: isValidSize,
+      fileName: file.name,
+      fileType: file.type || "no type",
+      fileSize: file.size,
+    });
+
+    // Accept if extension is valid AND size is valid
+    // Type check is optional since some systems don't set it correctly
+    return isValidExtension && isValidSize;
+  };
+
+  // Handle file selection
+  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file && isValidFile(file)) {
+      if (selectedFile === undefined) {
+        setLocalSelectedFile(file);
+      }
+      onFileUploadRef.current?.(file);
+    }
+  };
+
+  // Clear file - FIXED
+  const clearFile = () => {
+    if (selectedFile === undefined) {
+      setLocalSelectedFile(null);
+    }
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+    onClearFile?.();
+  };
+
+  // Trigger file input click
+  const triggerFileSelect = () => {
+    fileInputRef.current?.click();
+  };
+
+  return {
+    currentFile,
+    isDragging,
+    fileInputRef,
+    dropZoneRef,
+    handleFileSelect,
+    clearFile,
+    triggerFileSelect,
+  };
+}

--- a/src/pages/ai-chat.tsx
+++ b/src/pages/ai-chat.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Button,
   Chip,
@@ -10,344 +9,41 @@ import {
   Tooltip,
 } from "@heroui/react";
 import { Icon } from "@iconify/react";
-import { open } from "@tauri-apps/plugin-dialog";
 
-import {
-  apiKeyFor,
-  getAiSettings,
-  modelFor,
-  prepareChatAttachment,
-  PROVIDER_LABELS,
-  providerNeedsApiKey,
-  streamChat,
-  type AiChatEvent,
-  type AiProvider,
-  type AiSettings,
-  type ChatBlock,
-  type ChatMessage,
-  type PreparedAttachment,
-} from "@services/ai-chat-service";
-import {
-  appendMessages,
-  createConversation,
-  deleteConversation,
-  listConversations,
-  listMessages,
-  replaceMessages,
-  type Conversation,
-} from "@services/chat-store-service";
-import { toast } from "@services/toast-service";
-import {
-  LiveMessageView,
-  MessageView,
-  type LiveSegment,
-} from "@components/ai-chat/chat-message-view";
-import { isToolResultMessage } from "@components/ai-chat/message-utils";
+import { PROVIDER_LABELS, type AiProvider } from "@services/ai-chat-service";
+import { LiveMessageView, MessageView } from "@components/ai-chat/chat-message-view";
 import { ProviderSettingsModal } from "@components/ai-chat/provider-settings-modal";
+import { useAiChat } from "@/hooks/use-ai-chat";
 
-const ATTACHMENT_EXTENSIONS = [
-  "csv",
-  "tsv",
-  "txt",
-  "md",
-  "json",
-  "xlsx",
-  "xls",
-  "xlsm",
-  "xlsb",
-  "ods",
-  "pdf",
-  "png",
-  "jpg",
-  "jpeg",
-  "gif",
-  "webp",
-];
-
-function titleFrom(text: string, fallback: string): string {
-  const trimmed = text.trim().replace(/\s+/g, " ");
-  if (!trimmed) return fallback;
-  return trimmed.length > 60 ? `${trimmed.slice(0, 60)}…` : trimmed;
-}
-
-/**
- * A prepared attachment plus a client-generated id, so the pending-attachment
- * chips have a stable key while the user adds and removes them before sending.
- */
-interface LocalAttachment extends PreparedAttachment {
-  id: string;
-}
-
-// react-doctor-disable-next-line react-doctor/prefer-useReducer -- these hold largely independent concerns (settings, conversation list, active messages, composer input, attachments, streaming status) that change at different times, so a single reducer would not improve consistency
 function AiChat() {
-  const [settings, setSettings] = useState<AiSettings | null>(null);
-  const [provider, setProvider] = useState<AiProvider>("anthropic");
-  const [model, setModel] = useState("");
-  const [settingsOpen, setSettingsOpen] = useState(false);
-
-  const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [activeId, setActiveId] = useState<string | null>(null);
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
-
-  const [input, setInput] = useState("");
-  const [attachments, setAttachments] = useState<LocalAttachment[]>([]);
-  const [attaching, setAttaching] = useState(false);
-  const [streaming, setStreaming] = useState(false);
-  const [liveSegments, setLiveSegments] = useState<LiveSegment[]>([]);
-
-  // Persistence degrades gracefully until the chat tables exist in Supabase.
-  const persistenceBroken = useRef(false);
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    getAiSettings()
-      .then((loaded) => {
-        setSettings(loaded);
-        setProvider(loaded.default_provider);
-        setModel(modelFor(loaded, loaded.default_provider));
-      })
-      .catch((error) => toast.error("Failed to load AI settings", String(error)));
-
-    listConversations()
-      .then(setConversations)
-      .catch(() => {
-        persistenceBroken.current = true;
-      });
-  }, []);
-
-  useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
-  }, [messages, liveSegments]);
-
-  const warnPersistence = (error: unknown) => {
-    if (!persistenceBroken.current) {
-      persistenceBroken.current = true;
-      toast.warning(
-        "Chat history is not being saved",
-        `Conversations will work but won't persist: ${String(error)}`
-      );
-    }
-  };
-
-  const handleProviderChange = (next: AiProvider) => {
-    setProvider(next);
-    if (settings) setModel(modelFor(settings, next));
-  };
-
-  const handleNewChat = () => {
-    if (streaming) return;
-    setActiveId(null);
-    setMessages([]);
-  };
-
-  const handleSelectConversation = async (conversation: Conversation) => {
-    if (streaming || conversation.id === activeId) return;
-    setActiveId(conversation.id);
-    if (conversation.provider in PROVIDER_LABELS) {
-      setProvider(conversation.provider as AiProvider);
-    }
-    if (conversation.model) setModel(conversation.model);
-    try {
-      setMessages(await listMessages(conversation.id));
-    } catch (error) {
-      setMessages([]);
-      warnPersistence(error);
-    }
-  };
-
-  const handleDeleteConversation = async (id: string) => {
-    try {
-      await deleteConversation(id);
-      setConversations((prev) => prev.filter((c) => c.id !== id));
-      if (activeId === id) handleNewChat();
-    } catch (error) {
-      toast.error("Failed to delete conversation", String(error));
-    }
-  };
-
-  const handleAttach = async () => {
-    setAttaching(true);
-    try {
-      const selected = await open({
-        multiple: true,
-        filters: [{ name: "Documents & data", extensions: ATTACHMENT_EXTENSIONS }],
-      });
-      if (!selected) return;
-      const paths = Array.isArray(selected) ? selected : [selected];
-      // The picks are independent, so prepare them together instead of
-      // awaiting each one in turn.
-      const prepared = await Promise.all(paths.map((path) => prepareChatAttachment(path)));
-      const withIds: LocalAttachment[] = prepared.map((attachment) => ({
-        ...attachment,
-        id: crypto.randomUUID(),
-      }));
-      setAttachments((prev) => [...prev, ...withIds]);
-    } catch (error) {
-      toast.error("Could not attach file", String(error));
-    } finally {
-      setAttaching(false);
-    }
-  };
-
-  const onEvent = useCallback((event: AiChatEvent) => {
-    setLiveSegments((prev) => {
-      if (event.type === "text_delta") {
-        const last = prev[prev.length - 1];
-        if (last?.type === "text") {
-          return [...prev.slice(0, -1), { type: "text", text: last.text + event.text }];
-        }
-        return [...prev, { type: "text", text: event.text }];
-      }
-      if (event.type === "tool_call") {
-        return [...prev, { type: "tool", id: event.id, name: event.name, status: "running" }];
-      }
-      if (event.type === "tool_result") {
-        return prev.map((segment) =>
-          segment.type === "tool" && segment.id === event.id
-            ? { ...segment, status: event.is_error ? "error" : "done" }
-            : segment
-        );
-      }
-      return prev;
-    });
-  }, []);
-
-  /** Validates provider/model setup, surfacing a toast and returning false if not ready. */
-  const ensureConfigured = (): boolean => {
-    if (!settings || (providerNeedsApiKey(provider) && !apiKeyFor(settings, provider))) {
-      toast.warning(
-        "No API key configured",
-        `Add your ${PROVIDER_LABELS[provider]} API key in the AI settings first.`
-      );
-      setSettingsOpen(true);
-      return false;
-    }
-    if (!model.trim()) {
-      const hint =
-        provider === "lmstudio"
-          ? "Enter the model id loaded in LM Studio (settings or the header field)."
-          : "Enter a model id in the header first.";
-      toast.warning("No model set", hint);
-      if (provider === "lmstudio") setSettingsOpen(true);
-      return false;
-    }
-    return true;
-  };
-
-  /** Moves a conversation to the top of the list after a new turn. */
-  const bumpConversation = (id: string) => {
-    setConversations((prev) => {
-      const bumped = prev.find((c) => c.id === id);
-      if (!bumped) return prev;
-      return [bumped, ...prev.filter((c) => c.id !== id)];
-    });
-  };
-
-  const handleSend = async () => {
-    const text = input.trim();
-    if (streaming || (!text && attachments.length === 0)) return;
-    if (!ensureConfigured()) return;
-
-    const blocks: ChatBlock[] = [
-      ...attachments.flatMap((attachment) => attachment.blocks),
-      ...(text ? [{ kind: "text", text } as ChatBlock] : []),
-    ];
-    const userMessage: ChatMessage = { role: "user", blocks };
-    const history = [...messages, userMessage];
-
-    setMessages(history);
-    setInput("");
-    setAttachments([]);
-    setStreaming(true);
-    setLiveSegments([]);
-
-    // Persist the user message (creating the conversation on first send).
-    let conversationId = activeId;
-    if (!persistenceBroken.current) {
-      try {
-        if (!conversationId) {
-          const conversation = await createConversation(
-            titleFrom(text, attachments[0]?.name ?? "New chat"),
-            provider,
-            model
-          );
-          conversationId = conversation.id;
-          setActiveId(conversation.id);
-          setConversations((prev) => [conversation, ...prev]);
-        }
-        await appendMessages(conversationId, [userMessage]);
-      } catch (error) {
-        warnPersistence(error);
-      }
-    }
-
-    try {
-      const newMessages = await streamChat({ provider, model, messages: history, onEvent });
-      setMessages([...history, ...newMessages]);
-      if (!persistenceBroken.current && conversationId) {
-        try {
-          await appendMessages(conversationId, newMessages);
-          bumpConversation(conversationId);
-        } catch (error) {
-          warnPersistence(error);
-        }
-      }
-    } catch (error) {
-      toast.error("AI request failed", String(error));
-    } finally {
-      setStreaming(false);
-      setLiveSegments([]);
-    }
-  };
-
-  /**
-   * Regenerates the assistant turn that produced `messages[index]`. Everything
-   * from the start of that turn onward is dropped and re-streamed from the
-   * user prompt that triggered it.
-   */
-  const handleRetry = async (index: number) => {
-    if (streaming || !ensureConfigured()) return;
-
-    // Walk back to the genuine user prompt that started this assistant turn,
-    // skipping the assistant messages and tool-result plumbing in between.
-    let cut = index;
-    while (cut > 0) {
-      const prev = messages[cut - 1];
-      if (prev.role === "user" && !isToolResultMessage(prev)) break;
-      cut--;
-    }
-    const history = messages.slice(0, cut);
-    if (history.length === 0) return;
-
-    const previousMessages = messages;
-    setMessages(history);
-    setStreaming(true);
-    setLiveSegments([]);
-
-    try {
-      const newMessages = await streamChat({ provider, model, messages: history, onEvent });
-      const finalMessages = [...history, ...newMessages];
-      setMessages(finalMessages);
-      if (!persistenceBroken.current && activeId) {
-        try {
-          await replaceMessages(activeId, finalMessages);
-          bumpConversation(activeId);
-        } catch (error) {
-          warnPersistence(error);
-        }
-      }
-    } catch (error) {
-      toast.error("AI request failed", String(error));
-      setMessages(previousMessages); // restore the response we tried to replace
-    } finally {
-      setStreaming(false);
-      setLiveSegments([]);
-    }
-  };
-
-  const needsSetup = settings
-    ? providerNeedsApiKey(provider) && !apiKeyFor(settings, provider)
-    : true;
+  const {
+    settings,
+    provider,
+    model,
+    setModel,
+    settingsOpen,
+    setSettingsOpen,
+    conversations,
+    activeId,
+    messages,
+    input,
+    setInput,
+    attachments,
+    removeAttachment,
+    attaching,
+    streaming,
+    liveSegments,
+    scrollRef,
+    needsSetup,
+    handleProviderChange,
+    handleNewChat,
+    handleSelectConversation,
+    handleDeleteConversation,
+    handleAttach,
+    handleSend,
+    handleRetry,
+    onSettingsSaved,
+  } = useAiChat();
 
   return (
     <div className="flex h-full gap-4">
@@ -487,9 +183,7 @@ function AiChat() {
                   size="sm"
                   variant="flat"
                   color="secondary"
-                  onClose={() =>
-                    setAttachments((prev) => prev.filter((a) => a.id !== attachment.id))
-                  }
+                  onClose={() => removeAttachment(attachment.id)}
                 >
                   {attachment.name}
                 </Chip>
@@ -542,10 +236,7 @@ function AiChat() {
           isOpen={settingsOpen}
           onClose={() => setSettingsOpen(false)}
           settings={settings}
-          onSaved={(saved) => {
-            setSettings(saved);
-            setModel(modelFor(saved, provider));
-          }}
+          onSaved={onSettingsSaved}
         />
       )}
     </div>

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,29 +1,7 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
 import { Button, Card, Chip, Select, SelectItem } from "@heroui/react";
 import { Icon } from "@iconify/react";
-import {
-  listPortfolios,
-  getPortfolioAnalytics,
-  getFunderDeals,
-  computeKpis,
-  aggregateMonthlyByVintage,
-  buildAllocationsByMonth,
-  normalizeStacked,
-  latestMonthAllocation,
-  currentAllocation,
-  buildCommissionsByMonth,
-  buildRtrSeries,
-  buildVintagePerformance,
-  formatMoney,
-  formatPct,
-  type PortfolioOption,
-  type PortfolioSelection,
-  type PortfolioAnalytics,
-  type MonthlyStatsRow,
-  type FunderDealRow,
-} from "@services/analytics-service";
 import {
   KpiCard,
   AllocationsByMonthCard,
@@ -34,228 +12,35 @@ import {
   TermVsFactorCard,
 } from "@components/dashboard/charts";
 import FunderDealsTable from "@components/dashboard/funder-deals-table";
+import { useDashboardAnalytics } from "@/hooks/use-dashboard-analytics";
 
 const ALL_PORTFOLIOS_KEY = "all";
 
 function Dashboard() {
-  const [portfolios, setPortfolios] = useState<PortfolioOption[]>([]);
-  const [selection, setSelection] = useState<PortfolioSelection | null>(null);
-  const [analytics, setAnalytics] = useState<PortfolioAnalytics | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  // Funder drill-down (set by clicking a funder in a legend / pie / bar)
-  const [funderId, setFunderId] = useState<number | null>(null);
-  const [deals, setDeals] = useState<FunderDealRow[]>([]);
-  const [dealsLoading, setDealsLoading] = useState(false);
-  const [dealsError, setDealsError] = useState<string | null>(null);
-
-  useEffect(() => {
-    listPortfolios()
-      .then((list) => {
-        setPortfolios(list);
-        setSelection((current) => current ?? (list.length > 0 ? "all" : null));
-        if (list.length === 0) {
-          setLoading(false);
-          setError("No portfolios are shared with your account.");
-        }
-      })
-      .catch((err) => {
-        setLoading(false);
-        setError(err instanceof Error ? err.message : "Failed to load portfolios");
-      });
-  }, []);
-
-  useEffect(() => {
-    if (selection == null) return;
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    getPortfolioAnalytics(selection)
-      .then((data) => {
-        if (!cancelled) setAnalytics(data);
-      })
-      .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load analytics");
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [selection]);
-
-  useEffect(() => {
-    if (funderId == null || selection == null) {
-      setDeals([]);
-      setDealsError(null);
-      return;
-    }
-    let cancelled = false;
-    setDealsLoading(true);
-    setDealsError(null);
-    getFunderDeals(selection, funderId)
-      .then((rows) => {
-        if (!cancelled) setDeals(rows);
-      })
-      .catch((err) => {
-        if (!cancelled) setDealsError(err instanceof Error ? err.message : "Failed to load deals");
-      })
-      .finally(() => {
-        if (!cancelled) setDealsLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [funderId, selection]);
-
-  const funderIdsByName = useMemo(
-    () =>
-      new Map(Object.entries(analytics?.funderNames ?? {}).map(([id, name]) => [name, Number(id)])),
-    [analytics]
-  );
-
-  const handleFunderClick = (funderName: string) => {
-    const id = funderIdsByName.get(funderName);
-    if (id != null) setFunderId(id);
-  };
-
-  const funderName = funderId != null ? (analytics?.funderNames[funderId] ?? null) : null;
-  const scopeLabel =
-    selection === "all"
-      ? "All Portfolios"
-      : (portfolios.find((p) => p.id === selection)?.name ?? "");
-
-  // Vintage-month rows for the current scope. The combined view and the funder
-  // view can both have several source rows per month, so collapse them first.
-  const monthlyRows = useMemo<MonthlyStatsRow[]>(() => {
-    if (!analytics) return [];
-    if (funderId != null)
-      return aggregateMonthlyByVintage(analytics.vintages.filter((v) => v.funder_id === funderId));
-    if (selection === "all") return aggregateMonthlyByVintage(analytics.monthly);
-    return analytics.monthly;
-  }, [analytics, selection, funderId]);
-
-  const vintagesInScope = useMemo(() => {
-    if (!analytics) return [];
-    return funderId != null
-      ? analytics.vintages.filter((v) => v.funder_id === funderId)
-      : analytics.vintages;
-  }, [analytics, funderId]);
-
-  const rtrInScope = useMemo(() => {
-    if (!analytics) return [];
-    return funderId != null ? analytics.rtr.filter((r) => r.funder_id === funderId) : analytics.rtr;
-  }, [analytics, funderId]);
-
-  const kpis = useMemo(() => computeKpis(monthlyRows), [monthlyRows]);
-  const allocations = useMemo(
-    () => buildAllocationsByMonth(vintagesInScope, analytics?.funderNames ?? {}),
-    [vintagesInScope, analytics]
-  );
-  const allocationsPct = useMemo(() => normalizeStacked(allocations), [allocations]);
-  const latestVintage = useMemo(
-    () => latestMonthAllocation(vintagesInScope, analytics?.funderNames ?? {}),
-    [vintagesInScope, analytics]
-  );
-  const currentAlloc = useMemo(
-    () => currentAllocation(analytics?.allocations ?? [], analytics?.funderNames ?? {}),
-    [analytics]
-  );
-  const commissions = useMemo(() => buildCommissionsByMonth(monthlyRows), [monthlyRows]);
-  const rtrSeries = useMemo(
-    () => buildRtrSeries(rtrInScope, analytics?.funderNames ?? {}),
-    [rtrInScope, analytics]
-  );
-  const performance = useMemo(() => buildVintagePerformance(monthlyRows), [monthlyRows]);
-
-  // Snapshot cards for the funder drill-down, from funder_allocation_current.
-  // In the "all" scope a funder has one row per portfolio, so sum / re-weight.
-  const funderSnapshot = useMemo(() => {
-    if (funderId == null || !analytics) return null;
-    const rows = analytics.allocations.filter((a) => a.funder_id === funderId);
-    const initial = rows.reduce((acc, r) => acc + (r.initial_cost_basis ?? 0), 0);
-    const current = rows.reduce((acc, r) => acc + (r.current_cost_basis ?? 0), 0);
-    const received = rows.reduce((acc, r) => acc + (r.rtr_received ?? 0), 0);
-    const totalCurrent = analytics.allocations.reduce(
-      (acc, r) => acc + Math.max(r.current_cost_basis ?? 0, 0),
-      0
-    );
-    return {
-      initial,
-      current,
-      received,
-      share: totalCurrent > 0 ? Math.max(current, 0) / totalCurrent : 0,
-    };
-  }, [analytics, funderId]);
-
-  const hasData = monthlyRows.length > 0;
-
-  const kpiCards = [
-    {
-      title: "Dollars at Work",
-      value: formatMoney(kpis.dollarsAtWork),
-      subtitle: `${kpis.dealCount.toLocaleString()} deals`,
-      icon: "solar:dollar-bold",
-    },
-    {
-      title: "Cost Basis",
-      value: formatMoney(kpis.costBasis),
-      subtitle: "participation + commissions",
-      icon: "solar:wallet-money-bold",
-    },
-    {
-      title: "Net RTR Outstanding",
-      value: formatMoney(kpis.netRtrOutstanding),
-      subtitle: "after bad debt",
-      icon: "solar:hourglass-bold",
-    },
-    {
-      title: "Principal / Profit Returned",
-      value: `${formatMoney(kpis.principalReturned)} / ${formatMoney(kpis.profitReturned)}`,
-      subtitle: `${formatMoney(kpis.principalReturned + kpis.profitReturned)} total received`,
-      icon: "solar:round-transfer-diagonal-bold",
-    },
-    {
-      title: "Lifetime Return",
-      value: formatPct(kpis.lifetimeReturn),
-      subtitle: "RTR received / cost basis − 1",
-      icon: "solar:chart-2-bold",
-      tone: kpis.lifetimeReturn >= 0 ? ("success" as const) : ("danger" as const),
-    },
-    {
-      title: "Bad Debt",
-      value: formatPct(kpis.badDebtPct),
-      subtitle: "of initial net RTR",
-      icon: "solar:danger-triangle-bold",
-      tone: kpis.badDebtPct > 0.05 ? ("danger" as const) : ("success" as const),
-    },
-    ...(funderSnapshot
-      ? [
-          {
-            title: "Current Cost Basis",
-            value: formatMoney(funderSnapshot.current),
-            subtitle: `of ${formatMoney(funderSnapshot.initial)} initial`,
-            icon: "solar:money-bag-bold",
-          },
-          {
-            title: "RTR Received (snapshot)",
-            value: formatMoney(funderSnapshot.received),
-            subtitle: "current allocation view",
-            icon: "solar:round-double-alt-arrow-down-bold",
-          },
-          {
-            title: "Share of Current Allocation",
-            value: formatPct(funderSnapshot.share),
-            subtitle: `within ${scopeLabel.toLowerCase()}`,
-            icon: "solar:pie-chart-2-bold",
-          },
-        ]
-      : []),
-  ];
-
-  const onFunderClick = funderId == null ? handleFunderClick : undefined;
+  const {
+    portfolios,
+    selection,
+    setSelection,
+    funderId,
+    setFunderId,
+    funderName,
+    scopeLabel,
+    loading,
+    error,
+    hasData,
+    kpiCards,
+    allocations,
+    allocationsPct,
+    latestVintage,
+    currentAlloc,
+    commissions,
+    rtrSeries,
+    performance,
+    deals,
+    dealsLoading,
+    dealsError,
+    onFunderClick,
+  } = useDashboardAnalytics();
 
   return (
     <div className="p-6">

--- a/src/pages/deal-lookup.tsx
+++ b/src/pages/deal-lookup.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,
   Card,
@@ -16,343 +15,155 @@ import {
   Tabs,
 } from "@heroui/react";
 import { Icon } from "@iconify/react";
-import { useToast } from "@/contexts/toast-context-value";
 import { formatMoney } from "@services/analytics-service";
-import {
-  applyFilters,
-  getDealRecords,
-  pivotToCsv,
-  recordsToCsv,
-  saveCsvFile,
-  DEFAULT_CHART_CONFIG,
-  DEFAULT_PIVOT_CONFIG,
-  DEFAULT_VISIBLE_FIELDS,
-  EMPTY_FILTERS,
-  type ChartConfig,
-  type DealRecord,
-  type ExplorerFilters,
-  type PivotConfig,
-  type PivotData,
-} from "@services/deal-explorer-service";
-import {
-  deleteDeal,
-  getDealFormValues,
-  getEditorLookups,
-  EMPTY_DEAL_FORM,
-  type DealFormValues,
-  type EditorLookups,
-} from "@services/deal-editor-service";
-import PivotSyncService, { type UnresolvedPivotRow } from "@services/pivot-sync-service";
-import FilterPanel, { type FilterOptions } from "@components/deal-explorer/filter-panel";
+import { type DealRecord } from "@services/deal-explorer-service";
+import FilterPanel from "@components/deal-explorer/filter-panel";
 import ExplorerTable from "@components/deal-explorer/explorer-table";
 import PivotBuilder from "@components/deal-explorer/pivot-builder";
 import ChartBuilder from "@components/deal-explorer/chart-builder";
 import DealFormModal from "@components/deal-explorer/deal-form-modal";
 import ReconcilePanel from "@components/deal-explorer/reconcile-panel";
+import { useDealLookup } from "@/hooks/use-deal-lookup";
 
-const EMPTY_LOOKUPS: EditorLookups = {
-  portfolios: [],
-  funders: [],
-  industries: [],
-  states: [],
-  merchants: [],
-};
-
-// Versioned so a future change to the SavedView shape can bump the suffix and
-// ignore incompatible saved data instead of crashing on parse.
-const VIEWS_STORAGE_KEY = "excelerate.deal-lookup.views:v1";
-
-interface SavedView {
-  id: string;
-  name: string;
-  filters: ExplorerFilters;
-  visibleFields: string[];
-  pivot: PivotConfig;
-  chart: ChartConfig;
+interface DeleteDealModalProps {
+  deal: DealRecord | null;
+  busy: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
 }
 
-function loadSavedViews(): SavedView[] {
-  try {
-    const raw = localStorage.getItem(VIEWS_STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as SavedView[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-const today = () => new Date().toISOString().slice(0, 10);
-
-const uniqueSorted = (values: (string | null)[]): string[] =>
-  [...new Set(values.filter((v): v is string => v != null && v !== ""))].sort();
-
-// react-doctor-disable-next-line react-doctor/prefer-useReducer -- these hold largely independent concerns (records, load status, filters, visible fields, pivot/chart config, saved views) that change at different times, so a single reducer would not improve consistency
-function DealLookup() {
-  const { showToast } = useToast();
-  const [records, setRecords] = useState<DealRecord[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const [filters, setFilters] = useState<ExplorerFilters>(EMPTY_FILTERS);
-  const [visibleFields, setVisibleFields] = useState<string[]>(DEFAULT_VISIBLE_FIELDS);
-  const [pivotConfig, setPivotConfig] = useState<PivotConfig>(DEFAULT_PIVOT_CONFIG);
-  const [chartConfig, setChartConfig] = useState<ChartConfig>(DEFAULT_CHART_CONFIG);
-
-  const [savedViews, setSavedViews] = useState<SavedView[]>(loadSavedViews);
-  const [activeViewId, setActiveViewId] = useState<string | null>(null);
-  const [viewName, setViewName] = useState("");
-  const [saveModalOpen, setSaveModalOpen] = useState(false);
-  const [exporting, setExporting] = useState(false);
-
-  // Deal CRUD
-  const [lookups, setLookups] = useState<EditorLookups>(EMPTY_LOOKUPS);
-  const [formOpen, setFormOpen] = useState(false);
-  const [editing, setEditing] = useState<{ dealId: string; values: DealFormValues } | null>(null);
-  const [createDefaults, setCreateDefaults] = useState<DealFormValues | null>(null);
-  const [deleting, setDeleting] = useState<DealRecord | null>(null);
-  const [deleteBusy, setDeleteBusy] = useState(false);
-
-  // Unmatched pivot-row reconciliation
-  const [unresolvedRows, setUnresolvedRows] = useState<UnresolvedPivotRow[]>([]);
-  const [unresolvedLoading, setUnresolvedLoading] = useState(true);
-  const [busyRowId, setBusyRowId] = useState<string | null>(null);
-  /**
-   * When set, the next saved deal also resolves this pivot row. A ref, not
-   * state: it is only ever read inside handlers, never rendered.
-   */
-  const pendingResolveRowIdRef = useRef<string | null>(null);
-
-  const fetchLookups = useCallback(() => {
-    getEditorLookups()
-      .then(setLookups)
-      .catch((err) =>
-        showToast({
-          title: "Failed to load deal form lookups",
-          description: err instanceof Error ? err.message : String(err),
-          type: "error",
-        })
-      );
-  }, [showToast]);
-
-  const fetchRecords = useCallback(() => {
-    setLoading(true);
-    setError(null);
-    getDealRecords()
-      .then(setRecords)
-      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load deals"))
-      .finally(() => setLoading(false));
-  }, []);
-
-  const fetchUnresolved = useCallback(() => {
-    setUnresolvedLoading(true);
-    PivotSyncService.listUnresolvedRows()
-      .then(setUnresolvedRows)
-      .catch((err) =>
-        showToast({
-          title: "Failed to load unmatched pivot rows",
-          description: err instanceof Error ? err.message : String(err),
-          type: "error",
-        })
-      )
-      .finally(() => setUnresolvedLoading(false));
-  }, [showToast]);
-
-  useEffect(fetchRecords, [fetchRecords]);
-  useEffect(fetchLookups, [fetchLookups]);
-  useEffect(fetchUnresolved, [fetchUnresolved]);
-
-  const openCreate = () => {
-    setEditing(null);
-    setCreateDefaults(null);
-    pendingResolveRowIdRef.current = null;
-    setFormOpen(true);
-  };
-
-  const openEdit = async (record: DealRecord) => {
-    try {
-      const values = await getDealFormValues(record.id);
-      setEditing({ dealId: record.id, values });
-      setCreateDefaults(null);
-      pendingResolveRowIdRef.current = null;
-      setFormOpen(true);
-    } catch (err) {
-      showToast({
-        title: "Failed to load deal",
-        description: err instanceof Error ? err.message : String(err),
-        type: "error",
-      });
-    }
-  };
-
-  const resolveRow = async (row: UnresolvedPivotRow, dealId: string) => {
-    setBusyRowId(row.row_id);
-    try {
-      await PivotSyncService.resolveRow(row.row_id, dealId);
-      showToast({
-        title: "Pivot row resolved",
-        description: `${row.merchant_name} — payment written for ${row.report_date}`,
-        type: "success",
-      });
-      fetchRecords();
-      fetchUnresolved();
-    } catch (err) {
-      showToast({
-        title: "Failed to resolve pivot row",
-        description: err instanceof Error ? err.message : String(err),
-        type: "error",
-      });
-    } finally {
-      setBusyRowId(null);
-    }
-  };
-
-  /** "New deal" from an unmatched row: prefill the form, resolve after save. */
-  const createDealFromRow = (row: UnresolvedPivotRow) => {
-    setEditing(null);
-    setCreateDefaults({
-      ...EMPTY_DEAL_FORM,
-      portfolioId: row.portfolio_id,
-      funderId: row.funder_id,
-      merchantName: row.merchant_name,
-      funderAdvanceId: row.advance_id ?? "",
-      dateFunded: row.report_date,
-    });
-    pendingResolveRowIdRef.current = row.row_id;
-    setFormOpen(true);
-  };
-
-  const handleSaved = async (dealId: string) => {
-    showToast({ title: editing != null ? "Deal updated" : "Deal created", type: "success" });
-    const pendingRowId = pendingResolveRowIdRef.current;
-    if (pendingRowId != null) {
-      const row = unresolvedRows.find((r) => r.row_id === pendingRowId);
-      pendingResolveRowIdRef.current = null;
-      if (row != null) {
-        await resolveRow(row, dealId);
-        fetchLookups();
-        return; // resolveRow already refetched records
-      }
-    }
-    fetchRecords();
-    fetchLookups(); // a save may have added or renamed a merchant
-  };
-
-  const confirmDelete = async () => {
-    if (deleting == null) return;
-    setDeleteBusy(true);
-    try {
-      await deleteDeal(deleting.id);
-      showToast({
-        title: "Deal deleted",
-        description: deleting.merchant_name ?? deleting.funder_advance_id ?? deleting.id,
-        type: "success",
-      });
-      setDeleting(null);
-      fetchRecords();
-    } catch (err) {
-      showToast({
-        title: "Delete failed",
-        description: err instanceof Error ? err.message : String(err),
-        type: "error",
-      });
-    } finally {
-      setDeleteBusy(false);
-    }
-  };
-
-  const options = useMemo<FilterOptions>(
-    () => ({
-      portfolios: uniqueSorted(records.map((r) => r.portfolio_name)),
-      funders: uniqueSorted(records.map((r) => r.funder_name)),
-      industries: uniqueSorted(records.map((r) => r.industry)),
-      states: uniqueSorted(records.map((r) => r.state)),
-      months: uniqueSorted(records.map((r) => r.vintage_month?.slice(0, 7) ?? null)),
-    }),
-    [records]
+// Confirmation dialog for deleting a deal (and its recorded payments).
+function DeleteDealModal({ deal, busy, onClose, onConfirm }: DeleteDealModalProps) {
+  return (
+    <Modal isOpen={deal != null} onOpenChange={(open) => !open && onClose()} size="sm">
+      <ModalContent>
+        <ModalHeader>Delete deal</ModalHeader>
+        <ModalBody>
+          <p className="text-small">
+            Delete the deal for{" "}
+            <span className="font-semibold">{deal?.merchant_name ?? "this merchant"}</span>
+            {deal?.funder_advance_id != null && (
+              <span className="text-default-500"> ({deal.funder_advance_id})</span>
+            )}
+            ?
+          </p>
+          {deal != null && deal.total_net_received > 0 && (
+            <p className="text-small text-danger">
+              {formatMoney(deal.total_net_received)} of recorded payments will be deleted with it.
+            </p>
+          )}
+          <p className="text-tiny text-default-400">This cannot be undone.</p>
+        </ModalBody>
+        <ModalFooter>
+          <Button size="sm" variant="light" onPress={onClose} isDisabled={busy}>
+            Cancel
+          </Button>
+          <Button size="sm" color="danger" isLoading={busy} onPress={onConfirm}>
+            Delete
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
   );
+}
 
-  const filtered = useMemo(() => applyFilters(records, filters), [records, filters]);
+interface SaveViewModalProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  viewName: string;
+  onViewNameChange: (value: string) => void;
+  onSave: () => void;
+}
 
-  const summary = useMemo(() => {
-    const sum = (pick: (r: DealRecord) => number | null) =>
-      filtered.reduce((acc, r) => acc + (pick(r) ?? 0), 0);
-    return {
-      funded: sum((r) => r.total_amount_funded),
-      costBasis: sum((r) => r.cost_basis),
-      netReceived: sum((r) => r.total_net_received),
-      balance: sum((r) => r.net_rtr_balance),
-    };
-  }, [filtered]);
+// Names and saves the current filters/columns/pivot/chart as a reusable view.
+function SaveViewModal({
+  isOpen,
+  onOpenChange,
+  viewName,
+  onViewNameChange,
+  onSave,
+}: SaveViewModalProps) {
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange} size="sm">
+      <ModalContent>
+        <ModalHeader>Save current view</ModalHeader>
+        <ModalBody>
+          <p className="text-small text-default-500">
+            Saves the filters, visible columns, pivot, and chart setup so you can reapply them
+            later.
+          </p>
+          <Input
+            aria-label="View name"
+            autoFocus
+            label="View name"
+            size="sm"
+            value={viewName}
+            onValueChange={onViewNameChange}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onSave();
+            }}
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Button size="sm" variant="light" onPress={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button size="sm" color="primary" isDisabled={!viewName.trim()} onPress={onSave}>
+            Save
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
 
-  const persistViews = (views: SavedView[]) => {
-    setSavedViews(views);
-    localStorage.setItem(VIEWS_STORAGE_KEY, JSON.stringify(views));
-  };
-
-  const saveCurrentView = () => {
-    const name = viewName.trim();
-    if (!name) return;
-    const view: SavedView = {
-      id: `view-${Date.now()}`,
-      name,
-      filters,
-      visibleFields,
-      pivot: pivotConfig,
-      chart: chartConfig,
-    };
-    persistViews([...savedViews, view]);
-    setActiveViewId(view.id);
-    setViewName("");
-    setSaveModalOpen(false);
-    showToast({ title: `View "${name}" saved`, type: "success" });
-  };
-
-  const applyView = (view: SavedView) => {
-    // Merge over defaults so views saved before new filters/configs still load.
-    setFilters({ ...EMPTY_FILTERS, ...view.filters });
-    setVisibleFields(view.visibleFields.length > 0 ? view.visibleFields : DEFAULT_VISIBLE_FIELDS);
-    setPivotConfig({ ...DEFAULT_PIVOT_CONFIG, ...view.pivot });
-    setChartConfig({ ...DEFAULT_CHART_CONFIG, ...view.chart });
-    setActiveViewId(view.id);
-  };
-
-  const deleteActiveView = () => {
-    if (activeViewId == null) return;
-    const view = savedViews.find((v) => v.id === activeViewId);
-    persistViews(savedViews.filter((v) => v.id !== activeViewId));
-    setActiveViewId(null);
-    if (view) showToast({ title: `View "${view.name}" deleted`, type: "info" });
-  };
-
-  const exportCsv = async (defaultName: string, csv: string) => {
-    setExporting(true);
-    try {
-      const path = await saveCsvFile(defaultName, csv);
-      if (path != null) {
-        showToast({ title: "Export complete", description: path, type: "success" });
-      }
-    } catch (err) {
-      showToast({
-        title: "Export failed",
-        description: err instanceof Error ? err.message : String(err),
-        type: "error",
-      });
-    } finally {
-      setExporting(false);
-    }
-  };
-
-  const exportTable = () =>
-    exportCsv(`deals-${today()}.csv`, recordsToCsv(filtered, visibleFields));
-  const exportPivot = (pivot: PivotData) =>
-    exportCsv(`deal-pivot-${today()}.csv`, pivotToCsv(pivot));
-
-  const summaryCards = [
-    { label: "Deals", value: filtered.length.toLocaleString() },
-    { label: "Amount Funded", value: formatMoney(summary.funded) },
-    { label: "Cost Basis", value: formatMoney(summary.costBasis) },
-    { label: "Net Received", value: formatMoney(summary.netReceived) },
-    { label: "Net RTR Balance", value: formatMoney(summary.balance) },
-  ];
+function DealLookup() {
+  const {
+    records,
+    loading,
+    error,
+    filters,
+    setFilters,
+    visibleFields,
+    setVisibleFields,
+    pivotConfig,
+    setPivotConfig,
+    chartConfig,
+    setChartConfig,
+    savedViews,
+    activeViewId,
+    viewName,
+    setViewName,
+    saveModalOpen,
+    setSaveModalOpen,
+    exporting,
+    lookups,
+    formOpen,
+    setFormOpen,
+    editing,
+    createDefaults,
+    deleting,
+    setDeleting,
+    deleteBusy,
+    unresolvedRows,
+    unresolvedLoading,
+    busyRowId,
+    options,
+    filtered,
+    summaryCards,
+    fetchRecords,
+    openCreate,
+    openEdit,
+    resolveRow,
+    createDealFromRow,
+    handleSaved,
+    confirmDelete,
+    saveCurrentView,
+    applyView,
+    deleteActiveView,
+    exportTable,
+    exportPivot,
+  } = useDealLookup();
 
   return (
     <div className="p-6">
@@ -538,81 +349,20 @@ function DealLookup() {
         onSaved={handleSaved}
       />
 
-      <Modal
-        isOpen={deleting != null}
-        onOpenChange={(open) => !open && setDeleting(null)}
-        size="sm"
-      >
-        <ModalContent>
-          <ModalHeader>Delete deal</ModalHeader>
-          <ModalBody>
-            <p className="text-small">
-              Delete the deal for{" "}
-              <span className="font-semibold">{deleting?.merchant_name ?? "this merchant"}</span>
-              {deleting?.funder_advance_id != null && (
-                <span className="text-default-500"> ({deleting.funder_advance_id})</span>
-              )}
-              ?
-            </p>
-            {deleting != null && deleting.total_net_received > 0 && (
-              <p className="text-small text-danger">
-                {formatMoney(deleting.total_net_received)} of recorded payments will be deleted with
-                it.
-              </p>
-            )}
-            <p className="text-tiny text-default-400">This cannot be undone.</p>
-          </ModalBody>
-          <ModalFooter>
-            <Button
-              size="sm"
-              variant="light"
-              onPress={() => setDeleting(null)}
-              isDisabled={deleteBusy}
-            >
-              Cancel
-            </Button>
-            <Button size="sm" color="danger" isLoading={deleteBusy} onPress={confirmDelete}>
-              Delete
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+      <DeleteDealModal
+        deal={deleting}
+        busy={deleteBusy}
+        onClose={() => setDeleting(null)}
+        onConfirm={confirmDelete}
+      />
 
-      <Modal isOpen={saveModalOpen} onOpenChange={setSaveModalOpen} size="sm">
-        <ModalContent>
-          <ModalHeader>Save current view</ModalHeader>
-          <ModalBody>
-            <p className="text-small text-default-500">
-              Saves the filters, visible columns, pivot, and chart setup so you can reapply them
-              later.
-            </p>
-            <Input
-              aria-label="View name"
-              autoFocus
-              label="View name"
-              size="sm"
-              value={viewName}
-              onValueChange={setViewName}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") saveCurrentView();
-              }}
-            />
-          </ModalBody>
-          <ModalFooter>
-            <Button size="sm" variant="light" onPress={() => setSaveModalOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              size="sm"
-              color="primary"
-              isDisabled={!viewName.trim()}
-              onPress={saveCurrentView}
-            >
-              Save
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+      <SaveViewModal
+        isOpen={saveModalOpen}
+        onOpenChange={setSaveModalOpen}
+        viewName={viewName}
+        onViewNameChange={setViewName}
+        onSave={saveCurrentView}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Resolves #42.

Follow-up from #32: the deferred `no-giant-component` findings. The rule fires on **component function length** (>300 lines), so each fix pulls stateful logic into a `use-*` hook and/or large render sections into sub-components until the parent function drops under the threshold.

## Changes
| File | Extraction |
|---|---|
| `file-upload.tsx` | `useFileUpload` hook (Tauri drop + validation); `FileDropZone` + `SelectedFileCard` local components |
| `workbook-import-wizard.tsx` | `ImportPreviewBody` + `ImportSummaryBody` local components (the two large wizard steps) |
| `dashboard.tsx` | `useDashboardAnalytics` hook (data fetching + memoized series/KPIs); page is now pure render |
| `ai-chat.tsx` | `useAiChat` hook; `prefer-useReducer` disable moved onto the hook; added `removeAttachment`/`onSettingsSaved` helpers |
| `deal-lookup.tsx` | `useDealLookup` hook; `prefer-useReducer` disable moved onto the hook; `DeleteDealModal` + `SaveViewModal` local components |

New hooks live in `src/hooks/` (matching the existing `use-cloud-sync` / `use-file-error-state` convention).

## Verification
- `npm run lint`, `npm run format:check`, `npm run build` all pass.
- react-doctor: all 5 `no-giant-component` findings cleared (warnings 8 → 3); **no new findings** introduced (remaining items — RLS policy, BaaS artifact, `prefer-dynamic-import` — are pre-existing/unrelated).
- Changes are a behavior-preserving lift-and-shift; controlled/uncontrolled `file-upload` semantics unchanged.

## Not done here
Manual smoke-testing needs the running Tauri app. Before merge, click through the affected screens: file upload, workbook import wizard, dashboard funder drill-down, AI chat streaming, and deal-lookup filters/save-view/delete modals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)