### PR TITLE
feat: add Pivot Tables page to browse & export committed funder pivots

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,6 +5,7 @@ import Dashboard from "@pages/dashboard";
 import AlderPortfolio from "@pages/alder-portfolio";
 import WhiteRabbitPortfolio from "@pages/white-rabbit-portfolio";
 import DealLookup from "@pages/deal-lookup";
+import PivotTables from "@pages/pivot-tables";
 import AiChat from "@pages/ai-chat";
 import Settings from "@pages/settings";
 import Login from "@pages/login";
@@ -45,6 +46,7 @@ function App() {
           <Route path="alder-portfolio" element={<AlderPortfolio />} />
           <Route path="white-rabbit-portfolio" element={<WhiteRabbitPortfolio />} />
           <Route path="deal-lookup" element={<DealLookup />} />
+          <Route path="pivot-tables" element={<PivotTables />} />
           <Route path="ai-chat" element={<AiChat />} />
           <Route path="settings" element={<Settings />} />
         </Route>

--- a/src/features/sidebar/sidebar-items.tsx
+++ b/src/features/sidebar/sidebar-items.tsx
@@ -26,6 +26,11 @@ export const items: SidebarItem[] = [
     title: "Deal Lookup",
   },
   {
+    key: "pivot-tables",
+    icon: "solar:widget-5-outline",
+    title: "Pivot Tables",
+  },
+  {
     key: "ai-chat",
     icon: "solar:chat-round-line-duotone",
     title: "AI Chat",

--- a/src/hooks/use-pivot-tables.ts
+++ b/src/hooks/use-pivot-tables.ts
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useToast } from "@/contexts/toast-context-value";
+import { saveCsvFile } from "@services/deal-explorer-service";
+import PivotSyncService, {
+  type CommittedPivot,
+  type CommittedPivotRow,
+} from "@services/pivot-sync-service";
+
+export const PORTFOLIOS = ["Alder", "White Rabbit"] as const;
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+/** "YYYY-MM-DD" → "June". */
+export const monthName = (reportDate: string): string =>
+  MONTH_NAMES[Number(reportDate.slice(5, 7)) - 1] ?? reportDate.slice(5, 7);
+
+/** "YYYY-MM-DD" → "June 2026". */
+export const formatReportMonth = (reportDate: string): string =>
+  `${monthName(reportDate)} ${reportDate.slice(0, 4)}`;
+
+/** True when the pivot has at least one row carrying the split-fee breakdown. */
+export const hasFeeBreakdown = (rows: CommittedPivotRow[]): boolean =>
+  rows.some((r) => r.originator_fee != null || r.rb_fee != null || r.fee_discrepancy != null);
+
+const csvEscape = (value: string): string =>
+  /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+
+const csvLine = (values: (string | number | null)[]): string =>
+  values.map((v) => csvEscape(v == null ? "" : String(v))).join(",");
+
+/** Raw values so the CSV stays machine-readable; Receivabull columns only when present. */
+export const pivotRowsToCsv = (rows: CommittedPivotRow[]): string => {
+  const includeFees = hasFeeBreakdown(rows);
+  const header = ["Advance ID", "Merchant", "Gross", "Fee", "Net", "Matched"];
+  if (includeFees) header.splice(4, 0, "Originator Fee", "RB Fee", "Fee Discrepancy");
+  const lines = [csvLine(header)];
+  for (const row of rows) {
+    const values: (string | number | null)[] = [
+      row.advance_id,
+      row.merchant_name,
+      row.gross,
+      row.fee,
+    ];
+    if (includeFees) values.push(row.originator_fee, row.rb_fee, row.fee_discrepancy);
+    values.push(row.net, row.matched_deal_id != null ? "yes" : "no");
+    lines.push(csvLine(values));
+  }
+  return lines.join("\n");
+};
+
+export function usePivotTables() {
+  const { showToast } = useToast();
+
+  const [funders, setFunders] = useState<string[]>([]);
+  const [portfolio, setPortfolio] = useState<string>(PORTFOLIOS[0]);
+  const [funder, setFunder] = useState<string>("");
+
+  const [months, setMonths] = useState<string[]>([]);
+  const [monthsLoading, setMonthsLoading] = useState(false);
+  const [year, setYear] = useState<string>("");
+  const [reportDate, setReportDate] = useState<string>("");
+
+  const [pivot, setPivot] = useState<CommittedPivot | null>(null);
+  const [pivotLoading, setPivotLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  // Load the funder list once.
+  useEffect(() => {
+    PivotSyncService.listFunders()
+      .then((names) => {
+        setFunders(names);
+        setFunder((current) => current || (names[0] ?? ""));
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)));
+  }, []);
+
+  // Reload available months whenever portfolio + funder change.
+  useEffect(() => {
+    if (!portfolio || !funder) return;
+    let cancelled = false;
+    setMonthsLoading(true);
+    setError(null);
+    PivotSyncService.listPivotMonths(portfolio, funder)
+      .then((dates) => {
+        if (cancelled) return;
+        setMonths(dates);
+        setYear(dates[0]?.slice(0, 4) ?? "");
+        setReportDate(dates[0] ?? "");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setMonths([]);
+        setYear("");
+        setReportDate("");
+      })
+      .finally(() => !cancelled && setMonthsLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [portfolio, funder]);
+
+  // Load the pivot whenever the selected month changes.
+  useEffect(() => {
+    if (!portfolio || !funder || !reportDate) {
+      setPivot(null);
+      return;
+    }
+    let cancelled = false;
+    setPivotLoading(true);
+    setError(null);
+    PivotSyncService.getPivotTable(portfolio, funder, reportDate)
+      .then((data) => !cancelled && setPivot(data))
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setPivot(null);
+      })
+      .finally(() => !cancelled && setPivotLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [portfolio, funder, reportDate]);
+
+  // Years that have a committed pivot, newest first.
+  const years = useMemo(() => [...new Set(months.map((d) => d.slice(0, 4)))], [months]);
+
+  // Report dates within the selected year (the Month selector's options).
+  const monthsForYear = useMemo(() => months.filter((d) => d.slice(0, 4) === year), [months, year]);
+
+  // Selecting a year snaps the month to that year's newest available pivot.
+  const selectYear = useCallback(
+    (nextYear: string) => {
+      setYear(nextYear);
+      const first = months.find((d) => d.slice(0, 4) === nextYear);
+      if (first) setReportDate(first);
+    },
+    [months]
+  );
+
+  const showFeeBreakdown = useMemo(() => (pivot ? hasFeeBreakdown(pivot.rows) : false), [pivot]);
+
+  const exportCsv = useCallback(async () => {
+    if (!pivot || pivot.rows.length === 0) return;
+    setExporting(true);
+    try {
+      const name = `pivot-${portfolio}-${funder}-${reportDate}.csv`
+        .replace(/['\s]+/g, "-")
+        .toLowerCase();
+      const path = await saveCsvFile(name, pivotRowsToCsv(pivot.rows));
+      if (path != null) {
+        showToast({ title: "Export complete", description: path, type: "success" });
+      }
+    } catch (err) {
+      showToast({
+        title: "Export failed",
+        description: err instanceof Error ? err.message : String(err),
+        type: "error",
+      });
+    } finally {
+      setExporting(false);
+    }
+  }, [pivot, portfolio, funder, reportDate, showToast]);
+
+  return {
+    funders,
+    portfolio,
+    setPortfolio,
+    funder,
+    setFunder,
+    months,
+    monthsLoading,
+    years,
+    year,
+    selectYear,
+    monthsForYear,
+    reportDate,
+    setReportDate,
+    pivot,
+    pivotLoading,
+    showFeeBreakdown,
+    error,
+    exporting,
+    exportCsv,
+  };
+}

--- a/src/pages/alder-portfolio.tsx
+++ b/src/pages/alder-portfolio.tsx
@@ -228,26 +228,25 @@ function AlderPortfolio() {
             Uploaded Files for {selectedDate.toString()}
           </h3>
           <div className="space-y-2">
-            {monthlyFunderList
-              .filter((f) => !f.disabled)
-              .map((funder) => {
-                const uploaded = funderUploads.find(
-                  (u) => uiFunderName(u.funder_name) === funder.name
-                );
-                return (
-                  <div
-                    key={funder.name}
-                    className="flex items-center justify-between p-2 bg-default-100 rounded"
-                  >
-                    <span className="text-sm">{funder.name}</span>
-                    {uploaded ? (
-                      <span className="text-xs text-success-600">{uploaded.original_filename}</span>
-                    ) : (
-                      <span className="text-xs text-default-400">Not uploaded</span>
-                    )}
-                  </div>
-                );
-              })}
+            {monthlyFunderList.flatMap((funder) => {
+              if (funder.disabled) return [];
+              const uploaded = funderUploads.find(
+                (u) => uiFunderName(u.funder_name) === funder.name
+              );
+              return (
+                <div
+                  key={funder.name}
+                  className="flex items-center justify-between p-2 bg-default-100 rounded"
+                >
+                  <span className="text-sm">{funder.name}</span>
+                  {uploaded ? (
+                    <span className="text-xs text-success-600">{uploaded.original_filename}</span>
+                  ) : (
+                    <span className="text-xs text-default-400">Not uploaded</span>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/src/pages/pivot-tables.tsx
+++ b/src/pages/pivot-tables.tsx
@@ -1,0 +1,328 @@
+import {
+  Button,
+  Card,
+  Chip,
+  Select,
+  SelectItem,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+} from "@heroui/react";
+import { Icon } from "@iconify/react";
+import { type CommittedPivotRow } from "@services/pivot-sync-service";
+import { PORTFOLIOS, formatReportMonth, monthName, usePivotTables } from "@/hooks/use-pivot-tables";
+
+const money = (value: number) =>
+  `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+interface Column {
+  key: string;
+  label: string;
+  align: "start" | "end";
+}
+
+// Column set for the pivot table; the split-fee columns only appear when the
+// pivot carries them (Receivabull).
+const buildColumns = (showFeeBreakdown: boolean): Column[] => [
+  { key: "advance_id", label: "ADVANCE ID", align: "start" },
+  { key: "merchant_name", label: "MERCHANT", align: "start" },
+  { key: "gross", label: "GROSS", align: "end" },
+  ...(showFeeBreakdown
+    ? ([
+        { key: "originator_fee", label: "ORIG. FEE", align: "end" },
+        { key: "rb_fee", label: "RB FEE", align: "end" },
+      ] as Column[])
+    : []),
+  { key: "fee", label: "FEE", align: "end" },
+  { key: "net", label: "NET", align: "end" },
+  ...(showFeeBreakdown
+    ? ([{ key: "fee_discrepancy", label: "DISCREPANCY", align: "end" }] as Column[])
+    : []),
+  { key: "matched", label: "MATCHED", align: "start" },
+];
+
+function renderCell(row: CommittedPivotRow, columnKey: string) {
+  const discrepant = row.fee_discrepancy != null && Math.abs(row.fee_discrepancy) >= 0.01;
+  switch (columnKey) {
+    case "advance_id":
+      return <TableCell className="font-mono text-sm">{row.advance_id || "—"}</TableCell>;
+    case "merchant_name":
+      return <TableCell className="font-medium">{row.merchant_name}</TableCell>;
+    case "gross":
+      return <TableCell className="text-right font-mono text-sm">{money(row.gross)}</TableCell>;
+    case "originator_fee":
+      return (
+        <TableCell className="text-right font-mono text-sm">
+          {money(row.originator_fee ?? 0)}
+        </TableCell>
+      );
+    case "rb_fee":
+      return (
+        <TableCell className="text-right font-mono text-sm">{money(row.rb_fee ?? 0)}</TableCell>
+      );
+    case "fee":
+      return <TableCell className="text-right font-mono text-sm">{money(row.fee)}</TableCell>;
+    case "net":
+      return <TableCell className="text-right font-mono text-sm">{money(row.net)}</TableCell>;
+    case "fee_discrepancy":
+      return (
+        <TableCell
+          className={`text-right font-mono text-sm ${
+            discrepant ? "text-warning-600 font-semibold" : ""
+          }`}
+        >
+          {money(row.fee_discrepancy ?? 0)}
+        </TableCell>
+      );
+    case "matched":
+      return (
+        <TableCell>
+          {row.matched_deal_id != null ? (
+            <Chip size="sm" variant="flat" color="success">
+              Matched
+            </Chip>
+          ) : (
+            <Chip size="sm" variant="flat" color="warning">
+              Unmatched
+            </Chip>
+          )}
+        </TableCell>
+      );
+    default:
+      return <TableCell>—</TableCell>;
+  }
+}
+
+function PivotTables() {
+  const {
+    funders,
+    portfolio,
+    setPortfolio,
+    funder,
+    setFunder,
+    monthsLoading,
+    years,
+    year,
+    selectYear,
+    monthsForYear,
+    reportDate,
+    setReportDate,
+    pivot,
+    pivotLoading,
+    showFeeBreakdown,
+    error,
+    exporting,
+    exportCsv,
+  } = usePivotTables();
+
+  const rows = pivot?.rows ?? [];
+  const columns = buildColumns(showFeeBreakdown);
+  const noMonths = Boolean(funder) && !monthsLoading && years.length === 0;
+
+  return (
+    <div className="p-6">
+      <div className="flex flex-wrap justify-between items-center mb-6 gap-4">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-3xl font-bold">Pivot Tables</h1>
+          <p className="text-small text-default-400">
+            Browse and export the pivot committed for a portfolio, funder, and month.
+          </p>
+        </div>
+        <Button
+          size="sm"
+          color="primary"
+          variant="flat"
+          isLoading={exporting}
+          isDisabled={rows.length === 0}
+          startContent={!exporting && <Icon icon="solar:download-minimalistic-linear" width={16} />}
+          onPress={exportCsv}
+        >
+          Export CSV
+        </Button>
+      </div>
+
+      <Card className="mb-6 dark:border-default-100 border border-transparent">
+        <div className="p-4 grid grid-cols-2 md:grid-cols-4 gap-3">
+          <Select
+            aria-label="Portfolio"
+            label="Portfolio"
+            size="sm"
+            selectedKeys={[portfolio]}
+            onSelectionChange={(keys) => {
+              const key = Array.from(keys)[0];
+              if (key) setPortfolio(String(key));
+            }}
+          >
+            {PORTFOLIOS.map((p) => (
+              <SelectItem key={p}>{p}</SelectItem>
+            ))}
+          </Select>
+
+          <Select
+            aria-label="Funder"
+            label="Funder"
+            size="sm"
+            isDisabled={funders.length === 0}
+            selectedKeys={funder ? [funder] : []}
+            onSelectionChange={(keys) => {
+              const key = Array.from(keys)[0];
+              if (key) setFunder(String(key));
+            }}
+          >
+            {funders.map((f) => (
+              <SelectItem key={f}>{f}</SelectItem>
+            ))}
+          </Select>
+
+          <Select
+            aria-label="Year"
+            label="Year"
+            size="sm"
+            isDisabled={years.length === 0}
+            selectedKeys={year ? [year] : []}
+            onSelectionChange={(keys) => {
+              const key = Array.from(keys)[0];
+              if (key) selectYear(String(key));
+            }}
+          >
+            {years.map((y) => (
+              <SelectItem key={y}>{y}</SelectItem>
+            ))}
+          </Select>
+
+          <Select
+            aria-label="Month"
+            label="Month"
+            size="sm"
+            isDisabled={monthsForYear.length === 0}
+            selectedKeys={reportDate ? [reportDate] : []}
+            onSelectionChange={(keys) => {
+              const key = Array.from(keys)[0];
+              if (key) setReportDate(String(key));
+            }}
+          >
+            {monthsForYear.map((d) => (
+              <SelectItem key={d}>{monthName(d)}</SelectItem>
+            ))}
+          </Select>
+        </div>
+      </Card>
+
+      {error && (
+        <Card className="mb-6 bg-danger-50 border-danger-200">
+          <div className="p-4 flex items-center gap-2">
+            <Icon icon="solar:danger-triangle-bold" className="text-danger" width={20} />
+            <span className="text-danger">{error}</span>
+          </div>
+        </Card>
+      )}
+
+      {monthsLoading && !error && (
+        <Card className="dark:border-default-100 border border-transparent">
+          <div className="p-4">
+            <Skeleton className="rounded-lg">
+              <div className="h-[300px] w-full bg-default-200"></div>
+            </Skeleton>
+          </div>
+        </Card>
+      )}
+
+      {noMonths && !error && (
+        <Card className="dark:border-default-100 border border-transparent">
+          <div className="p-10 flex flex-col items-center gap-2 text-center">
+            <Icon icon="solar:folder-open-linear" className="text-default-300" width={40} />
+            <p className="text-default-500">
+              No committed pivots for {funder || "this funder"} in {portfolio}.
+            </p>
+            <p className="text-tiny text-default-400">
+              Upload a funder file from the portfolio page to create one.
+            </p>
+          </div>
+        </Card>
+      )}
+
+      {Boolean(funder) &&
+        !monthsLoading &&
+        !noMonths &&
+        !error &&
+        (pivotLoading ? (
+          <Card className="dark:border-default-100 border border-transparent">
+            <div className="p-4">
+              <Skeleton className="rounded-lg mb-4">
+                <div className="h-4 w-48 bg-default-200"></div>
+              </Skeleton>
+              <Skeleton className="rounded-lg">
+                <div className="h-[400px] w-full bg-default-200"></div>
+              </Skeleton>
+            </div>
+          </Card>
+        ) : pivot == null ? (
+          <Card className="dark:border-default-100 border border-transparent">
+            <div className="p-10 flex flex-col items-center gap-2 text-center">
+              <Icon icon="solar:folder-open-linear" className="text-default-300" width={40} />
+              <p className="text-default-500">
+                No pivot committed for this selection
+                {reportDate ? ` (${formatReportMonth(reportDate)})` : ""}.
+              </p>
+            </div>
+          </Card>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              {[
+                { label: "Rows", value: pivot.row_count.toLocaleString() },
+                { label: "Total Gross", value: money(pivot.total_gross) },
+                { label: "Total Fee", value: money(pivot.total_fee) },
+                { label: "Total Net", value: money(pivot.total_net) },
+              ].map((card) => (
+                <Card
+                  key={card.label}
+                  className="dark:border-default-100 border border-transparent"
+                >
+                  <div className="p-3 flex flex-col gap-1">
+                    <span className="text-tiny text-default-500">{card.label}</span>
+                    <span className="text-large font-semibold">{card.value}</span>
+                  </div>
+                </Card>
+              ))}
+            </div>
+
+            <div className="overflow-x-auto">
+              <Table
+                aria-label={`Committed pivot for ${portfolio} ${funder}`}
+                classNames={{
+                  tr: "data-[discrepant=true]:bg-warning-50 dark:data-[discrepant=true]:bg-warning-500/10",
+                }}
+              >
+                <TableHeader columns={columns}>
+                  {(column) => (
+                    <TableColumn key={column.key} align={column.align}>
+                      {column.label}
+                    </TableColumn>
+                  )}
+                </TableHeader>
+                <TableBody items={rows} emptyContent="This pivot has no rows.">
+                  {(row) => (
+                    <TableRow
+                      key={row.id}
+                      data-discrepant={
+                        row.fee_discrepancy != null && Math.abs(row.fee_discrepancy) >= 0.01
+                      }
+                    >
+                      {(columnKey) => renderCell(row, String(columnKey))}
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        ))}
+    </div>
+  );
+}
+
+export default PivotTables;

--- a/src/pages/white-rabbit-portfolio.tsx
+++ b/src/pages/white-rabbit-portfolio.tsx
@@ -213,26 +213,25 @@ function WhiteRabbitPortfolio() {
             Uploaded Files for {selectedDate.toString()}
           </h3>
           <div className="space-y-2">
-            {monthlyFunderList
-              .filter((f) => !f.disabled)
-              .map((funder) => {
-                const uploaded = funderUploads.find(
-                  (u) => uiFunderName(u.funder_name) === funder.name
-                );
-                return (
-                  <div
-                    key={funder.name}
-                    className="flex items-center justify-between p-2 bg-default-100 rounded"
-                  >
-                    <span className="text-sm">{funder.name}</span>
-                    {uploaded ? (
-                      <span className="text-xs text-success-600">{uploaded.original_filename}</span>
-                    ) : (
-                      <span className="text-xs text-default-400">Not uploaded</span>
-                    )}
-                  </div>
-                );
-              })}
+            {monthlyFunderList.flatMap((funder) => {
+              if (funder.disabled) return [];
+              const uploaded = funderUploads.find(
+                (u) => uiFunderName(u.funder_name) === funder.name
+              );
+              return (
+                <div
+                  key={funder.name}
+                  className="flex items-center justify-between p-2 bg-default-100 rounded"
+                >
+                  <span className="text-sm">{funder.name}</span>
+                  {uploaded ? (
+                    <span className="text-xs text-success-600">{uploaded.original_filename}</span>
+                  ) : (
+                    <span className="text-xs text-default-400">Not uploaded</span>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/src/services/pivot-sync-service.ts
+++ b/src/services/pivot-sync-service.ts
@@ -94,6 +94,31 @@ export interface UnresolvedPivotRow {
   report_date: string;
 }
 
+/** One committed pivot row as stored in funder_pivot_rows. */
+export interface CommittedPivotRow {
+  id: string;
+  advance_id: string | null;
+  merchant_name: string;
+  gross: number;
+  fee: number;
+  net: number;
+  originator_fee: number | null;
+  rb_fee: number | null;
+  fee_discrepancy: number | null;
+  matched_deal_id: string | null;
+}
+
+/** A committed pivot: the funder_pivot_tables totals row plus its rows. */
+export interface CommittedPivot {
+  id: string;
+  report_date: string;
+  total_gross: number;
+  total_fee: number;
+  total_net: number;
+  row_count: number;
+  rows: CommittedPivotRow[];
+}
+
 /** One funder_uploads row, resolved for display. */
 export interface CloudUploadInfo {
   id: string;
@@ -370,6 +395,74 @@ export class PivotSyncService {
           b.report_date.localeCompare(a.report_date) ||
           a.merchant_name.localeCompare(b.merchant_name)
       );
+  }
+
+  /** All funder UI labels known to Supabase, alphabetically. */
+  static async listFunders(): Promise<string[]> {
+    const names = await this.getFunderNames();
+    return [...names.values()].map(uiFunderName).sort((a, b) => a.localeCompare(b));
+  }
+
+  /**
+   * Distinct report dates that have a committed pivot for one portfolio +
+   * funder, newest first. Drives the year/month selectors on the Pivot Tables
+   * page so only periods with data are offered.
+   */
+  static async listPivotMonths(portfolioName: string, funderName: string): Promise<string[]> {
+    const [portfolioId, funderId] = await Promise.all([
+      this.getPortfolioId(portfolioName),
+      this.getFunderId(funderName),
+    ]);
+    const { data, error } = await supabase
+      .from("funder_pivot_tables")
+      .select("report_date")
+      .eq("portfolio_id", portfolioId)
+      .eq("funder_id", funderId)
+      .order("report_date", { ascending: false });
+    if (error) throw new Error(`Failed to load pivot months: ${error.message}`);
+    return [...new Set((data ?? []).map((r) => r.report_date))];
+  }
+
+  /**
+   * The committed pivot (totals + every row) for one portfolio + funder +
+   * report date, or null if none was committed for that combination.
+   */
+  static async getPivotTable(
+    portfolioName: string,
+    funderName: string,
+    reportDate: string
+  ): Promise<CommittedPivot | null> {
+    const [portfolioId, funderId] = await Promise.all([
+      this.getPortfolioId(portfolioName),
+      this.getFunderId(funderName),
+    ]);
+    const { data: table, error: tableError } = await supabase
+      .from("funder_pivot_tables")
+      .select("id, report_date, total_gross, total_fee, total_net, row_count")
+      .eq("portfolio_id", portfolioId)
+      .eq("funder_id", funderId)
+      .eq("report_date", reportDate)
+      .maybeSingle();
+    if (tableError) throw new Error(`Failed to load pivot table: ${tableError.message}`);
+    if (!table) return null;
+
+    const PAGE = 1000; // PostgREST response cap
+    const rows: CommittedPivotRow[] = [];
+    for (let from = 0; ; from += PAGE) {
+      const { data, error } = await supabase
+        .from("funder_pivot_rows")
+        .select(
+          "id, advance_id, merchant_name, gross, fee, net, originator_fee, rb_fee, fee_discrepancy, matched_deal_id"
+        )
+        .eq("pivot_table_id", table.id)
+        .order("merchant_name")
+        .range(from, from + PAGE - 1);
+      if (error) throw new Error(`Failed to load pivot rows: ${error.message}`);
+      if (!data || data.length === 0) break;
+      rows.push(...data);
+      if (data.length < PAGE) break;
+    }
+    return { ...table, rows };
   }
 
   /** All funder uploads recorded in Supabase for one portfolio + report date. */


### PR DESCRIPTION
## Summary

Adds a new top-level **Pivot Tables** page where you select **portfolio, funder, year, and month** and see the pivot that was committed for that combination, rendered in a table with a **CSV export**. Previously committed pivots (`funder_pivot_tables` / `funder_pivot_rows`) were only viewable through Supabase Studio — the reconciliation modal showed them only during upload and couldn't be reopened.

Closes #49.

## What's included

**Service** (`src/services/pivot-sync-service.ts`)
- `listFunders()` — UI funder labels from the `funders` table (via existing `uiFunderName` mapping).
- `listPivotMonths(portfolio, funder)` — distinct committed `report_date`s, newest first; drives the year/month selectors so only periods with data are offered.
- `getPivotTable(portfolio, funder, reportDate)` — totals row + all rows, paged at the 1000-row PostgREST cap; `null` when none. Reuses `getPortfolioId` / `getFunderId`; reads stay RLS-scoped (no new policies).

**Hook** (`src/hooks/use-pivot-tables.ts`)
- Drives Portfolio → Funder → Year → Month selection with cancel-guarded loads.
- `pivotRowsToCsv()` + export via `saveCsvFile` and the existing toast pattern (Receivabull columns included only when present).

**Page** (`src/pages/pivot-tables.tsx`)
- Totals cards (`row_count`, gross/fee/net) + one row per pivot row with a Matched/Unmatched chip.
- Receivabull pivots additionally surface `originator_fee`, `rb_fee`, `fee_discrepancy`, with discrepant rows flagged (warning tint + warning-colored discrepancy text, matching the reconciliation modal).
- Distinct empty states for "no pivots for this funder/portfolio" vs "no pivot for this month". Read-only for v1 (resolution stays in Deal Lookup).

**Wiring** — route in `src/App.tsx`, sidebar entry (`pivot-tables`, `solar:widget-5-outline`).

**Drive-by** — collapse a chained `filter().map()` into a single `flatMap` in the Alder and White Rabbit portfolio pages (React Doctor `js-combine-iterations`).

## Acceptance criteria
- [x] New Pivot Tables sidebar item + route with Portfolio, Funder, Year, Month selectors
- [x] Committed combination shows all rows + stored totals; no-pivot shows a clear empty state
- [x] Year/Month options reflect only periods with a committed pivot
- [x] Receivabull pivots show the fee breakdown with discrepant rows flagged
- [x] Each row shows matched/unmatched status
- [x] Export CSV downloads the displayed pivot (incl. Receivabull columns when present)
- [x] Reads RLS-scoped; CI gates pass (`npm run lint && format:check && build`)

## Test plan
- `npm run lint && npm run format:check && npm run build` — all pass.
- Manual: select portfolio/funder/year/month; verify rows, totals, empty states, Receivabull fee columns + discrepancy flag, and CSV export contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)