### PR TITLE
feat: admin user management + password reveal toggle

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -101,3 +101,5 @@ chosen so an exported workbook re-imports cleanly through
 ## RLS
 
 `has_portfolio_access(portfolio_id)` + `is_admin()` (both `SECURITY DEFINER`) gate all portfolio-scoped tables via `portfolio_access`. Tables without a `portfolio_id` scope through their parent (`net_rtr_payments` via `deals`, `funder_pivot_rows` via `funder_pivot_tables`). Lookups (`funders`, `industries`, `states`) remain readable by any authenticated user; anon sees nothing.
+
+`user_profiles`: users can view/update their own row; admins can view/update every row (drives the User Management page). A `BEFORE UPDATE OF role` trigger (`enforce_admin_role_change`) rejects role changes by non-admins, so a member cannot self-promote through the "update own profile" policy. New accounts are created from the app via a stateless auth client (`AuthService.inviteUser`) so signing up an invitee never replaces the admin's session; the profile row comes from `on_auth_user_created` with role `member` and is promoted afterwards if needed.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -9,6 +9,7 @@ import PivotTables from "@pages/pivot-tables";
 import DatabasePage from "@pages/database";
 import AiChat from "@pages/ai-chat";
 import Settings from "@pages/settings";
+import Users from "@pages/users";
 import Login from "@pages/login";
 import { ProtectedRoute } from "@components/auth/protected-route";
 import { useAuth } from "@/contexts/auth-context-value";
