### PR TITLE
fix: keep deal table pagination fixed outside horizontal scroll

### DIFF
--- a/src/components/deal-explorer/explorer-table.tsx
+++ b/src/components/deal-explorer/explorer-table.tsx
@@ -154,19 +154,6 @@ const ExplorerTable = ({
             setSort(descriptor);
             setPage(1);
           }}
-          bottomContent={
-            pages > 1 ? (
-              <div className="flex justify-center">
-                <Pagination
-                  size="sm"
-                  showControls
-                  page={currentPage}
-                  total={pages}
-                  onChange={setPage}
-                />
-              </div>
-            ) : null
-          }
         >
           <TableHeader columns={columns}>
             {(column) => (
@@ -232,6 +219,12 @@ const ExplorerTable = ({
           </TableBody>
         </Table>
       </div>
+
+      {pages > 1 && (
+        <div className="flex justify-center p-4 pt-2">
+          <Pagination size="sm" showControls page={currentPage} total={pages} onChange={setPage} />
+        </div>
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
## Problem

On the Deal Lookup page, the table's page selector (`Pagination`) was passed as the `Table`'s `bottomContent`, which renders **inside** the `overflow-x-auto` scroll container. When enough columns are visible to trigger the horizontal scrollbar, the page selector scrolled sideways along with the table body instead of staying put.

## Fix

Moved the `Pagination` out of the `Table`'s `bottomContent` and render it as a direct sibling of the `Card`, outside the horizontal scroll container. It now stays centered and fixed regardless of horizontal scrolling.

- No behavior change beyond positioning — the `pages > 1` visibility guard and existing `currentPage` / `setPage` state are preserved.
- `npm run lint` and `npm run format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)