### PR TITLE
fix(deps): bump @internationalized/date to 3.12.0 to match HeroUI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@heroui/react": "^2.8.4",
-        "@internationalized/date": "3.9.0",
+        "@internationalized/date": "3.12.0",
         "@supabase/supabase-js": "^2.89.0",
         "@tauri-apps/api": "~2.8.0",
         "@tauri-apps/plugin-dialog": "~2.4.0",
@@ -3243,9 +3243,9 @@
       "license": "MIT"
     },
     "node_modules/@internationalized/date": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.9.0.tgz",
-      "integrity": "sha512-yaN3brAnHRD+4KyyOsJyk49XUvj2wtbNACSqg0bz3u8t2VuzhC8Q5dfRnrSxjnnbDb+ienBnkn1TzQfE154vyg==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
+      "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@heroui/react": "^2.8.4",
-    "@internationalized/date": "3.9.0",
+    "@internationalized/date": "3.12.0",
     "@supabase/supabase-js": "^2.89.0",
     "@tauri-apps/api": "~2.8.0",
     "@tauri-apps/plugin-dialog": "~2.4.0",
@@ -43,7 +43,7 @@
     "remark-gfm": "^4.0.1"
   },
   "overrides": {
-    "@internationalized/date": "3.9.0"
+    "@internationalized/date": "3.12.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",


### PR DESCRIPTION
## Problem

Opening any portfolio page (e.g. Alder) went **completely black with no usable UI**. Console:

```
TypeError: this.calendar.getMaximumMonthsInYear is not a function
  getSegmentLimits → useDateInput → DateInput2 → DatePicker2
  → MonthlyDatePicker → BasePortfolio → AlderPortfolio
```

HeroUI 2.8.4's date packages (`@heroui/calendar`, `@heroui/date-picker`, `@heroui/date-input`) depend on `@internationalized/date` **3.12.0** and call `getMaximumMonthsInYear()`. But an `overrides` block force-pinned the entire dependency tree to **3.9.0**, whose `Calendar` prototype doesn't have that method. So `MonthlyDatePicker` threw on mount, and — since the app has no error boundary (tracked in #44) — the whole tree unmounted.

## Fix

Bump both the direct dependency and the `overrides` entry to `3.12.0`, so a single deduped copy with `getMaximumMonthsInYear()` is installed.

```
-    "@internationalized/date": "3.9.0",
+    "@internationalized/date": "3.12.0",
   "overrides": {
-    "@internationalized/date": "3.9.0"
+    "@internationalized/date": "3.12.0"
```

App-side usage (`CalendarDate`, `today`, `getLocalTimeZone`, `.subtract()`) is unchanged across 3.9 → 3.12.

## Verification

- `find node_modules -path '*@internationalized*' -name date` → single copy, `3.12.0`.
- `c.calendar.getMaximumMonthsInYear()` → `12` (was `undefined`).
- `npm run build` passes.
- Reviewer: after checkout, run `npm install` and **fully restart** `npm run tauri dev` (Vite caches optimized deps) — portfolio pages should load.

## Notes

- Independent of #42 / #43 (giant-component refactor); this reproduces on `main`.
- Follow-up #44 tracks adding a React error boundary so a single component crash can't blank the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)