### PR TITLE
feat: deal health / at-risk flags ("Needs Attention")

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -67,6 +67,7 @@ from uploads and replace-on-re-upload depends on them.
 - **weekly_rtr_matrix** — the `RTR` sheet in long form (funder × payment date)
 - **funder_allocation_current** — the `R&H-ALDER-P` allocation snapshot
 - **deal_payments** — per-deal payment rows with portfolio/funder scope (Phase 5, feeds the export's payment matrix)
+- **deal_health** — at-risk flags for open, non-defaulted deals: pace ratio (% RTR collected ÷ % term elapsed), days since last payment, and `health_status` (`past_term` > `stale` > `slipping` > `on_track`, with a numeric `severity` for sorting). Thresholds are constants in the view (stale = 60 days, slipping = pace < 0.5 past 25% of term, balance epsilon $1). Feeds the dashboard's Needs Attention card and Deal Lookup's Health column.
 
 ## Functions (write paths)
 

--- a/src/__tests__/deal-explorer-service.test.ts
+++ b/src/__tests__/deal-explorer-service.test.ts
@@ -66,6 +66,10 @@ const deal = (overrides: Partial<DealRecord> = {}): DealRecord => ({
   funder_name: "BIG",
   portfolio_name: "Alder",
   status: "Active",
+  health_status: "On Track",
+  pace_ratio: 1,
+  days_since_last_payment: 10,
+  last_payment_date: "2025-06-01",
   ...overrides,
 });
 
@@ -118,6 +122,20 @@ describe("applyFilters", () => {
     ).toEqual(["1", "3"]);
     expect(applyFilters(records, filters({ funders: ["CFG"] })).map((r) => r.id)).toEqual(["3"]);
     expect(applyFilters(records, filters({ statuses: ["Defaulted"] })).map((r) => r.id)).toEqual([
+      "2",
+    ]);
+  });
+
+  it("filters by health status labels", () => {
+    const withHealth = [
+      deal({ id: "1", health_status: "Slipping" }),
+      deal({ id: "2", health_status: "On Track" }),
+      deal({ id: "3", health_status: null, status: "Closed", date_closed: "2025-02-01" }),
+    ];
+    expect(applyFilters(withHealth, filters({ health: ["Slipping"] })).map((r) => r.id)).toEqual([
+      "1",
+    ]);
+    expect(applyFilters(withHealth, filters({ health: ["On Track"] })).map((r) => r.id)).toEqual([
       "2",
     ]);
   });

