### PR TITLE
feat: add React error boundary so one crash doesn't blank the app

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -11,6 +11,7 @@ import Login from "@pages/login";
 import { ProtectedRoute } from "@components/auth/protected-route";
 import { useAuth } from "@/contexts/auth-context-value";
 import { backendNotifications } from "@services/notification-service";
+import ErrorBoundary from "@components/error-boundary";
 
 function App() {
   const { user } = useAuth();
@@ -25,28 +26,30 @@ function App() {
   }, []);
 
   return (
-    <Routes>
-      {/* Public routes */}
-      <Route path="/login" element={!user ? <Login /> : <Navigate to="/dashboard" replace />} />
+    <ErrorBoundary title="The app ran into a problem">
+      <Routes>
+        {/* Public routes */}
+        <Route path="/login" element={!user ? <Login /> : <Navigate to="/dashboard" replace />} />
 
-      {/* Protected routes */}
-      <Route
-        path="/"
-        element={
-          <ProtectedRoute>
-            <Layout />
-          </ProtectedRoute>
-        }
-      >
-        <Route index element={<Navigate to="/dashboard" replace />} />
-        <Route path="dashboard" element={<Dashboard />} />
-        <Route path="alder-portfolio" element={<AlderPortfolio />} />
-        <Route path="white-rabbit-portfolio" element={<WhiteRabbitPortfolio />} />
-        <Route path="deal-lookup" element={<DealLookup />} />
-        <Route path="ai-chat" element={<AiChat />} />
-        <Route path="settings" element={<Settings />} />
-      </Route>
-    </Routes>
+        {/* Protected routes */}
+        <Route
+          path="/"
+          element={
+            <ProtectedRoute>
+              <Layout />
+            </ProtectedRoute>
+          }
+        >
+          <Route index element={<Navigate to="/dashboard" replace />} />
+          <Route path="dashboard" element={<Dashboard />} />
+          <Route path="alder-portfolio" element={<AlderPortfolio />} />
+          <Route path="white-rabbit-portfolio" element={<WhiteRabbitPortfolio />} />
+          <Route path="deal-lookup" element={<DealLookup />} />
+          <Route path="ai-chat" element={<AiChat />} />
+          <Route path="settings" element={<Settings />} />
+        </Route>
+      </Routes>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,0 +1,91 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+import { Card, CardBody, Button } from "@heroui/react";
+import { Icon } from "@iconify/react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** When this value changes, the boundary clears its error and re-renders children. */
+  resetKey?: string;
+  /** Heading shown in the fallback UI. */
+  title?: string;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Catches runtime errors thrown while rendering its subtree and shows a
+ * fallback UI instead of unmounting the whole React tree (which would leave a
+ * blank screen). Pass a `resetKey` (e.g. the route path) to recover
+ * automatically when the user navigates elsewhere.
+ */
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught an error:", error, info.componentStack);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    if (this.state.error && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  handleTryAgain = () => {
+    this.setState({ error: null });
+  };
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    const { error } = this.state;
+
+    if (!error) {
+      return this.props.children;
+    }
+
+    const { title = "Something went wrong" } = this.props;
+
+    return (
+      <div className="flex h-full w-full items-center justify-center p-6">
+        <Card className="max-w-lg border-1 border-danger-200 bg-danger-50 shadow-lg">
+          <CardBody className="p-6">
+            <div className="flex items-start gap-3">
+              <Icon
+                icon="heroicons:exclamation-triangle-20-solid"
+                className="mt-0.5 h-6 w-6 flex-shrink-0 text-danger-500"
+              />
+              <div className="flex-1 min-w-0">
+                <p className="text-base font-semibold text-danger-900">{title}</p>
+                <p className="mt-1 text-sm text-danger-900/90">
+                  This part of the app hit an unexpected error. You can try again or reload the app.
+                </p>
+                <pre className="mt-3 max-h-40 overflow-auto rounded-medium bg-danger-100 p-3 text-xs text-danger-900">
+                  {error.message}
+                </pre>
+                <div className="mt-4 flex gap-2">
+                  <Button color="danger" variant="flat" size="sm" onPress={this.handleTryAgain}>
+                    Try again
+                  </Button>
+                  <Button color="danger" variant="solid" size="sm" onPress={this.handleReload}>
+                    Reload app
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </CardBody>
+        </Card>
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -3,6 +3,7 @@ import { ScrollShadow, Button, Listbox, ListboxItem, Tooltip } from "@heroui/rea
 import Sidebar from "@features/sidebar/sidebar";
 import { items, settingsItem } from "@features/sidebar/sidebar-items";
 import { UserMenu } from "@components/auth/user-menu";
+import ErrorBoundary from "@components/error-boundary";
 import { useEffect, useState, useRef } from "react";
 import { Icon } from "@iconify/react";
 import { useTheme } from "@/contexts/theme-context-value";
@@ -191,7 +192,9 @@ function Layout() {
         </div>
       </div>
       <div className="flex-1 overflow-auto p-4">
-        <Outlet />
+        <ErrorBoundary resetKey={location.pathname}>
+          <Outlet />
+        </ErrorBoundary>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds a reusable React error boundary so a runtime throw in a single component degrades gracefully instead of unmounting the entire tree (which left a black screen). Closes #44.

## Changes

- **`src/components/error-boundary.tsx`** — new reusable `ErrorBoundary` class component: `getDerivedStateFromError` for the fallback, `componentDidCatch` logging to the console (including component stack), and a `resetKey` prop that clears the error when it changes. Fallback UI (styled to match the existing toast/HeroUI look) shows the error message with **Try again** and **Reload app** actions.
- **`src/layout.tsx`** — wraps `<Outlet />` in an `ErrorBoundary` keyed by `location.pathname`, so a page crash keeps the sidebar/nav shell usable and navigating to another page auto-recovers.
- **`src/app.tsx`** — top-level `ErrorBoundary` around `<Routes>` as a last resort.

## Acceptance criteria

- ✅ A thrown error in a page component renders a fallback UI instead of a black screen.
- ✅ The surrounding app shell (navigation) remains usable when a single page crashes.
- ✅ The error is logged to the console, and reload works.

## Testing

- `npm run lint && npm run format:check && npm run build` all pass. No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)