@@ -50,6 +51,7 @@ function App() {
           <Route path="pivot-tables" element={<PivotTables />} />
           <Route path="database" element={<DatabasePage />} />
           <Route path="ai-chat" element={<AiChat />} />
+          <Route path="users" element={<Users />} />
           <Route path="settings" element={<Settings />} />
         </Route>
       </Routes>

--- a/src/components/ai-chat/provider-settings-modal.tsx
+++ b/src/components/ai-chat/provider-settings-modal.tsx
@@ -17,6 +17,7 @@ import {
   type AiSettings,
 } from "@services/ai-chat-service";
 import { toast } from "@services/toast-service";
+import { PasswordInput } from "@components/ui/password-input";
 
 interface Props {
   isOpen: boolean;
@@ -72,9 +73,8 @@ export function ProviderSettingsModal({ isOpen, onClose, settings, onSaved }: Pr
 
           <div className="flex flex-col gap-2">
             <p className="text-small font-semibold">Anthropic</p>
-            <Input
+            <PasswordInput
               label="API key"
-              type="password"
               value={draft.anthropic_api_key}
               onValueChange={(v) => set({ anthropic_api_key: v })}
               placeholder="sk-ant-…"
@@ -88,9 +88,8 @@ export function ProviderSettingsModal({ isOpen, onClose, settings, onSaved }: Pr
 
           <div className="flex flex-col gap-2">
             <p className="text-small font-semibold">OpenAI</p>
-            <Input
+            <PasswordInput
               label="API key"
-              type="password"
               value={draft.openai_api_key}
               onValueChange={(v) => set({ openai_api_key: v })}
               placeholder="sk-…"
@@ -104,9 +103,8 @@ export function ProviderSettingsModal({ isOpen, onClose, settings, onSaved }: Pr
 
           <div className="flex flex-col gap-2">
             <p className="text-small font-semibold">Google</p>
-            <Input
+            <PasswordInput
               label="API key"
-              type="password"
               value={draft.google_api_key}
               onValueChange={(v) => set({ google_api_key: v })}
               placeholder="AIza…"
@@ -137,9 +135,8 @@ export function ProviderSettingsModal({ isOpen, onClose, settings, onSaved }: Pr
               onValueChange={(v) => set({ lmstudio_model: v })}
               placeholder="e.g. qwen/qwen3-32b — the model id shown in LM Studio"
             />
-            <Input
+            <PasswordInput
               label="API token (optional)"
-              type="password"
               value={draft.lmstudio_api_key}
               onValueChange={(v) => set({ lmstudio_api_key: v })}
               description="Only needed if your server requires an API token (LM Studio: Developer → Server Settings)."

--- a/src/components/auth/change-password.tsx
+++ b/src/components/auth/change-password.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { Button } from "@heroui/react";
+import { useAuth } from "@/contexts/auth-context-value";
+import { AuthService } from "@services/auth-service";
+import { PasswordInput } from "@components/ui/password-input";
+
+// react-doctor-disable-next-line react-doctor/prefer-useReducer -- independent form fields, validation errors, and async submit status that change at different times
+export function ChangePassword() {
+  const { user } = useAuth();
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    if (!user?.email) {
+      setError("No signed-in user.");
+      return;
+    }
+    if (newPassword.length < 8) {
+      setError("New password must be at least 8 characters.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError("New passwords do not match.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const currentValid = await AuthService.verifyPassword(user.email, currentPassword);
+      if (!currentValid) {
+        setError("Current password is incorrect.");
+        return;
+      }
+
+      const { error: updateError } = await AuthService.updatePassword(newPassword);
+      if (updateError) {
+        throw updateError;
+      }
+
+      setSuccess("Password updated successfully.");
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (err) {
+      console.error("Change password error:", err);
+      setError(err instanceof Error ? err.message : "Failed to update password.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {error && <div className="rounded-lg bg-danger-50 p-3 text-sm text-danger">{error}</div>}
+      {success && (
+        <div className="rounded-lg bg-success-50 p-3 text-sm text-success">{success}</div>
+      )}
+
+      <PasswordInput
+        label="Current Password"
+        value={currentPassword}
+        onChange={(e) => setCurrentPassword(e.target.value)}
+        isRequired
+        variant="bordered"
+      />
+      <PasswordInput
+        label="New Password"
+        value={newPassword}
+        onChange={(e) => setNewPassword(e.target.value)}
+        isRequired
+        variant="bordered"
+        description="Minimum 8 characters"
+      />
+      <PasswordInput
+        label="Confirm New Password"
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+        isRequired
+        variant="bordered"
+      />
+
+      <Button type="submit" color="primary" isLoading={loading} className="w-fit">
+        {loading ? "Updating..." : "Update Password"}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/auth/invite-user.tsx
+++ b/src/components/auth/invite-user.tsx
@@ -2,9 +2,10 @@ import { useState } from "react";
 import { Button, Input, Card, CardBody, CardHeader, Select, SelectItem } from "@heroui/react";
 import { useAuth } from "@/contexts/auth-context-value";
 import { AuthService } from "@services/auth-service";
+import { PasswordInput } from "@components/ui/password-input";
 
 // react-doctor-disable-next-line react-doctor/prefer-useReducer -- these hold largely independent concerns (form fields, per-field validation errors, async submit status) that change at different times, so a single reducer would not improve consistency
-export function InviteUser() {
+export function InviteUser({ onInvited }: { onInvited?: () => void }) {
   const { profile } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -83,24 +84,17 @@ export function InviteUser() {
     setLoading(true);
 
     try {
-      // Create the user account
-      const { user, error: signUpError } = await AuthService.signUp({
+      // Creates the account on an isolated auth client so the current
+      // admin session is not replaced by the new user's session.
+      const { error: inviteError } = await AuthService.inviteUser({
         email,
         password,
         fullName,
+        role,
       });
 
-      if (signUpError) {
-        throw signUpError;
-      }
-
-      if (!user) {
-        throw new Error("Failed to create user account");
-      }
-
-      // Update the user's role if not member
-      if (role !== "member") {
-        await AuthService.updateUserProfile(user.id, { role });
+      if (inviteError) {
+        throw inviteError;
       }
 
       setSuccess(`User ${fullName} (${email}) has been invited successfully!`);
@@ -110,6 +104,7 @@ export function InviteUser() {
       setPassword("");
       setFullName("");
       setRole("member");
+      onInvited?.();
     } catch (err) {
       console.error("Invite user error:", err);
       if (err instanceof Error) {
@@ -172,9 +167,8 @@ export function InviteUser() {
             variant="bordered"
           />
 
-          <Input
+          <PasswordInput
             label="Temporary Password"
-            type="password"
             placeholder="Create a temporary password"
             value={password}
             onChange={(e) => {

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { Input, type InputProps } from "@heroui/react";
+import { Icon } from "@iconify/react";
+
+/**
+ * Password input with a show/hide toggle. Drop-in replacement for a HeroUI
+ * <Input type="password" />; all Input props are forwarded.
+ */
+export function PasswordInput(props: Omit<InputProps, "type" | "endContent">) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <Input
+      {...props}
+      type={visible ? "text" : "password"}
+      endContent={
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={() => setVisible((v) => !v)}
+          className="text-default-400 outline-none transition-colors hover:text-default-600 focus:text-default-600"
+          aria-label={visible ? "Hide password" : "Show password"}
+        >
+          <Icon icon={visible ? "solar:eye-closed-linear" : "solar:eye-linear"} width={18} />
+        </button>
+      }
+    />
+  );
+}

--- a/src/features/sidebar/sidebar-items.tsx
+++ b/src/features/sidebar/sidebar-items.tsx
@@ -42,6 +42,13 @@ export const items: SidebarItem[] = [
   },
 ];
 
+// Shown only to admins (appended in layout.tsx based on the user's role).
+export const usersItem: SidebarItem = {
+  key: "users",
+  icon: "solar:users-group-rounded-outline",
+  title: "User Management",
+};
+
 export const settingsItem: SidebarItem = {
   key: "settings",
   icon: "solar:settings-outline",

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -1,7 +1,8 @@
 import { Outlet, useNavigate, useLocation } from "react-router-dom";
 import { ScrollShadow, Button, Listbox, ListboxItem, Tooltip } from "@heroui/react";
 import Sidebar from "@features/sidebar/sidebar";
-import { items, settingsItem } from "@features/sidebar/sidebar-items";
+import { items, usersItem, settingsItem } from "@features/sidebar/sidebar-items";
+import { useAuth } from "@/contexts/auth-context-value";
 import { UserMenu } from "@components/auth/user-menu";
 import ErrorBoundary from "@components/error-boundary";
 import { useEffect, useState, useRef } from "react";
@@ -12,6 +13,8 @@ function Layout() {
   const navigate = useNavigate();
   const location = useLocation();
   const { theme, toggleTheme } = useTheme();
+  const { profile } = useAuth();
+  const navItems = profile?.role === "admin" ? [...items, usersItem] : items;
   const [selectedKey, setSelectedKey] = useState("dashboard");
   const [isCompact, setIsCompact] = useState(() => {
     const saved = localStorage.getItem("sidebarCompact");
@@ -89,7 +92,7 @@ function Layout() {
         <ScrollShadow className="flex-1 max-h-full py-2">
           <Sidebar
             defaultSelectedKey={selectedKey}
-            items={items}
+            items={navItems}
             isCompact={isCompact}
             onSelect={(key: string) => handleSelect(key)}
             className="select-none"

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button, Input, Card, CardBody, CardHeader } from "@heroui/react";
 import { useAuth } from "@/contexts/auth-context-value";
+import { PasswordInput } from "@components/ui/password-input";
 
 export default function Login() {
   const navigate = useNavigate();
@@ -101,9 +102,8 @@ export default function Login() {
               variant="bordered"
             />
 
-            <Input
+            <PasswordInput
               label="Password"
-              type="password"
               placeholder="Enter your password"
               value={password}
               onChange={(e) => {

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,6 +1,7 @@
-import { InviteUser } from "@components/auth/invite-user";
+import { ChangePassword } from "@components/auth/change-password";
 import { useAuth } from "@/contexts/auth-context-value";
 import { Card, CardBody, CardHeader, Select, SelectItem, Checkbox, Button } from "@heroui/react";
+import { useNavigate } from "react-router-dom";
 import { useTheme } from "@/contexts/theme-context-value";
 import { useReleaseNotes } from "@/contexts/release-notes-context-value";
 import { Icon } from "@iconify/react";
@@ -18,19 +19,46 @@ function Settings() {
   const { currentVersion, openReleaseNotes } = useReleaseNotes();
   const [exportFormat, setExportFormat] = useState("csv");
   const [autoSave, setAutoSave] = useState(false);
+  const navigate = useNavigate();
 
   return (
     <div className="p-6">
       <h1 className="text-3xl font-bold mb-6">Settings</h1>
       <div className="space-y-6 max-w-2xl">
-        {/* User Management - Only visible to admins */}
+        {/* Account - change your own password */}
+        <Card>
+          <CardHeader className="pb-3">
+            <h2 className="text-xl font-semibold">Account</h2>
+          </CardHeader>
+          <CardBody className="gap-4">
+            <div className="text-sm text-default-600">
+              <p>{profile?.full_name || profile?.email}</p>
+              <p className="text-default-500">
+                {profile?.email} · {profile?.role === "admin" ? "Admin" : "Member"}
+              </p>
+            </div>
+            <ChangePassword />
+          </CardBody>
+        </Card>
+
+        {/* User management moved to its own page - admins only */}
         {profile?.role === "admin" && (
           <Card>
             <CardHeader className="pb-3">
               <h2 className="text-xl font-semibold">User Management</h2>
             </CardHeader>
-            <CardBody>
-              <InviteUser />
+            <CardBody className="items-start gap-3">
+              <p className="text-sm text-default-600">
+                Invite users, set roles, and manage portfolio access from the User Management page.
+              </p>
+              <Button
+                color="primary"
+                variant="flat"
+                startContent={<Icon icon="solar:users-group-rounded-outline" width={20} />}
+                onPress={() => navigate("/users")}
+              >
+                Open User Management
+              </Button>
             </CardBody>
           </Card>
         )}

--- a/src/pages/users.tsx
+++ b/src/pages/users.tsx
@@ -1,0 +1,289 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Checkbox,
+  Chip,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Select,
+  SelectItem,
+  Spinner,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+} from "@heroui/react";
+import { Icon } from "@iconify/react";
+import { useAuth } from "@/contexts/auth-context-value";
+import { InviteUser } from "@components/auth/invite-user";
+import type { UserProfile } from "@services/auth-service";
+import {
+  UserAdminService,
+  type PortfolioSummary,
+  type PortfolioAccessEntry,
+} from "@services/user-admin-service";
+import { useToast } from "@/contexts/toast-context-value";
+
+function Users() {
+  const { profile } = useAuth();
+  const { showToast } = useToast();
+  const [users, setUsers] = useState<UserProfile[]>([]);
+  const [portfolios, setPortfolios] = useState<PortfolioSummary[]>([]);
+  const [access, setAccess] = useState<PortfolioAccessEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<UserProfile | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const isAdmin = profile?.role === "admin";
+
+  const loadData = useCallback(async () => {
+    setLoadError(null);
+    try {
+      const [userRows, portfolioRows, accessRows] = await Promise.all([
+        UserAdminService.listUsers(),
+        UserAdminService.listPortfolios(),
+        UserAdminService.listPortfolioAccess(),
+      ]);
+      setUsers(userRows);
+      setPortfolios(portfolioRows);
+      setAccess(accessRows);
+    } catch (err) {
+      console.error("Failed to load users:", err);
+      setLoadError(err instanceof Error ? err.message : "Failed to load users.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAdmin) {
+      loadData();
+    } else {
+      setLoading(false);
+    }
+  }, [isAdmin, loadData]);
+
+  const hasAccess = (userId: string, portfolioId: number) =>
+    access.some((a) => a.user_id === userId && a.portfolio_id === portfolioId);
+
+  const handleRoleChange = async (userId: string, role: "admin" | "member") => {
+    const previous = users;
+    setUsers((rows) => rows.map((u) => (u.id === userId ? { ...u, role } : u)));
+    try {
+      await UserAdminService.setUserRole(userId, role);
+      showToast({ title: "Role updated", type: "success" });
+    } catch (err) {
+      console.error("Failed to update role:", err);
+      setUsers(previous);
+      showToast({
+        title: "Failed to update role",
+        description: err instanceof Error ? err.message : undefined,
+        type: "error",
+      });
+    }
+  };
+
+  const handleAccessToggle = async (userId: string, portfolioId: number, granted: boolean) => {
+    const previous = access;
+    setAccess((rows) =>
+      granted
+        ? [...rows, { user_id: userId, portfolio_id: portfolioId }]
+        : rows.filter((a) => !(a.user_id === userId && a.portfolio_id === portfolioId))
+    );
+    try {
+      if (granted) {
+        await UserAdminService.grantPortfolioAccess(userId, portfolioId);
+      } else {
+        await UserAdminService.revokePortfolioAccess(userId, portfolioId);
+      }
+    } catch (err) {
+      console.error("Failed to update portfolio access:", err);
+      setAccess(previous);
+      showToast({
+        title: "Failed to update portfolio access",
+        description: err instanceof Error ? err.message : undefined,
+        type: "error",
+      });
+    }
+  };
+
+  const handleDeleteUser = async () => {
+    if (!deleteTarget) {
+      return;
+    }
+    setDeleting(true);
+    try {
+      await UserAdminService.deleteUser(deleteTarget.id);
+      setUsers((rows) => rows.filter((u) => u.id !== deleteTarget.id));
+      setAccess((rows) => rows.filter((a) => a.user_id !== deleteTarget.id));
+      showToast({ title: "User deleted", type: "success" });
+      setDeleteTarget(null);
+    } catch (err) {
+      console.error("Failed to delete user:", err);
+      showToast({
+        title: "Failed to delete user",
+        description: err instanceof Error ? err.message : undefined,
+        type: "error",
+      });
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <div className="p-6">
+        <Card>
+          <CardBody>
+            <p className="text-default-500">Only administrators can manage users.</p>
+          </CardBody>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <h1 className="text-3xl font-bold mb-6">User Management</h1>
+      <div className="space-y-6 max-w-4xl">
+        <Card>
+          <CardHeader className="flex flex-col items-start gap-1 px-6 pt-6">
+            <h2 className="text-xl font-semibold">Team Members</h2>
+            <p className="text-sm text-default-500">
+              Set roles and choose which portfolios each member can view. Admins always have access
+              to every portfolio.
+            </p>
+          </CardHeader>
+          <CardBody className="px-6 pb-6">
+            {loading ? (
+              <div className="flex justify-center py-8">
+                <Spinner label="Loading users..." />
+              </div>
+            ) : loadError ? (
+              <div className="rounded-lg bg-danger-50 p-3 text-sm text-danger">{loadError}</div>
+            ) : (
+              <Table aria-label="Team members" removeWrapper>
+                <TableHeader>
+                  <TableColumn>USER</TableColumn>
+                  <TableColumn>ROLE</TableColumn>
+                  <TableColumn>PORTFOLIO ACCESS</TableColumn>
+                  <TableColumn aria-label="Actions" align="end">
+                    {""}
+                  </TableColumn>
+                </TableHeader>
+                <TableBody emptyContent="No users found.">
+                  {users.map((u) => {
+                    const isSelf = u.id === profile?.id;
+                    return (
+                      <TableRow key={u.id}>
+                        <TableCell>
+                          <div className="flex flex-col">
+                            <span className="flex items-center gap-2 text-sm font-medium">
+                              {u.full_name || "—"}
+                              {isSelf && (
+                                <Chip size="sm" variant="flat">
+                                  You
+                                </Chip>
+                              )}
+                            </span>
+                            <span className="text-xs text-default-500">{u.email}</span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Select
+                            aria-label={`Role for ${u.email}`}
+                            selectedKeys={[u.role]}
+                            onChange={(e) => {
+                              const role = e.target.value as "admin" | "member";
+                              if (role && role !== u.role) {
+                                handleRoleChange(u.id, role);
+                              }
+                            }}
+                            isDisabled={isSelf}
+                            size="sm"
+                            variant="bordered"
+                            className="w-32"
+                          >
+                            <SelectItem key="member">Member</SelectItem>
+                            <SelectItem key="admin">Admin</SelectItem>
+                          </Select>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex flex-wrap gap-4">
+                            {u.role === "admin" ? (
+                              <span className="text-sm text-default-500">All portfolios</span>
+                            ) : (
+                              portfolios.map((p) => (
+                                <Checkbox
+                                  key={p.id}
+                                  size="sm"
+                                  isSelected={hasAccess(u.id, p.id)}
+                                  onValueChange={(granted) =>
+                                    handleAccessToggle(u.id, p.id, granted)
+                                  }
+                                >
+                                  <span className="text-sm">{p.name}</span>
+                                </Checkbox>
+                              ))
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            variant="light"
+                            color="danger"
+                            aria-label={`Delete ${u.email}`}
+                            isDisabled={isSelf}
+                            onPress={() => setDeleteTarget(u)}
+                          >
+                            <Icon icon="solar:trash-bin-trash-linear" width={18} />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            )}
+          </CardBody>
+        </Card>
+
+        <InviteUser onInvited={loadData} />
+      </div>
+
+      <Modal isOpen={!!deleteTarget} onClose={() => !deleting && setDeleteTarget(null)} size="md">
+        <ModalContent>
+          <ModalHeader>Delete user?</ModalHeader>
+          <ModalBody>
+            <p className="text-sm text-default-600">
+              This permanently deletes{" "}
+              <span className="font-medium">{deleteTarget?.full_name || deleteTarget?.email}</span>{" "}
+              along with their portfolio access. This cannot be undone.
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="flat" onPress={() => setDeleteTarget(null)} isDisabled={deleting}>
+              Cancel
+            </Button>
+            <Button color="danger" onPress={handleDeleteUser} isLoading={deleting}>
+              Delete
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+}
+
+export default Users;

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,4 +1,4 @@
-import { supabase } from "./supabase";
+import { supabase, createStatelessAuthClient } from "./supabase";
 import type { User, Session, AuthError } from "@supabase/supabase-js";
 import type { Database } from "./supabase.types";
 type UserProfileUpdate = Database["public"]["Tables"]["user_profiles"]["Update"];
@@ -73,6 +73,82 @@ export class AuthService {
       session: data.session,
       error,
     };
+  }
+
+  /**
+   * Create an account for an invited user WITHOUT signing them in here.
+   * Uses a stateless client so the inviting admin's session is untouched.
+   */
+  static async inviteUser(invite: {
+    email: string;
+    password: string;
+    fullName: string;
+    role: "admin" | "member";
+  }): Promise<{ userId: string | null; error: Error | null }> {
+    const inviteClient = createStatelessAuthClient();
+
+    const { data, error } = await inviteClient.auth.signUp({
+      email: invite.email,
+      password: invite.password,
+      options: {
+        data: {
+          full_name: invite.fullName,
+        },
+      },
+    });
+
+    if (error) {
+      return { userId: null, error };
+    }
+
+    const newUser = data.user;
+    if (!newUser) {
+      return { userId: null, error: new Error("Failed to create user account") };
+    }
+
+    // Supabase returns an obfuscated user with no identities when the email
+    // is already registered (to prevent enumeration).
+    if (newUser.identities && newUser.identities.length === 0) {
+      return { userId: null, error: new Error("This email is already registered.") };
+    }
+
+    // Drop the throwaway session from memory; ignore errors (there is no
+    // session at all when email confirmation is enabled).
+    await inviteClient.auth.signOut({ scope: "local" }).catch(() => undefined);
+
+    // The profile row is created by the on_auth_user_created trigger with
+    // role 'member'; promote via the admin's own session if requested.
+    if (invite.role === "admin") {
+      const { data: updated, error: roleError } = await supabase
+        .from("user_profiles")
+        .update({ role: "admin", updated_at: new Date().toISOString() })
+        .eq("id", newUser.id)
+        .select("id");
+
+      if (roleError || !updated || updated.length === 0) {
+        return {
+          userId: newUser.id,
+          error: new Error(
+            "User was created but could not be made an admin. You can change their role from User Management."
+          ),
+        };
+      }
+    }
+
+    return { userId: newUser.id, error: null };
+  }
+
+  /**
+   * Verify a user's current password without touching the app session.
+   */
+  static async verifyPassword(email: string, password: string): Promise<boolean> {
+    const checkClient = createStatelessAuthClient();
+    const { error } = await checkClient.auth.signInWithPassword({ email, password });
+    if (!error) {
+      await checkClient.auth.signOut({ scope: "local" }).catch(() => undefined);
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -18,3 +18,16 @@ export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
     storage: window.localStorage,
   },
 });
+
+// Throwaway client for auth calls that must not touch the persisted session
+// (inviting a user calls signUp, which would otherwise replace the current
+// admin's session with the new account's).
+export function createStatelessAuthClient() {
+  return createClient<Database>(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  });
+}

--- a/src/services/supabase.types.ts
+++ b/src/services/supabase.types.ts
@@ -840,6 +840,10 @@ export interface Database {
         Args: Record<string, never>;
         Returns: boolean;
       };
+      admin_delete_user: {
+        Args: { target_id: string };
+        Returns: undefined;
+      };
       commit_funder_pivot: {
         Args: {
           p_upload_id: string;

--- a/src/services/user-admin-service.ts
+++ b/src/services/user-admin-service.ts
@@ -1,0 +1,102 @@
+import { supabase } from "./supabase";
+import type { UserProfile } from "./auth-service";
+
+export interface PortfolioSummary {
+  id: number;
+  name: string;
+}
+
+export interface PortfolioAccessEntry {
+  user_id: string;
+  portfolio_id: number;
+}
+
+/**
+ * Admin-only user management operations. All of these are gated by RLS:
+ * non-admins get empty results / rejected writes.
+ */
+export class UserAdminService {
+  static async listUsers(): Promise<UserProfile[]> {
+    const { data, error } = await supabase
+      .from("user_profiles")
+      .select("*")
+      .order("created_at", { ascending: true });
+
+    if (error) {
+      throw error;
+    }
+    return data ?? [];
+  }
+
+  static async listPortfolios(): Promise<PortfolioSummary[]> {
+    const { data, error } = await supabase
+      .from("portfolios")
+      .select("id, name")
+      .eq("is_deleted", false)
+      .order("id", { ascending: true });
+
+    if (error) {
+      throw error;
+    }
+    return data ?? [];
+  }
+
+  static async listPortfolioAccess(): Promise<PortfolioAccessEntry[]> {
+    const { data, error } = await supabase.from("portfolio_access").select("user_id, portfolio_id");
+
+    if (error) {
+      throw error;
+    }
+    return data ?? [];
+  }
+
+  static async setUserRole(userId: string, role: "admin" | "member"): Promise<void> {
+    const { data, error } = await supabase
+      .from("user_profiles")
+      .update({ role, updated_at: new Date().toISOString() })
+      .eq("id", userId)
+      .select("id");
+
+    if (error) {
+      throw error;
+    }
+    if (!data || data.length === 0) {
+      throw new Error("Role change was not applied — you may not have permission.");
+    }
+  }
+
+  static async grantPortfolioAccess(userId: string, portfolioId: number): Promise<void> {
+    const { error } = await supabase
+      .from("portfolio_access")
+      .upsert({ user_id: userId, portfolio_id: portfolioId });
+
+    if (error) {
+      throw error;
+    }
+  }
+
+  static async revokePortfolioAccess(userId: string, portfolioId: number): Promise<void> {
+    const { error } = await supabase
+      .from("portfolio_access")
+      .delete()
+      .eq("user_id", userId)
+      .eq("portfolio_id", portfolioId);
+
+    if (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * Permanently delete a user. Removes the auth account, which cascades to
+   * their profile and portfolio access. Admin-only and enforced server-side
+   * by the admin_delete_user RPC (which also blocks deleting yourself).
+   */
+  static async deleteUser(userId: string): Promise<void> {
+    const { error } = await supabase.rpc("admin_delete_user", { target_id: userId });
+
+    if (error) {
+      throw error;
+    }
+  }
+}

--- a/supabase/migrations/20260716210000_admin_user_management.sql
+++ b/supabase/migrations/20260716210000_admin_user_management.sql
@@ -1,0 +1,69 @@
+-- Admin user management.
+--
+-- user_profiles RLS only allowed users to see/update their own row, so an
+-- admin could not list users or change anyone's role. Additionally the
+-- "Users can update own profile" policy let a member set role = 'admin' on
+-- their own row; a trigger now restricts role changes to admins.
+
+CREATE POLICY "Admins can view all profiles"
+  ON user_profiles FOR SELECT
+  TO authenticated
+  USING (is_admin());
+
+CREATE POLICY "Admins can update all profiles"
+  ON user_profiles FOR UPDATE
+  TO authenticated
+  USING (is_admin())
+  WITH CHECK (is_admin());
+
+-- Block role changes by non-admins. auth.uid() IS NULL covers service-role
+-- and migration contexts, which bypass RLS but still fire triggers.
+CREATE OR REPLACE FUNCTION public.enforce_admin_role_change()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.role IS DISTINCT FROM OLD.role
+     AND auth.uid() IS NOT NULL
+     AND NOT is_admin() THEN
+    RAISE EXCEPTION 'Only admins can change user roles';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER enforce_admin_role_change
+  BEFORE UPDATE OF role ON user_profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_admin_role_change();
+
+-- Delete a user outright. Deleting the auth.users row cascades to
+-- user_profiles (user_profiles_id_fkey ON DELETE CASCADE) and from there to
+-- portfolio_access. Runs as SECURITY DEFINER (owner: postgres) because the
+-- authenticated role has no direct DELETE on auth.users; the is_admin() gate
+-- keeps it admin-only, and admins cannot delete themselves.
+CREATE OR REPLACE FUNCTION public.admin_delete_user(target_id uuid)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT is_admin() THEN
+    RAISE EXCEPTION 'Only admins can delete users';
+  END IF;
+
+  IF target_id = auth.uid() THEN
+    RAISE EXCEPTION 'You cannot delete your own account';
+  END IF;
+
+  DELETE FROM auth.users WHERE id = target_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'User not found';
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_delete_user(uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.admin_delete_user(uuid) TO authenticated;


### PR DESCRIPTION
## Summary

Adds an admin-only **User Management** page and a **show/hide toggle** for password inputs across the app.

### User management
- New **Users** page (admin-only): invite team members, set roles, grant/revoke per-portfolio access, and **delete users**.
- Change-password form on the Settings page.
- `admin_delete_user` RPC — `SECURITY DEFINER`, admin-gated, and blocks deleting your own account. Deleting the `auth.users` row cascades to `user_profiles` → `portfolio_access` via existing `ON DELETE CASCADE` FKs.
- RLS policies letting admins view/update all profiles, plus a trigger restricting role changes to admins.
- `UserAdminService` + a stateless auth client so inviting a user doesn't replace the admin's session.

### Password reveal toggle
- Reusable `PasswordInput` (HeroUI `Input` + eye-icon toggle), applied to all `type="password"` fields: login, change-password, invite-user, and the four AI-provider API-key fields.

## Migration ⚠️
Includes `supabase/migrations/20260716210000_admin_user_management.sql`. It must be applied with `supabase db push` before the role/delete actions work against the target database. `npm run tauri dev` runs against **production** Supabase, so the Delete button will error until the migration is pushed.

## Notes
- The AI-provider API-key fields were included in the reveal treatment since they use `type="password"` and revealing a pasted key is useful — easy to revert if you'd prefer them masked-only.
- The local `.claude/settings.json` permission change was intentionally left out of this PR.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build` (tsc + vite)
- [ ] Apply migration and manually verify invite / role change / access toggle / delete against a Supabase instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