--- a/src/components/dashboard/needs-attention-card.tsx
+++ b/src/components/dashboard/needs-attention-card.tsx
@@ -1,0 +1,112 @@
+import { Card, Chip, Skeleton } from "@heroui/react";
+import { Icon } from "@iconify/react";
+import {
+  formatMoney,
+  formatPct,
+  type HealthStatus,
+  type NeedsAttentionDeal,
+} from "@services/analytics-service";
+
+const STATUS_META: Record<
+  Exclude<HealthStatus, "on_track">,
+  { label: string; color: "danger" | "warning" | "secondary" }
+> = {
+  past_term: { label: "Past Term", color: "danger" },
+  stale: { label: "Stale", color: "warning" },
+  slipping: { label: "Slipping", color: "secondary" },
+};
+
+/** One line explaining why the deal is flagged. */
+function flagDetail(deal: NeedsAttentionDeal): string {
+  switch (deal.health_status) {
+    case "past_term":
+      return `term elapsed, ${formatPct(deal.pct_rtr_paid)} of RTR collected`;
+    case "stale":
+      return deal.last_payment_date != null
+        ? `no payment in ${deal.days_since_last_payment} days`
+        : `no payment ever, funded ${deal.days_since_last_payment} days ago`;
+    case "slipping":
+      return `${formatPct(deal.pct_rtr_paid)} collected at ${formatPct(
+        deal.pct_term_elapsed ?? 0
+      )} of term`;
+    default:
+      return "";
+  }
+}
+
+const NeedsAttentionCard = ({
+  deals,
+  loading,
+}: {
+  deals: NeedsAttentionDeal[];
+  loading: boolean;
+}) => {
+  if (loading) {
+    return (
+      <Card className="dark:border-default-100 border border-transparent mb-6">
+        <div className="p-4">
+          <Skeleton className="rounded-lg mb-4">
+            <div className="h-4 w-48 bg-default-200"></div>
+          </Skeleton>
+          <Skeleton className="rounded-lg">
+            <div className="h-24 w-full bg-default-200"></div>
+          </Skeleton>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="dark:border-default-100 border border-transparent mb-6">
+      <div className="flex items-center gap-2 p-4 pb-0">
+        <Icon icon="solar:danger-triangle-bold" className="text-warning" width={18} />
+        <h3 className="text-small text-default-500 font-medium">Needs Attention</h3>
+        {deals.length > 0 && (
+          <Chip size="sm" variant="flat" color="warning">
+            {deals.length}
+          </Chip>
+        )}
+      </div>
+
+      {deals.length === 0 ? (
+        <div className="p-4 pt-3 flex items-center gap-2 text-default-400">
+          <Icon icon="solar:check-circle-bold" className="text-success" width={18} />
+          <span className="text-small">All open deals are on pace.</span>
+        </div>
+      ) : (
+        <div className="p-4 pt-2 max-h-[320px] overflow-y-auto">
+          <ul className="divide-y divide-default-100">
+            {deals.map((deal) => {
+              const meta = STATUS_META[deal.health_status as keyof typeof STATUS_META];
+              if (!meta) return null;
+              return (
+                <li key={deal.id} className="flex items-center gap-3 py-2">
+                  <Chip size="sm" variant="flat" color={meta.color} className="shrink-0">
+                    {meta.label}
+                  </Chip>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-small font-medium truncate">
+                      {deal.merchant_name ?? deal.funder_advance_id ?? deal.id}
+                      {deal.funder_name != null && (
+                        <span className="text-default-400 font-normal"> · {deal.funder_name}</span>
+                      )}
+                    </p>
+                    <p className="text-tiny text-default-400 truncate">{flagDetail(deal)}</p>
+                  </div>
+                  <div className="text-right shrink-0">
+                    <p className="text-small font-semibold">
+                      {formatMoney(deal.net_rtr_balance ?? 0)}
+                    </p>
+                    <p className="text-tiny text-default-400">outstanding</p>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default NeedsAttentionCard;

--- a/src/components/deal-explorer/explorer-table.tsx
+++ b/src/components/deal-explorer/explorer-table.tsx
@@ -37,6 +37,15 @@ const statusColor = (status: string) =>
       ? ("default" as const)
       : ("success" as const);
 
+const healthColor = (health: string) =>
+  health === "Past Term"
+    ? ("danger" as const)
+    : health === "Stale"
+      ? ("warning" as const)
+      : health === "Slipping"
+        ? ("secondary" as const)
+        : ("success" as const);
+
 function compareValues(a: unknown, b: unknown): number {
   if (a == null && b == null) return 0;
   if (a == null) return 1; // nulls last
@@ -205,6 +214,19 @@ const ExplorerTable = ({
                         <Chip size="sm" variant="flat" color={statusColor(record.status)}>
                           {record.status}
                         </Chip>
+                      </TableCell>
+                    );
+                  }
+                  if (def?.key === "health_status") {
+                    return (
+                      <TableCell>
+                        {record.health_status != null ? (
+                          <Chip size="sm" variant="flat" color={healthColor(record.health_status)}>
+                            {record.health_status}
+                          </Chip>
+                        ) : (
+                          "—"
+                        )}
                       </TableCell>
                     );
                   }

--- a/src/components/deal-explorer/filter-panel.tsx
+++ b/src/components/deal-explorer/filter-panel.tsx
@@ -6,6 +6,7 @@ import {
   formatFieldValue,
   DEAL_FIELDS,
   EMPTY_FILTERS,
+  HEALTH_OPTIONS,
   OPERATORS_BY_TYPE,
   OPERATOR_LABELS,
   type ExplorerFilters,
@@ -249,6 +250,12 @@ const FilterPanel = ({
             options={STATUS_OPTIONS}
             selected={filters.statuses}
             onChange={(statuses) => onChange({ ...filters, statuses })}
+          />
+          <MultiSelect
+            label="Health"
+            options={HEALTH_OPTIONS}
+            selected={filters.health}
+            onChange={(health) => onChange({ ...filters, health })}
           />
           <MonthSelect
             label="Vintage from"

--- a/src/hooks/use-dashboard-analytics.ts
+++ b/src/hooks/use-dashboard-analytics.ts
@@ -3,6 +3,7 @@ import {
   listPortfolios,
   getPortfolioAnalytics,
   getFunderDeals,
+  getNeedsAttention,
   computeKpis,
   aggregateMonthlyByVintage,
   buildAllocationsByMonth,
@@ -19,6 +20,7 @@ import {
   type PortfolioAnalytics,
   type MonthlyStatsRow,
   type FunderDealRow,
+  type NeedsAttentionDeal,
 } from "@services/analytics-service";
 
 /**
@@ -32,6 +34,10 @@ export function useDashboardAnalytics() {
   const [analytics, setAnalytics] = useState<PortfolioAnalytics | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // At-risk deals for the Needs Attention card (deal_health, severity > 0)
+  const [attention, setAttention] = useState<NeedsAttentionDeal[]>([]);
+  const [attentionLoading, setAttentionLoading] = useState(true);
 
   // Funder drill-down (set by clicking a funder in a legend / pie / bar)
   const [funderId, setFunderId] = useState<number | null>(null);
@@ -69,6 +75,27 @@ export function useDashboardAnalytics() {
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selection]);
+
+  useEffect(() => {
+    if (selection == null) return;
+    let cancelled = false;
+    setAttentionLoading(true);
+    getNeedsAttention(selection)
+      .then((rows) => {
+        if (!cancelled) setAttention(rows);
+      })
+      .catch(() => {
+        // Non-critical card — on failure show the empty state rather than
+        // blocking the dashboard with a second error banner.
+        if (!cancelled) setAttention([]);
+      })
+      .finally(() => {
+        if (!cancelled) setAttentionLoading(false);
       });
     return () => {
       cancelled = true;
@@ -137,6 +164,12 @@ export function useDashboardAnalytics() {
     if (!analytics) return [];
     return funderId != null ? analytics.rtr.filter((r) => r.funder_id === funderId) : analytics.rtr;
   }, [analytics, funderId]);
+
+  // The card follows the funder drill-down like every other chart.
+  const needsAttention = useMemo(
+    () => (funderId != null ? attention.filter((d) => d.funder_id === funderId) : attention),
+    [attention, funderId]
+  );
 
   const kpis = useMemo(() => computeKpis(monthlyRows), [monthlyRows]);
   const allocations = useMemo(
@@ -268,6 +301,8 @@ export function useDashboardAnalytics() {
     deals,
     dealsLoading,
     dealsError,
+    needsAttention,
+    attentionLoading,
     onFunderClick,
   };
 }

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -12,6 +12,7 @@ import {
   TermVsFactorCard,
 } from "@components/dashboard/charts";
 import FunderDealsTable from "@components/dashboard/funder-deals-table";
+import NeedsAttentionCard from "@components/dashboard/needs-attention-card";
 import { useDashboardAnalytics } from "@/hooks/use-dashboard-analytics";
 
 const ALL_PORTFOLIOS_KEY = "all";
@@ -39,6 +40,8 @@ function Dashboard() {
     deals,
     dealsLoading,
     dealsError,
+    needsAttention,
+    attentionLoading,
     onFunderClick,
   } = useDashboardAnalytics();
 
@@ -123,6 +126,9 @@ function Dashboard() {
           <KpiCard key={item.title} {...item} loading={loading} />
         ))}
       </div>
+
+      {/* At-risk deals flagged by the deal_health view, worst first */}
+      <NeedsAttentionCard deals={needsAttention} loading={attentionLoading} />
 
       {/* Allocations / cost basis by vintage month */}
       <AllocationsByMonthCard

--- a/src/services/analytics-service.ts
+++ b/src/services/analytics-service.ts
@@ -7,6 +7,8 @@ export type MonthlyVintageRow = Views["monthly_vintage_stats"]["Row"];
 export type FunderAllocationRow = Views["funder_allocation_current"]["Row"];
 export type WeeklyRtrRow = Views["weekly_rtr_matrix"]["Row"];
 export type DealComputedRow = Views["deal_computed"]["Row"];
+export type DealHealthRow = Views["deal_health"]["Row"];
+export type HealthStatus = DealHealthRow["health_status"];
 
 export interface PortfolioOption {
   id: number;
@@ -154,6 +156,42 @@ export async function getFunderDeals(
     ...d,
     merchant_name: d.merchant_id != null ? (names.get(d.merchant_id) ?? null) : null,
   }));
+}
+
+/** A flagged deal_health row with its lookups, for the Needs Attention card. */
+export interface NeedsAttentionDeal extends DealHealthRow {
+  merchant_name: string | null;
+  funder_name: string | null;
+}
+
+/**
+ * Flagged deals (severity > 0) in scope, worst first: past_term before stale
+ * before slipping, most dollars outstanding first within a status.
+ */
+export async function getNeedsAttention(
+  selection: PortfolioSelection
+): Promise<NeedsAttentionDeal[]> {
+  const scope = <T extends { eq: (col: string, v: number) => T }>(query: T): T =>
+    selection === "all" ? query : query.eq("portfolio_id", selection);
+
+  const [rows, merchants, funderNames] = await Promise.all([
+    fetchAllPages<DealHealthRow>((from, to) =>
+      scope(supabase.from("deal_health").select("*")).gt("severity", 0).order("id").range(from, to)
+    ),
+    fetchAllPages<{ id: string; name: string }>((from, to) =>
+      scope(supabase.from("merchants").select("id, name")).order("id").range(from, to)
+    ),
+    getFunderNames(),
+  ]);
+
+  const merchantNames = new Map(merchants.map((m) => [m.id, m.name]));
+  return rows
+    .map((row) => ({
+      ...row,
+      merchant_name: row.merchant_id != null ? (merchantNames.get(row.merchant_id) ?? null) : null,
+      funder_name: row.funder_id != null ? (funderNames[row.funder_id] ?? null) : null,
+    }))
+    .sort((a, b) => b.severity - a.severity || (b.net_rtr_balance ?? 0) - (a.net_rtr_balance ?? 0));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/deal-explorer-service.ts
+++ b/src/services/deal-explorer-service.ts
@@ -6,8 +6,21 @@ import type { Database } from "./supabase.types";
 import { formatMonth } from "./analytics-service";
 
 type DealComputedRow = Database["public"]["Views"]["deal_computed"]["Row"];
+type DealHealthRow = Database["public"]["Views"]["deal_health"]["Row"];
 
 export type DealStatus = "Active" | "Closed" | "Defaulted";
+
+export type HealthLabel = "On Track" | "Slipping" | "Stale" | "Past Term";
+
+/** Display labels for deal_health statuses, worst first. */
+export const HEALTH_LABELS: Record<DealHealthRow["health_status"], HealthLabel> = {
+  past_term: "Past Term",
+  stale: "Stale",
+  slipping: "Slipping",
+  on_track: "On Track",
+};
+
+export const HEALTH_OPTIONS: HealthLabel[] = ["Past Term", "Stale", "Slipping", "On Track"];
 
 /** A deal_computed row flattened with its lookups, ready for filtering/grouping. */
 export interface DealRecord extends DealComputedRow {
@@ -18,6 +31,11 @@ export interface DealRecord extends DealComputedRow {
   funder_name: string | null;
   portfolio_name: string | null;
   status: DealStatus;
+  /** null for closed/defaulted deals — deal_health only covers open deals. */
+  health_status: HealthLabel | null;
+  pace_ratio: number | null;
+  days_since_last_payment: number | null;
+  last_payment_date: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -82,6 +100,10 @@ export const DEAL_FIELDS: FieldDef[] = [
   { key: "total_net_received", label: "Net Received", type: "money", defaultVisible: true },
   { key: "net_rtr_balance", label: "Net RTR Balance", type: "money", defaultVisible: true },
   { key: "pct_rtr_paid", label: "% RTR Paid", type: "percent", defaultVisible: true },
+  { key: "health_status", label: "Health", type: "text", dimension: true, defaultVisible: true },
+  { key: "pace_ratio", label: "Pace Ratio", type: "number" },
+  { key: "days_since_last_payment", label: "Days Since Payment", type: "number" },
+  { key: "last_payment_date", label: "Last Payment", type: "date" },
   { key: "return_on_cost_basis", label: "Return on Cost Basis", type: "percent" },
   { key: "bad_debt_rtr", label: "Bad Debt RTR", type: "money" },
   { key: "default_dollars_lost", label: "Default $ Lost", type: "money" },
@@ -164,11 +186,23 @@ function dealStatus(deal: DealComputedRow): DealStatus {
   return "Active";
 }
 
+type HealthFields = Pick<
+  DealHealthRow,
+  "id" | "health_status" | "pace_ratio" | "days_since_last_payment" | "last_payment_date"
+>;
+
 /** Every deal visible to the user (RLS scopes reads), flattened with lookups. */
 export async function getDealRecords(): Promise<DealRecord[]> {
-  const [deals, merchants, industries, states, funders, portfolios] = await Promise.all([
+  const [deals, health, merchants, industries, states, funders, portfolios] = await Promise.all([
     fetchAllPages<DealComputedRow>((from, to) =>
       supabase.from("deal_computed").select("*").order("date_funded").range(from, to)
+    ),
+    fetchAllPages<HealthFields>((from, to) =>
+      supabase
+        .from("deal_health")
+        .select("id, health_status, pace_ratio, days_since_last_payment, last_payment_date")
+        .order("id")
+        .range(from, to)
     ),
     fetchAllPages<MerchantLookupRow>((from, to) =>
       supabase
@@ -192,9 +226,11 @@ export async function getDealRecords(): Promise<DealRecord[]> {
   const funderNames = new Map((funders.data ?? []).map((f) => [f.id, f.name]));
   const portfolioNames = new Map((portfolios.data ?? []).map((p) => [p.id, p.name]));
   const merchantsById = new Map(merchants.map((m) => [m.id, m]));
+  const healthById = new Map(health.map((h) => [h.id, h]));
 
   return deals.map((deal) => {
     const merchant = deal.merchant_id != null ? merchantsById.get(deal.merchant_id) : undefined;
+    const dealHealth = healthById.get(deal.id);
     return {
       ...deal,
       merchant_name: merchant?.name ?? null,
@@ -206,6 +242,10 @@ export async function getDealRecords(): Promise<DealRecord[]> {
       portfolio_name:
         deal.portfolio_id != null ? (portfolioNames.get(deal.portfolio_id) ?? null) : null,
       status: dealStatus(deal),
+      health_status: dealHealth != null ? HEALTH_LABELS[dealHealth.health_status] : null,
+      pace_ratio: dealHealth?.pace_ratio ?? null,
+      days_since_last_payment: dealHealth?.days_since_last_payment ?? null,
+      last_payment_date: dealHealth?.last_payment_date ?? null,
     };
   });
 }
@@ -266,6 +306,8 @@ export interface ExplorerFilters {
   industries: string[];
   states: string[];
   statuses: string[];
+  /** Health status labels ("Past Term", "Stale", …). */
+  health: string[];
   /** Vintage month range, "YYYY-MM" keys. */
   monthFrom: string | null;
   monthTo: string | null;
@@ -279,6 +321,7 @@ export const EMPTY_FILTERS: ExplorerFilters = {
   industries: [],
   states: [],
   statuses: [],
+  health: [],
   monthFrom: null,
   monthTo: null,
   rules: [],
@@ -292,6 +335,7 @@ export function countActiveFilters(filters: ExplorerFilters): number {
   if (filters.industries.length > 0) count++;
   if (filters.states.length > 0) count++;
   if (filters.statuses.length > 0) count++;
+  if (filters.health.length > 0) count++;
   if (filters.monthFrom != null || filters.monthTo != null) count++;
   count += filters.rules.length;
   return count;
@@ -375,6 +419,7 @@ export function applyFilters(records: DealRecord[], filters: ExplorerFilters): D
   const industries = new Set(filters.industries);
   const states = new Set(filters.states);
   const statuses = new Set(filters.statuses);
+  const health = new Set(filters.health);
 
   return records.filter((r) => {
     if (needle) {
@@ -389,6 +434,7 @@ export function applyFilters(records: DealRecord[], filters: ExplorerFilters): D
     if (industries.size > 0 && !industries.has(r.industry ?? "")) return false;
     if (states.size > 0 && !states.has(r.state ?? "")) return false;
     if (statuses.size > 0 && !statuses.has(r.status)) return false;
+    if (health.size > 0 && !health.has(r.health_status ?? "")) return false;
     const month = monthOf(r);
     if (filters.monthFrom != null && (month == null || month < filters.monthFrom)) return false;
     if (filters.monthTo != null && (month == null || month > filters.monthTo)) return false;

--- a/src/services/supabase.types.ts
+++ b/src/services/supabase.types.ts
@@ -815,6 +815,30 @@ export interface Database {
         };
         Relationships: [];
       };
+      deal_health: {
+        Row: {
+          id: string;
+          portfolio_id: number | null;
+          funder_id: number | null;
+          merchant_id: string | null;
+          advance_id: string | null;
+          funder_advance_id: string | null;
+          date_funded: string | null;
+          term_months: number | null;
+          net_rtr: number | null;
+          total_net_received: number;
+          net_rtr_balance: number | null;
+          pct_rtr_paid: number;
+          last_payment_date: string | null;
+          days_since_last_payment: number | null;
+          months_elapsed: number | null;
+          pct_term_elapsed: number | null;
+          pace_ratio: number | null;
+          health_status: "past_term" | "stale" | "slipping" | "on_track";
+          severity: number;
+        };
+        Relationships: [];
+      };
       funder_allocation_current: {
         Row: {
           portfolio_id: number | null;

--- a/supabase/migrations/20260719000000_deal_health_view.sql
+++ b/supabase/migrations/20260719000000_deal_health_view.sql
@@ -1,0 +1,85 @@
+-- deal_health: proactive at-risk flags for open deals ("Needs Attention").
+--
+-- A deal's expected collection pace is linear over its term; comparing the
+-- fraction of net RTR collected against the fraction of term elapsed flags
+-- deals that are quietly going bad long before they are marked default.
+--
+-- Statuses (checked in severity order, first match wins):
+--   * past_term (3) — term fully elapsed with net RTR still outstanding
+--   * stale     (2) — no payment recorded in STALE_DAYS+ days (measured from
+--                     date_funded when the deal has never paid)
+--   * slipping  (1) — at least SLIPPING_MIN_ELAPSED through the term but the
+--                     collected fraction is below SLIPPING_PACE × the elapsed
+--                     fraction (e.g. 60% through term, under 30% collected)
+--   * on_track  (0)
+--
+-- Thresholds are constants for now (candidates for per-portfolio settings):
+--   STALE_DAYS = 60, SLIPPING_MIN_ELAPSED = 0.25, SLIPPING_PACE = 0.5,
+--   BALANCE_EPSILON = $1 (deals with no meaningful balance are on_track).
+--
+-- Scope: open, non-defaulted deals only — closed deals need no attention and
+-- defaulted deals are already flagged (bad debt). Building on deal_computed
+-- inherits its soft-delete filter; security_invoker keeps RLS on the reader.
+CREATE VIEW deal_health
+WITH (security_invoker = true) AS
+WITH last_pay AS (
+  SELECT deal_id, MAX(payment_date) AS last_payment_date
+  FROM net_rtr_payments
+  GROUP BY deal_id
+),
+base AS (
+  SELECT
+    dc.id,
+    dc.portfolio_id,
+    dc.funder_id,
+    dc.merchant_id,
+    dc.advance_id,
+    dc.funder_advance_id,
+    dc.date_funded,
+    dc.term_months,
+    dc.net_rtr,
+    dc.total_net_received,
+    dc.net_rtr_balance,
+    dc.pct_rtr_paid,
+    lp.last_payment_date,
+    -- date_funded is timestamptz; cast so date - date yields integer days
+    (CURRENT_DATE - COALESCE(lp.last_payment_date, dc.date_funded::date))
+      AS days_since_last_payment,
+    -- calendar days → the sheet's fractional months
+    (CURRENT_DATE - dc.date_funded::date) / 30.44 AS months_elapsed
+  FROM deal_computed dc
+  LEFT JOIN last_pay lp ON lp.deal_id = dc.id
+  WHERE dc.date_closed IS NULL AND NOT dc.is_default
+),
+pace AS (
+  SELECT
+    b.*,
+    -- capped at 1: past the term end the question is only "is it paid off"
+    LEAST(b.months_elapsed / NULLIF(b.term_months, 0), 1) AS pct_term_elapsed,
+    -- 1.0 = exactly on schedule, below 1 = behind, above 1 = ahead
+    b.pct_rtr_paid
+      / NULLIF(LEAST(b.months_elapsed / NULLIF(b.term_months, 0), 1), 0)
+      AS pace_ratio
+  FROM base b
+),
+flagged AS (
+  SELECT
+    p.*,
+    CASE
+      WHEN COALESCE(p.net_rtr_balance, 0) <= 1 THEN 'on_track'
+      WHEN p.pct_term_elapsed >= 1 THEN 'past_term'
+      WHEN p.days_since_last_payment >= 60 THEN 'stale'
+      WHEN p.pct_term_elapsed >= 0.25 AND p.pace_ratio < 0.5 THEN 'slipping'
+      ELSE 'on_track'
+    END AS health_status
+  FROM pace p
+)
+SELECT
+  f.*,
+  CASE f.health_status
+    WHEN 'past_term' THEN 3
+    WHEN 'stale' THEN 2
+    WHEN 'slipping' THEN 1
+    ELSE 0
+  END AS severity
+FROM flagged f;


### PR DESCRIPTION
Closes #56

## What

Adds a proactive deal-health signal computed from expected vs. actual collection pace, per the issue:

- **`deal_health` view** (`security_invoker`, built on `deal_computed` + `net_rtr_payments`): per open, non-defaulted deal — `pct_term_elapsed`, `pace_ratio` (% RTR collected ÷ % term elapsed), `days_since_last_payment`, and a `health_status` with numeric `severity` for worst-first sorting.
  - `past_term` (3) — term fully elapsed with net RTR still outstanding
  - `stale` (2) — no payment recorded in 60+ days (from `date_funded` if never paid)
  - `slipping` (1) — ≥ 25% through term with collected fraction under half the elapsed fraction
  - Deals with ≤ $1 outstanding are `on_track`; closed/defaulted deals are excluded entirely.
- **Dashboard**: a "Needs Attention" card listing flagged deals worst first (severity, then dollars outstanding), scoped to the selected portfolio and the funder drill-down.
- **Deal Lookup**: a Health chip column (default-visible), a Health multi-select filter, and `health_status` as a pivot/chart dimension; `pace_ratio`, `days_since_last_payment`, and `last_payment_date` are available as columns and rule filters.

Thresholds are constants in the view SQL, documented in the migration header as candidates for per-portfolio settings later.

## Verification

- Migration applied to the local stack; smoke-tested every status branch with synthetic deals (rolled back): each of past_term / stale / slipping / on_track / paid-off fires correctly, precedence holds (past_term wins over stale), closed + defaulted deals excluded.
- Migration pushed to the linked Supabase project (`supabase db push`) — additive view, no data changes.
- `npm run lint`, `npm run format:check`, `npm run build`, and the vitest suite (52 tests, incl. new health-filter tests) all pass. No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)