### PR TITLE
feat: add AI-generated monthly portfolio commentary

### DIFF
--- a/src/components/ai-chat/chat-message-view.tsx
+++ b/src/components/ai-chat/chat-message-view.tsx
@@ -48,7 +48,7 @@ const markdownComponents: Components = {
   ),
 };
 
-function Markdown({ text }: { text: string }) {
+export function Markdown({ text }: { text: string }) {
   return (
     <div className="text-small leading-relaxed">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>

--- a/src/components/dashboard/commentary-modal.tsx
+++ b/src/components/dashboard/commentary-modal.tsx
@@ -1,0 +1,371 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ScrollShadow,
+  Select,
+  SelectItem,
+  Spinner,
+  Tab,
+  Tabs,
+  Textarea,
+  Tooltip,
+} from "@heroui/react";
+import { Icon } from "@iconify/react";
+import { save } from "@tauri-apps/plugin-dialog";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import { downloadDir } from "@tauri-apps/api/path";
+
+import {
+  apiKeyFor,
+  getAiSettings,
+  modelFor,
+  PROVIDER_LABELS,
+  providerNeedsApiKey,
+  type AiChatEvent,
+  type AiSettings,
+} from "@services/ai-chat-service";
+import {
+  buildCommentaryPrompt,
+  commentaryMonths,
+  formatMonthLong,
+  generateCommentary,
+  loadCommentarySeed,
+  type CommentarySeed,
+} from "@services/commentary-service";
+import type { PortfolioOption, PortfolioSelection } from "@services/analytics-service";
+import { toast } from "@services/toast-service";
+import { LiveMessageView, Markdown, type LiveSegment } from "@components/ai-chat/chat-message-view";
+import { ProviderSettingsModal } from "@components/ai-chat/provider-settings-modal";
+
+const ALL_KEY = "all";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  portfolios: PortfolioOption[];
+  /** The dashboard's current scope, used as the initial pick. */
+  initialSelection: PortfolioSelection | null;
+}
+
+/**
+ * "Generate monthly commentary" (issue #59): portfolio + month pickers, the
+ * streamed draft, then an editable markdown result with copy/export.
+ */
+export function CommentaryModal({ isOpen, onClose, portfolios, initialSelection }: Props) {
+  const [selection, setSelection] = useState<PortfolioSelection>(initialSelection ?? "all");
+  const [seed, setSeed] = useState<CommentarySeed | null>(null);
+  const [seedLoading, setSeedLoading] = useState(false);
+  const [month, setMonth] = useState<string | null>(null);
+
+  const [settings, setSettings] = useState<AiSettings | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const [generating, setGenerating] = useState(false);
+  const [liveSegments, setLiveSegments] = useState<LiveSegment[]>([]);
+  const [draft, setDraft] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const scopeLabel = useMemo(() => {
+    if (selection === "all") return "All Portfolios";
+    return portfolios.find((p) => p.id === selection)?.name ?? "Portfolio";
+  }, [selection, portfolios]);
+
+  // Reset to the dashboard's scope each time the modal opens.
+  useEffect(() => {
+    if (isOpen) {
+      setSelection(initialSelection ?? "all");
+      setDraft(null);
+      setLiveSegments([]);
+    }
+  }, [isOpen, initialSelection]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    getAiSettings()
+      .then(setSettings)
+      .catch((error) => toast.error("Failed to load AI settings", String(error)));
+  }, [isOpen]);
+
+  // (Re)load the seed data whenever the scope changes while open.
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setSeedLoading(true);
+    setSeed(null);
+    setMonth(null);
+    loadCommentarySeed(selection, scopeLabel)
+      .then((loaded) => {
+        if (cancelled) return;
+        setSeed(loaded);
+        setMonth(commentaryMonths(loaded)[0] ?? null);
+      })
+      .catch((error) => {
+        if (!cancelled) toast.error("Failed to load portfolio data", String(error));
+      })
+      .finally(() => {
+        if (!cancelled) setSeedLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, selection, scopeLabel]);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [liveSegments]);
+
+  const provider = settings?.default_provider ?? "anthropic";
+  const model = settings ? modelFor(settings, provider) : "";
+  const needsSetup =
+    !settings || (providerNeedsApiKey(provider) && !apiKeyFor(settings, provider)) || !model.trim();
+
+  const months = seed ? commentaryMonths(seed) : [];
+
+  const onEvent = useCallback((event: AiChatEvent) => {
+    setLiveSegments((prev) => {
+      if (event.type === "text_delta") {
+        const last = prev[prev.length - 1];
+        if (last?.type === "text") {
+          return [...prev.slice(0, -1), { type: "text", text: last.text + event.text }];
+        }
+        return [...prev, { type: "text", text: event.text }];
+      }
+      if (event.type === "tool_call") {
+        return [...prev, { type: "tool", id: event.id, name: event.name, status: "running" }];
+      }
+      if (event.type === "tool_result") {
+        return prev.map((segment) =>
+          segment.type === "tool" && segment.id === event.id
+            ? { ...segment, status: event.is_error ? "error" : "done" }
+            : segment
+        );
+      }
+      return prev;
+    });
+  }, []);
+
+  const handleGenerate = async () => {
+    if (!seed || !month || generating) return;
+    if (needsSetup) {
+      toast.warning(
+        "No AI provider configured",
+        `Add your ${PROVIDER_LABELS[provider]} API key and model first.`
+      );
+      setSettingsOpen(true);
+      return;
+    }
+
+    setGenerating(true);
+    setDraft(null);
+    setLiveSegments([]);
+    try {
+      const prompt = buildCommentaryPrompt(seed, month);
+      const text = await generateCommentary({ provider, model, prompt, onEvent });
+      setDraft(text);
+    } catch (error) {
+      toast.error("Commentary generation failed", String(error));
+    } finally {
+      setGenerating(false);
+      setLiveSegments([]);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!draft) return;
+    try {
+      await navigator.clipboard.writeText(draft);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard access can fail silently; nothing actionable for the user.
+    }
+  };
+
+  const handleExport = async () => {
+    if (!draft || !month) return;
+    try {
+      const name = `${scopeLabel.replace(/\s+/g, "_")}_Commentary_${month}.md`;
+      const filePath = await save({
+        defaultPath: `${await downloadDir()}/${name}`,
+        filters: [{ name: "Markdown", extensions: ["md"] }],
+      });
+      if (!filePath) return;
+      await writeTextFile(filePath, draft);
+      toast.success("Commentary exported", filePath);
+    } catch (error) {
+      toast.error("Export failed", String(error));
+    }
+  };
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={onClose} size="4xl" scrollBehavior="inside">
+        <ModalContent>
+          <ModalHeader className="flex items-center gap-2">
+            <Icon icon="solar:document-text-outline" width={20} />
+            Monthly Commentary
+          </ModalHeader>
+          <ModalBody className="gap-4">
+            <div className="flex flex-wrap items-end gap-3">
+              <Select
+                label="Portfolio"
+                size="sm"
+                className="w-52"
+                selectedKeys={[selection === "all" ? ALL_KEY : String(selection)]}
+                onSelectionChange={(keys) => {
+                  const key = Array.from(keys)[0];
+                  if (key == null) return;
+                  setSelection(key === ALL_KEY ? "all" : Number(key));
+                }}
+                isDisabled={generating}
+              >
+                {[
+                  <SelectItem key={ALL_KEY}>All Portfolios</SelectItem>,
+                  ...portfolios.map((p) => <SelectItem key={String(p.id)}>{p.name}</SelectItem>),
+                ]}
+              </Select>
+              <Select
+                label="Month"
+                size="sm"
+                className="w-44"
+                placeholder={seedLoading ? "Loading…" : "No data"}
+                selectedKeys={month ? [month] : []}
+                onSelectionChange={(keys) => {
+                  const key = Array.from(keys)[0];
+                  if (key != null) setMonth(String(key));
+                }}
+                isDisabled={generating || seedLoading || months.length === 0}
+              >
+                {months.map((m) => (
+                  <SelectItem key={m}>{formatMonthLong(m)}</SelectItem>
+                ))}
+              </Select>
+              <Button
+                color="primary"
+                startContent={!generating && <Icon icon="solar:magic-stick-3-outline" width={18} />}
+                onPress={handleGenerate}
+                isLoading={generating}
+                isDisabled={seedLoading || !seed || !month}
+              >
+                {draft ? "Regenerate" : "Generate"}
+              </Button>
+              <div className="flex flex-1 items-center justify-end gap-1">
+                <span className="text-tiny text-default-400">
+                  {needsSetup
+                    ? "AI provider not configured"
+                    : `${PROVIDER_LABELS[provider]} · ${model}`}
+                </span>
+                <Tooltip content="AI provider settings">
+                  <Button
+                    isIconOnly
+                    size="sm"
+                    variant="light"
+                    onPress={() => setSettingsOpen(true)}
+                    aria-label="AI settings"
+                  >
+                    <Icon icon="solar:settings-outline" width={18} />
+                  </Button>
+                </Tooltip>
+              </div>
+            </div>
+
+            {generating && (
+              <ScrollShadow
+                ref={scrollRef}
+                className="max-h-[50vh] rounded-medium border border-default-200 p-4"
+              >
+                <LiveMessageView segments={liveSegments} />
+              </ScrollShadow>
+            )}
+
+            {!generating && draft != null && (
+              <Tabs aria-label="Commentary view" size="sm">
+                <Tab key="preview" title="Preview">
+                  <ScrollShadow className="max-h-[50vh] rounded-medium border border-default-200 p-4">
+                    <Markdown text={draft} />
+                  </ScrollShadow>
+                </Tab>
+                <Tab key="edit" title="Edit">
+                  <Textarea
+                    aria-label="Edit commentary markdown"
+                    value={draft}
+                    onValueChange={setDraft}
+                    minRows={14}
+                    maxRows={22}
+                    classNames={{ input: "font-mono text-xs" }}
+                  />
+                </Tab>
+              </Tabs>
+            )}
+
+            {!generating && draft == null && (
+              <div className="flex flex-col items-center gap-2 rounded-medium border border-dashed border-default-200 py-10 text-center">
+                {seedLoading ? (
+                  <Spinner size="sm" label="Loading portfolio data…" labelColor="foreground" />
+                ) : (
+                  <>
+                    <Icon
+                      icon="solar:document-add-outline"
+                      width={36}
+                      className="text-default-300"
+                    />
+                    <p className="max-w-md text-small text-default-500">
+                      Drafts LP-letter commentary for the selected month — portfolio overview,
+                      vintage performance, collections vs. prior month, notable deals and
+                      concentration — from your live portfolio data.
+                    </p>
+                  </>
+                )}
+              </div>
+            )}
+          </ModalBody>
+          <ModalFooter>
+            {draft != null && !generating && (
+              <>
+                <Button
+                  variant="flat"
+                  startContent={
+                    <Icon
+                      icon={copied ? "solar:check-read-outline" : "solar:copy-outline"}
+                      width={16}
+                    />
+                  }
+                  onPress={handleCopy}
+                >
+                  {copied ? "Copied" : "Copy"}
+                </Button>
+                <Button
+                  variant="flat"
+                  startContent={<Icon icon="solar:download-outline" width={16} />}
+                  onPress={handleExport}
+                >
+                  Export .md
+                </Button>
+              </>
+            )}
+            <Button variant="light" onPress={onClose}>
+              Close
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      {settings && (
+        <ProviderSettingsModal
+          isOpen={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+          settings={settings}
+          onSaved={setSettings}
+        />
+      )}
+    </>
+  );
+}
+
+export default CommentaryModal;

--- a/src/components/dashboard/commentary-modal.tsx
+++ b/src/components/dashboard/commentary-modal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { RefObject } from "react";
 import {
   Button,
   Modal,
@@ -16,31 +16,13 @@ import {
   Tooltip,
 } from "@heroui/react";
 import { Icon } from "@iconify/react";
-import { save } from "@tauri-apps/plugin-dialog";
-import { writeTextFile } from "@tauri-apps/plugin-fs";
-import { downloadDir } from "@tauri-apps/api/path";
 
-import {
-  apiKeyFor,
-  getAiSettings,
-  modelFor,
-  PROVIDER_LABELS,
-  providerNeedsApiKey,
-  type AiChatEvent,
-  type AiSettings,
-} from "@services/ai-chat-service";
-import {
-  buildCommentaryPrompt,
-  commentaryMonths,
-  formatMonthLong,
-  generateCommentary,
-  loadCommentarySeed,
-  type CommentarySeed,
-} from "@services/commentary-service";
+import { PROVIDER_LABELS } from "@services/ai-chat-service";
+import { formatMonthLong } from "@services/commentary-service";
 import type { PortfolioOption, PortfolioSelection } from "@services/analytics-service";
-import { toast } from "@services/toast-service";
 import { LiveMessageView, Markdown, type LiveSegment } from "@components/ai-chat/chat-message-view";
 import { ProviderSettingsModal } from "@components/ai-chat/provider-settings-modal";
+import { useCommentary } from "@/hooks/use-commentary";
 
 const ALL_KEY = "all";
 
@@ -48,8 +30,153 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   portfolios: PortfolioOption[];
-  /** The dashboard's current scope, used as the initial pick. */
+  /**
+   * The dashboard's scope when the modal opened. The dashboard remounts the
+   * modal (React key) on each open, so this only needs to be right at mount.
+   */
   initialSelection: PortfolioSelection | null;
+}
+
+/** The pickers + Generate row and the provider indicator. */
+function ScopeBar({
+  portfolios,
+  commentary,
+}: {
+  portfolios: PortfolioOption[];
+  commentary: ReturnType<typeof useCommentary>;
+}) {
+  const c = commentary;
+  return (
+    <div className="flex flex-wrap items-end gap-3">
+      <Select
+        label="Portfolio"
+        size="sm"
+        className="w-52"
+        selectedKeys={[c.selection === "all" ? ALL_KEY : String(c.selection)]}
+        onSelectionChange={(keys) => {
+          const key = Array.from(keys)[0];
+          if (key == null) return;
+          c.setSelection(key === ALL_KEY ? "all" : Number(key));
+        }}
+        isDisabled={c.generating}
+      >
+        {[
+          <SelectItem key={ALL_KEY}>All Portfolios</SelectItem>,
+          ...portfolios.map((p) => <SelectItem key={String(p.id)}>{p.name}</SelectItem>),
+        ]}
+      </Select>
+      <Select
+        label="Month"
+        size="sm"
+        className="w-44"
+        placeholder={c.seedLoading ? "Loading…" : "No data"}
+        selectedKeys={c.month ? [c.month] : []}
+        onSelectionChange={(keys) => {
+          const key = Array.from(keys)[0];
+          if (key != null) c.setMonth(String(key));
+        }}
+        isDisabled={c.generating || c.seedLoading || c.months.length === 0}
+      >
+        {c.months.map((m) => (
+          <SelectItem key={m}>{formatMonthLong(m)}</SelectItem>
+        ))}
+      </Select>
+      <Button
+        color="primary"
+        startContent={!c.generating && <Icon icon="solar:magic-stick-3-outline" width={18} />}
+        onPress={c.handleGenerate}
+        isLoading={c.generating}
+        isDisabled={c.seedLoading || !c.seed || !c.month}
+      >
+        {c.draft ? "Regenerate" : "Generate"}
+      </Button>
+      <div className="flex flex-1 items-center justify-end gap-1">
+        <span className="text-tiny text-default-400">
+          {c.needsSetup
+            ? "AI provider not configured"
+            : `${PROVIDER_LABELS[c.provider]} · ${c.model}`}
+        </span>
+        <Tooltip content="AI provider settings">
+          <Button
+            isIconOnly
+            size="sm"
+            variant="light"
+            onPress={() => c.setSettingsOpen(true)}
+            aria-label="AI settings"
+          >
+            <Icon icon="solar:settings-outline" width={18} />
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}
+
+/** The output area: live stream while generating, then Preview/Edit tabs. */
+function CommentaryOutput({
+  generating,
+  liveSegments,
+  scrollRef,
+  draft,
+  setDraft,
+  seedLoading,
+}: {
+  generating: boolean;
+  liveSegments: LiveSegment[];
+  scrollRef: RefObject<HTMLDivElement | null>;
+  draft: string | null;
+  setDraft: (draft: string) => void;
+  seedLoading: boolean;
+}) {
+  if (generating) {
+    return (
+      <ScrollShadow
+        ref={scrollRef}
+        className="max-h-[50vh] rounded-medium border border-default-200 p-4"
+      >
+        <LiveMessageView segments={liveSegments} />
+      </ScrollShadow>
+    );
+  }
+
+  if (draft != null) {
+    return (
+      <Tabs aria-label="Commentary view" size="sm">
+        <Tab key="preview" title="Preview">
+          <ScrollShadow className="max-h-[50vh] rounded-medium border border-default-200 p-4">
+            <Markdown text={draft} />
+          </ScrollShadow>
+        </Tab>
+        <Tab key="edit" title="Edit">
+          <Textarea
+            aria-label="Edit commentary markdown"
+            value={draft}
+            onValueChange={setDraft}
+            minRows={14}
+            maxRows={22}
+            classNames={{ input: "font-mono text-xs" }}
+          />
+        </Tab>
+      </Tabs>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2 rounded-medium border border-dashed border-default-200 py-10 text-center">
+      {seedLoading ? (
+        <Spinner size="sm" label="Loading portfolio data…" labelColor="foreground" />
+      ) : (
+        <>
+          <Icon icon="solar:document-add-outline" width={36} className="text-default-300" />
+          <p className="max-w-md text-small text-default-500">
+            Drafts LP-letter commentary for the selected month — portfolio overview, vintage
+            performance, collections vs. prior month, notable deals and concentration — from your
+            live portfolio data.
+          </p>
+        </>
+      )}
+    </div>
+  );
 }
 
 /**
@@ -57,151 +184,8 @@ interface Props {
  * streamed draft, then an editable markdown result with copy/export.
  */
 export function CommentaryModal({ isOpen, onClose, portfolios, initialSelection }: Props) {
-  const [selection, setSelection] = useState<PortfolioSelection>(initialSelection ?? "all");
-  const [seed, setSeed] = useState<CommentarySeed | null>(null);
-  const [seedLoading, setSeedLoading] = useState(false);
-  const [month, setMonth] = useState<string | null>(null);
-
-  const [settings, setSettings] = useState<AiSettings | null>(null);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-
-  const [generating, setGenerating] = useState(false);
-  const [liveSegments, setLiveSegments] = useState<LiveSegment[]>([]);
-  const [draft, setDraft] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  const scopeLabel = useMemo(() => {
-    if (selection === "all") return "All Portfolios";
-    return portfolios.find((p) => p.id === selection)?.name ?? "Portfolio";
-  }, [selection, portfolios]);
-
-  // Reset to the dashboard's scope each time the modal opens.
-  useEffect(() => {
-    if (isOpen) {
-      setSelection(initialSelection ?? "all");
-      setDraft(null);
-      setLiveSegments([]);
-    }
-  }, [isOpen, initialSelection]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    getAiSettings()
-      .then(setSettings)
-      .catch((error) => toast.error("Failed to load AI settings", String(error)));
-  }, [isOpen]);
-
-  // (Re)load the seed data whenever the scope changes while open.
-  useEffect(() => {
-    if (!isOpen) return;
-    let cancelled = false;
-    setSeedLoading(true);
-    setSeed(null);
-    setMonth(null);
-    loadCommentarySeed(selection, scopeLabel)
-      .then((loaded) => {
-        if (cancelled) return;
-        setSeed(loaded);
-        setMonth(commentaryMonths(loaded)[0] ?? null);
-      })
-      .catch((error) => {
-        if (!cancelled) toast.error("Failed to load portfolio data", String(error));
-      })
-      .finally(() => {
-        if (!cancelled) setSeedLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, selection, scopeLabel]);
-
-  useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
-  }, [liveSegments]);
-
-  const provider = settings?.default_provider ?? "anthropic";
-  const model = settings ? modelFor(settings, provider) : "";
-  const needsSetup =
-    !settings || (providerNeedsApiKey(provider) && !apiKeyFor(settings, provider)) || !model.trim();
-
-  const months = seed ? commentaryMonths(seed) : [];
-
-  const onEvent = useCallback((event: AiChatEvent) => {
-    setLiveSegments((prev) => {
-      if (event.type === "text_delta") {
-        const last = prev[prev.length - 1];
-        if (last?.type === "text") {
-          return [...prev.slice(0, -1), { type: "text", text: last.text + event.text }];
-        }
-        return [...prev, { type: "text", text: event.text }];
-      }
-      if (event.type === "tool_call") {
-        return [...prev, { type: "tool", id: event.id, name: event.name, status: "running" }];
-      }
-      if (event.type === "tool_result") {
-        return prev.map((segment) =>
-          segment.type === "tool" && segment.id === event.id
-            ? { ...segment, status: event.is_error ? "error" : "done" }
-            : segment
-        );
-      }
-      return prev;
-    });
-  }, []);
-
-  const handleGenerate = async () => {
-    if (!seed || !month || generating) return;
-    if (needsSetup) {
-      toast.warning(
-        "No AI provider configured",
-        `Add your ${PROVIDER_LABELS[provider]} API key and model first.`
-      );
-      setSettingsOpen(true);
-      return;
-    }
-
-    setGenerating(true);
-    setDraft(null);
-    setLiveSegments([]);
-    try {
-      const prompt = buildCommentaryPrompt(seed, month);
-      const text = await generateCommentary({ provider, model, prompt, onEvent });
-      setDraft(text);
-    } catch (error) {
-      toast.error("Commentary generation failed", String(error));
-    } finally {
-      setGenerating(false);
-      setLiveSegments([]);
-    }
-  };
-
-  const handleCopy = async () => {
-    if (!draft) return;
-    try {
-      await navigator.clipboard.writeText(draft);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // Clipboard access can fail silently; nothing actionable for the user.
-    }
-  };
-
-  const handleExport = async () => {
-    if (!draft || !month) return;
-    try {
-      const name = `${scopeLabel.replace(/\s+/g, "_")}_Commentary_${month}.md`;
-      const filePath = await save({
-        defaultPath: `${await downloadDir()}/${name}`,
-        filters: [{ name: "Markdown", extensions: ["md"] }],
-      });
-      if (!filePath) return;
-      await writeTextFile(filePath, draft);
-      toast.success("Commentary exported", filePath);
-    } catch (error) {
-      toast.error("Export failed", String(error));
-    }
-  };
+  const commentary = useCommentary({ isOpen, portfolios, initialSelection });
+  const { generating, liveSegments, scrollRef, draft, setDraft, seedLoading, copied } = commentary;
 
   return (
     <>
@@ -212,118 +196,15 @@ export function CommentaryModal({ isOpen, onClose, portfolios, initialSelection 
             Monthly Commentary
           </ModalHeader>
           <ModalBody className="gap-4">
-            <div className="flex flex-wrap items-end gap-3">
-              <Select
-                label="Portfolio"
-                size="sm"
-                className="w-52"
-                selectedKeys={[selection === "all" ? ALL_KEY : String(selection)]}
-                onSelectionChange={(keys) => {
-                  const key = Array.from(keys)[0];
-                  if (key == null) return;
-                  setSelection(key === ALL_KEY ? "all" : Number(key));
-                }}
-                isDisabled={generating}
-              >
-                {[
-                  <SelectItem key={ALL_KEY}>All Portfolios</SelectItem>,
-                  ...portfolios.map((p) => <SelectItem key={String(p.id)}>{p.name}</SelectItem>),
-                ]}
-              </Select>
-              <Select
-                label="Month"
-                size="sm"
-                className="w-44"
-                placeholder={seedLoading ? "Loading…" : "No data"}
-                selectedKeys={month ? [month] : []}
-                onSelectionChange={(keys) => {
-                  const key = Array.from(keys)[0];
-                  if (key != null) setMonth(String(key));
-                }}
-                isDisabled={generating || seedLoading || months.length === 0}
-              >
-                {months.map((m) => (
-                  <SelectItem key={m}>{formatMonthLong(m)}</SelectItem>
-                ))}
-              </Select>
-              <Button
-                color="primary"
-                startContent={!generating && <Icon icon="solar:magic-stick-3-outline" width={18} />}
-                onPress={handleGenerate}
-                isLoading={generating}
-                isDisabled={seedLoading || !seed || !month}
-              >
-                {draft ? "Regenerate" : "Generate"}
-              </Button>
-              <div className="flex flex-1 items-center justify-end gap-1">
-                <span className="text-tiny text-default-400">
-                  {needsSetup
-                    ? "AI provider not configured"
-                    : `${PROVIDER_LABELS[provider]} · ${model}`}
-                </span>
-                <Tooltip content="AI provider settings">
-                  <Button
-                    isIconOnly
-                    size="sm"
-                    variant="light"
-                    onPress={() => setSettingsOpen(true)}
-                    aria-label="AI settings"
-                  >
-                    <Icon icon="solar:settings-outline" width={18} />
-                  </Button>
-                </Tooltip>
-              </div>
-            </div>
-
-            {generating && (
-              <ScrollShadow
-                ref={scrollRef}
-                className="max-h-[50vh] rounded-medium border border-default-200 p-4"
-              >
-                <LiveMessageView segments={liveSegments} />
-              </ScrollShadow>
-            )}
-
-            {!generating && draft != null && (
-              <Tabs aria-label="Commentary view" size="sm">
-                <Tab key="preview" title="Preview">
-                  <ScrollShadow className="max-h-[50vh] rounded-medium border border-default-200 p-4">
-                    <Markdown text={draft} />
-                  </ScrollShadow>
-                </Tab>
-                <Tab key="edit" title="Edit">
-                  <Textarea
-                    aria-label="Edit commentary markdown"
-                    value={draft}
-                    onValueChange={setDraft}
-                    minRows={14}
-                    maxRows={22}
-                    classNames={{ input: "font-mono text-xs" }}
-                  />
-                </Tab>
-              </Tabs>
-            )}
-
-            {!generating && draft == null && (
-              <div className="flex flex-col items-center gap-2 rounded-medium border border-dashed border-default-200 py-10 text-center">
-                {seedLoading ? (
-                  <Spinner size="sm" label="Loading portfolio data…" labelColor="foreground" />
-                ) : (
-                  <>
-                    <Icon
-                      icon="solar:document-add-outline"
-                      width={36}
-                      className="text-default-300"
-                    />
-                    <p className="max-w-md text-small text-default-500">
-                      Drafts LP-letter commentary for the selected month — portfolio overview,
-                      vintage performance, collections vs. prior month, notable deals and
-                      concentration — from your live portfolio data.
-                    </p>
-                  </>
-                )}
-              </div>
-            )}
+            <ScopeBar portfolios={portfolios} commentary={commentary} />
+            <CommentaryOutput
+              generating={generating}
+              liveSegments={liveSegments}
+              scrollRef={scrollRef}
+              draft={draft}
+              setDraft={setDraft}
+              seedLoading={seedLoading}
+            />
           </ModalBody>
           <ModalFooter>
             {draft != null && !generating && (
@@ -336,14 +217,14 @@ export function CommentaryModal({ isOpen, onClose, portfolios, initialSelection 
                       width={16}
                     />
                   }
-                  onPress={handleCopy}
+                  onPress={commentary.handleCopy}
                 >
                   {copied ? "Copied" : "Copy"}
                 </Button>
                 <Button
                   variant="flat"
                   startContent={<Icon icon="solar:download-outline" width={16} />}
-                  onPress={handleExport}
+                  onPress={commentary.handleExport}
                 >
                   Export .md
                 </Button>
@@ -356,12 +237,12 @@ export function CommentaryModal({ isOpen, onClose, portfolios, initialSelection 
         </ModalContent>
       </Modal>
 
-      {settings && (
+      {commentary.settings && (
         <ProviderSettingsModal
-          isOpen={settingsOpen}
-          onClose={() => setSettingsOpen(false)}
-          settings={settings}
-          onSaved={setSettings}
+          isOpen={commentary.settingsOpen}
+          onClose={() => commentary.setSettingsOpen(false)}
+          settings={commentary.settings}
+          onSaved={commentary.setSettings}
         />
       )}
     </>

--- a/src/hooks/use-commentary.ts
+++ b/src/hooks/use-commentary.ts
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { save } from "@tauri-apps/plugin-dialog";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import { downloadDir } from "@tauri-apps/api/path";
+
+import {
+  apiKeyFor,
+  getAiSettings,
+  modelFor,
+  PROVIDER_LABELS,
+  providerNeedsApiKey,
+  type AiChatEvent,
+  type AiSettings,
+} from "@services/ai-chat-service";
+import {
+  buildCommentaryPrompt,
+  commentaryMonths,
+  generateCommentary,
+  loadCommentarySeed,
+  type CommentarySeed,
+} from "@services/commentary-service";
+import type { PortfolioOption, PortfolioSelection } from "@services/analytics-service";
+import { toast } from "@services/toast-service";
+import type { LiveSegment } from "@components/ai-chat/chat-message-view";
+
+/**
+ * Owns all monthly-commentary state and side effects: the scope/month pick,
+ * seed-data loading, AI settings, generation streaming, and the draft with
+ * copy/export. The modal component stays pure presentation. The caller
+ * remounts the modal (via a React key) on each open, so initial state comes
+ * from `initialSelection` with no reset-on-prop-change effects.
+ */
+export function useCommentary({
+  isOpen,
+  portfolios,
+  initialSelection,
+}: {
+  isOpen: boolean;
+  portfolios: PortfolioOption[];
+  initialSelection: PortfolioSelection | null;
+}) {
+  const [selection, setSelection] = useState<PortfolioSelection>(initialSelection ?? "all");
+  const [seed, setSeed] = useState<CommentarySeed | null>(null);
+  const [seedLoading, setSeedLoading] = useState(false);
+  const [month, setMonth] = useState<string | null>(null);
+
+  const [settings, setSettings] = useState<AiSettings | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const [generating, setGenerating] = useState(false);
+  const [liveSegments, setLiveSegments] = useState<LiveSegment[]>([]);
+  const [draft, setDraft] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const scopeLabel = useMemo(() => {
+    if (selection === "all") return "All Portfolios";
+    return portfolios.find((p) => p.id === selection)?.name ?? "Portfolio";
+  }, [selection, portfolios]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    getAiSettings()
+      .then(setSettings)
+      .catch((error) => toast.error("Failed to load AI settings", String(error)));
+  }, [isOpen]);
+
+  // (Re)load the seed data whenever the scope changes while open.
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setSeedLoading(true);
+    setSeed(null);
+    setMonth(null);
+    loadCommentarySeed(selection, scopeLabel)
+      .then((loaded) => {
+        if (cancelled) return;
+        setSeed(loaded);
+        setMonth(commentaryMonths(loaded)[0] ?? null);
+      })
+      .catch((error) => {
+        if (!cancelled) toast.error("Failed to load portfolio data", String(error));
+      })
+      .finally(() => {
+        if (!cancelled) setSeedLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, selection, scopeLabel]);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [liveSegments]);
+
+  const provider = settings?.default_provider ?? "anthropic";
+  const model = settings ? modelFor(settings, provider) : "";
+  const needsSetup =
+    !settings || (providerNeedsApiKey(provider) && !apiKeyFor(settings, provider)) || !model.trim();
+
+  const months = seed ? commentaryMonths(seed) : [];
+
+  const onEvent = useCallback((event: AiChatEvent) => {
+    setLiveSegments((prev) => {
+      if (event.type === "text_delta") {
+        const last = prev[prev.length - 1];
+        if (last?.type === "text") {
+          return [...prev.slice(0, -1), { type: "text", text: last.text + event.text }];
+        }
+        return [...prev, { type: "text", text: event.text }];
+      }
+      if (event.type === "tool_call") {
+        return [...prev, { type: "tool", id: event.id, name: event.name, status: "running" }];
+      }
+      if (event.type === "tool_result") {
+        return prev.map((segment) =>
+          segment.type === "tool" && segment.id === event.id
+            ? { ...segment, status: event.is_error ? "error" : "done" }
+            : segment
+        );
+      }
+      return prev;
+    });
+  }, []);
+
+  const handleGenerate = async () => {
+    if (!seed || !month || generating) return;
+    if (needsSetup) {
+      toast.warning(
+        "No AI provider configured",
+        `Add your ${PROVIDER_LABELS[provider]} API key and model first.`
+      );
+      setSettingsOpen(true);
+      return;
+    }
+
+    setGenerating(true);
+    setDraft(null);
+    setLiveSegments([]);
+    try {
+      const prompt = buildCommentaryPrompt(seed, month);
+      const text = await generateCommentary({ provider, model, prompt, onEvent });
+      setDraft(text);
+    } catch (error) {
+      toast.error("Commentary generation failed", String(error));
+    } finally {
+      setGenerating(false);
+      setLiveSegments([]);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!draft) return;
+    try {
+      await navigator.clipboard.writeText(draft);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard access can fail silently; nothing actionable for the user.
+    }
+  };
+
+  const handleExport = async () => {
+    if (!draft || !month) return;
+    try {
+      const name = `${scopeLabel.replace(/\s+/g, "_")}_Commentary_${month}.md`;
+      const filePath = await save({
+        defaultPath: `${await downloadDir()}/${name}`,
+        filters: [{ name: "Markdown", extensions: ["md"] }],
+      });
+      if (!filePath) return;
+      await writeTextFile(filePath, draft);
+      toast.success("Commentary exported", filePath);
+    } catch (error) {
+      toast.error("Export failed", String(error));
+    }
+  };
+
+  return {
+    selection,
+    setSelection,
+    seed,
+    seedLoading,
+    month,
+    setMonth,
+    months,
+    settings,
+    setSettings,
+    settingsOpen,
+    setSettingsOpen,
+    provider,
+    model,
+    needsSetup,
+    generating,
+    liveSegments,
+    draft,
+    setDraft,
+    copied,
+    scrollRef,
+    handleGenerate,
+    handleCopy,
+    handleExport,
+  };
+}

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -80,9 +80,10 @@ function Dashboard() {
             </p>
           </div>
         )}
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <Button
             variant="flat"
+            className="shrink-0"
             startContent={<Icon icon="solar:document-text-outline" width={18} />}
             onPress={() => setCommentaryOpen(true)}
             isDisabled={portfolios.length === 0}
@@ -91,7 +92,7 @@ function Dashboard() {
           </Button>
           <Select
             aria-label="Select Portfolio"
-            className="max-w-[220px]"
+            className="w-[220px]"
             isDisabled={portfolios.length === 0}
             selectedKeys={
               selection != null

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -14,7 +14,9 @@ import {
 import FunderDealsTable from "@components/dashboard/funder-deals-table";
 import NeedsAttentionCard from "@components/dashboard/needs-attention-card";
 import { ConcentrationSection } from "@components/dashboard/concentration-section";
+import { CommentaryModal } from "@components/dashboard/commentary-modal";
 import { useDashboardAnalytics } from "@/hooks/use-dashboard-analytics";
+import { useState } from "react";
 
 const ALL_PORTFOLIOS_KEY = "all";
 
@@ -49,6 +51,8 @@ function Dashboard() {
     onFunderClick,
   } = useDashboardAnalytics();
 
+  const [commentaryOpen, setCommentaryOpen] = useState(false);
+
   return (
     <div className="p-6">
       <div className="flex justify-between items-center mb-6 gap-4">
@@ -76,26 +80,45 @@ function Dashboard() {
             </p>
           </div>
         )}
-        <Select
-          aria-label="Select Portfolio"
-          className="max-w-[220px]"
-          isDisabled={portfolios.length === 0}
-          selectedKeys={
-            selection != null ? [selection === "all" ? ALL_PORTFOLIOS_KEY : String(selection)] : []
-          }
-          onSelectionChange={(keys) => {
-            const key = Array.from(keys)[0];
-            if (key == null) return;
-            setFunderId(null);
-            setSelection(key === ALL_PORTFOLIOS_KEY ? "all" : Number(key));
-          }}
-        >
-          {[
-            <SelectItem key={ALL_PORTFOLIOS_KEY}>All Portfolios</SelectItem>,
-            ...portfolios.map((p) => <SelectItem key={String(p.id)}>{p.name}</SelectItem>),
-          ]}
-        </Select>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="flat"
+            startContent={<Icon icon="solar:document-text-outline" width={18} />}
+            onPress={() => setCommentaryOpen(true)}
+            isDisabled={portfolios.length === 0}
+          >
+            Monthly commentary
+          </Button>
+          <Select
+            aria-label="Select Portfolio"
+            className="max-w-[220px]"
+            isDisabled={portfolios.length === 0}
+            selectedKeys={
+              selection != null
+                ? [selection === "all" ? ALL_PORTFOLIOS_KEY : String(selection)]
+                : []
+            }
+            onSelectionChange={(keys) => {
+              const key = Array.from(keys)[0];
+              if (key == null) return;
+              setFunderId(null);
+              setSelection(key === ALL_PORTFOLIOS_KEY ? "all" : Number(key));
+            }}
+          >
+            {[
+              <SelectItem key={ALL_PORTFOLIOS_KEY}>All Portfolios</SelectItem>,
+              ...portfolios.map((p) => <SelectItem key={String(p.id)}>{p.name}</SelectItem>),
+            ]}
+          </Select>
+        </div>
       </div>
+
+      <CommentaryModal
+        isOpen={commentaryOpen}
+        onClose={() => setCommentaryOpen(false)}
+        portfolios={portfolios}
+        initialSelection={selection}
+      />
 
       {error && (
         <Card className="mb-6 bg-danger-50 border-danger-200">

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -52,6 +52,14 @@ function Dashboard() {
   } = useDashboardAnalytics();
 
   const [commentaryOpen, setCommentaryOpen] = useState(false);
+  // Remounts the modal on each open so it starts fresh from the current
+  // dashboard scope, instead of resetting state when props change.
+  const [commentaryEpoch, setCommentaryEpoch] = useState(0);
+
+  const openCommentary = () => {
+    setCommentaryEpoch((epoch) => epoch + 1);
+    setCommentaryOpen(true);
+  };
 
   return (
     <div className="p-6">
@@ -85,7 +93,7 @@ function Dashboard() {
             variant="flat"
             className="shrink-0"
             startContent={<Icon icon="solar:document-text-outline" width={18} />}
-            onPress={() => setCommentaryOpen(true)}
+            onPress={openCommentary}
             isDisabled={portfolios.length === 0}
           >
             Monthly commentary
@@ -115,6 +123,7 @@ function Dashboard() {
       </div>
 
       <CommentaryModal
+        key={commentaryEpoch}
         isOpen={commentaryOpen}
         onClose={() => setCommentaryOpen(false)}
         portfolios={portfolios}

--- a/src/services/commentary-service.ts
+++ b/src/services/commentary-service.ts
@@ -1,0 +1,250 @@
+/**
+ * AI-generated monthly portfolio commentary (issue #59): pre-fetches the KPI
+ * numbers the letter needs from the analytics views, packages them into a
+ * purpose-built prompt, and runs it through the existing AI chat agent loop
+ * (`streamChat`), which can still pull deal-level detail with its tools.
+ */
+import {
+  aggregateMonthlyByVintage,
+  buildConcentration,
+  computeKpis,
+  formatMonth,
+  getConcentrationData,
+  getNeedsAttention,
+  getPortfolioAnalytics,
+  type MonthlyStatsRow,
+  type PortfolioAnalytics,
+  type PortfolioSelection,
+} from "./analytics-service";
+import { streamChat, type AiChatEvent, type AiProvider, type ChatMessage } from "./ai-chat-service";
+
+/** Everything the prompt is seeded with, fetched once per scope. */
+export interface CommentarySeed {
+  scopeLabel: string;
+  vintages: MonthlyStatsRow[];
+  /** Net collections per "YYYY-MM" month per funder name. */
+  collectionsByMonth: Map<string, Record<string, number>>;
+  allocations: Array<{
+    funder: string;
+    current_cost_basis: number | null;
+    pct_current_cost_basis: number | null;
+    factor: number;
+  }>;
+  topStates: Array<{ name: string; share: number; deals: number }>;
+  topIndustries: Array<{ name: string; share: number; deals: number }>;
+  atRiskDeals: Array<Record<string, unknown>>;
+}
+
+const TOP_BUCKETS = 6;
+const MAX_AT_RISK_DEALS = 15;
+
+function monthKey(isoDate: string): string {
+  return isoDate.slice(0, 7);
+}
+
+/** "2026-06" → "2026-05". */
+export function priorMonth(month: string): string {
+  const [year, m] = month.split("-").map(Number);
+  const date = new Date(Date.UTC(year, m - 2, 1));
+  return date.toISOString().slice(0, 7);
+}
+
+/** "2026-06" → "June 2026", for titles and the prompt. */
+export function formatMonthLong(month: string): string {
+  const [year, m] = month.split("-").map(Number);
+  const names = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
+  return `${names[(m || 1) - 1]} ${year}`;
+}
+
+function collectionsByMonth(analytics: PortfolioAnalytics): Map<string, Record<string, number>> {
+  const months = new Map<string, Record<string, number>>();
+  for (const row of analytics.rtr) {
+    if (!row.payment_date || row.funder_id == null) continue;
+    const key = monthKey(row.payment_date);
+    const funder = analytics.funderNames[row.funder_id] ?? `Funder ${row.funder_id}`;
+    const bucket = months.get(key) ?? {};
+    bucket[funder] = (bucket[funder] ?? 0) + (row.total_net ?? 0);
+    months.set(key, bucket);
+  }
+  return months;
+}
+
+export async function loadCommentarySeed(
+  selection: PortfolioSelection,
+  scopeLabel: string
+): Promise<CommentarySeed> {
+  const [analytics, atRisk, concentrationData] = await Promise.all([
+    getPortfolioAnalytics(selection),
+    getNeedsAttention(selection),
+    getConcentrationData(selection),
+  ]);
+
+  const concentration = buildConcentration(concentrationData);
+  const bucketSummary = (buckets: typeof concentration.states) =>
+    buckets
+      .slice(0, TOP_BUCKETS)
+      .map((b) => ({ name: b.name, share: b.share, deals: b.dealCount }));
+
+  return {
+    scopeLabel,
+    vintages: aggregateMonthlyByVintage(analytics.monthly),
+    collectionsByMonth: collectionsByMonth(analytics),
+    allocations: analytics.allocations
+      .filter((a) => a.funder_id != null)
+      .map((a) => ({
+        funder: analytics.funderNames[a.funder_id!] ?? `Funder ${a.funder_id}`,
+        current_cost_basis: a.current_cost_basis,
+        pct_current_cost_basis: a.pct_current_cost_basis,
+        factor: a.factor,
+      })),
+    topStates: bucketSummary(concentration.states),
+    topIndustries: bucketSummary(concentration.industries),
+    atRiskDeals: atRisk.slice(0, MAX_AT_RISK_DEALS).map((deal) => ({
+      merchant: deal.merchant_name,
+      funder: deal.funder_name,
+      status: deal.health_status,
+      date_funded: deal.date_funded,
+      pct_rtr_paid: deal.pct_rtr_paid,
+      net_rtr_balance: deal.net_rtr_balance,
+      days_since_last_payment: deal.days_since_last_payment,
+      pct_term_elapsed: deal.pct_term_elapsed,
+      pace_ratio: deal.pace_ratio,
+    })),
+  };
+}
+
+/**
+ * Months the commentary can cover: every month with collections activity or
+ * new vintage deployment, newest first (the default pick).
+ */
+export function commentaryMonths(seed: CommentarySeed): string[] {
+  const months = new Set<string>(seed.collectionsByMonth.keys());
+  for (const vintage of seed.vintages) {
+    if (vintage.vintage_month) months.add(monthKey(vintage.vintage_month));
+  }
+  return [...months].sort().reverse();
+}
+
+const round = (value: number | null | undefined) =>
+  value == null ? null : Math.round(value * 100) / 100;
+
+/** The purpose-built user prompt: task, section spec, style, seeded data. */
+export function buildCommentaryPrompt(seed: CommentarySeed, month: string): string {
+  const monthLabel = formatMonthLong(month);
+  const prior = priorMonth(month);
+  const kpis = computeKpis(seed.vintages);
+
+  const vintageTable = seed.vintages.map((v) => ({
+    vintage: v.vintage_month ? formatMonth(v.vintage_month) : "?",
+    deals: v.deal_count,
+    new_invested: round(v.new_invested),
+    cost_basis: round(v.cost_basis),
+    factor: round(v.weighted_avg_factor),
+    rtr_received: round(v.rtr_received),
+    outstanding: round(v.net_rtr_outstanding_after_bad_debt),
+    bad_debt_rtr: round(v.bad_debt_rtr),
+    points_per_month: round(v.points_per_month),
+  }));
+
+  const collections = {
+    [month]: seed.collectionsByMonth.get(month) ?? {},
+    [prior]: seed.collectionsByMonth.get(prior) ?? {},
+  };
+
+  const data = {
+    scope: seed.scopeLabel,
+    month: monthLabel,
+    portfolio_kpis: {
+      deal_count: kpis.dealCount,
+      dollars_at_work: round(kpis.dollarsAtWork),
+      cost_basis: round(kpis.costBasis),
+      net_rtr_outstanding: round(kpis.netRtrOutstanding),
+      principal_returned: round(kpis.principalReturned),
+      profit_returned: round(kpis.profitReturned),
+      lifetime_return_on_cost_basis: round(kpis.lifetimeReturn),
+      bad_debt_pct_of_initial_net_rtr: round(kpis.badDebtPct),
+    },
+    vintage_performance: vintageTable,
+    net_collections_by_funder: collections,
+    funder_allocation_current: seed.allocations,
+    top_states_by_dollars_at_work: seed.topStates,
+    top_industries_by_dollars_at_work: seed.topIndustries,
+    at_risk_deals_from_deal_health: seed.atRiskDeals,
+  };
+
+  return `Write the monthly investor commentary (LP-letter style) for ${seed.scopeLabel}, covering ${monthLabel}.
+
+Use the pre-fetched data below as your primary source — it comes from the same analytics views your tools query. You may run query_data for supporting detail (e.g. a specific deal in deal_computed), but keep tool calls to a minimum (at most 3) and never re-fetch what is already provided.
+
+# Output
+Respond with the commentary markdown only — no preamble, no closing note about how it was produced. Start with a "# ${seed.scopeLabel} — Monthly Commentary, ${monthLabel}" title, then exactly these sections:
+
+## Portfolio Overview
+Scale and health at a glance: deal count, dollars at work, net RTR outstanding, lifetime return, and what changed in ${monthLabel}.
+
+## Vintage Performance
+How the vintages are tracking: deployment pace, weighted factors, points per month, and which vintages stand out (good or bad).
+
+## Collections
+${monthLabel} net collections versus the prior month, in total and by funder where the movement is notable.
+
+## Notable Deals & Slippage
+The at-risk picture: past-term, stale, and slipping deals with merchant names and dollar amounts; bad-debt exposure and any concentration of risk in one funder.
+
+## Concentration
+State and industry exposure — call out anything above roughly 20% of dollars at work, and note diversification breadth otherwise.
+
+# Style
+- Professional, factual LP-letter prose. Short paragraphs; use a small markdown table only where it genuinely helps (e.g. collections by funder).
+- Cite concrete figures: dollars as $1.23M / $456k style, rates and factors to two decimals, percentages to one decimal.
+- Numbers must come from the data below or your tool results — never estimate or invent. If a section has no data, say so in one sentence.
+- Month labels like "May 26" in the data mean May 2026.
+
+# Pre-fetched data (JSON)
+${JSON.stringify(data, null, 1)}`;
+}
+
+/**
+ * Runs the commentary prompt through the AI chat agent loop and returns the
+ * final markdown. `onEvent` receives the same live events as the chat page.
+ */
+export async function generateCommentary(params: {
+  provider: AiProvider;
+  model: string;
+  prompt: string;
+  onEvent: (event: AiChatEvent) => void;
+}): Promise<string> {
+  const messages: ChatMessage[] = [
+    { role: "user", blocks: [{ kind: "text", text: params.prompt }] },
+  ];
+  const newMessages = await streamChat({
+    provider: params.provider,
+    model: params.model,
+    messages,
+    onEvent: params.onEvent,
+  });
+
+  const text = newMessages
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.blocks)
+    .filter((block): block is Extract<typeof block, { kind: "text" }> => block.kind === "text")
+    .map((block) => block.text)
+    .join("\n\n")
+    .trim();
+
+  if (!text) throw new Error("The model returned no commentary text.");
+  return text;
+}

--- a/src/services/commentary-service.ts
+++ b/src/services/commentary-service.ts
@@ -237,13 +237,14 @@ export async function generateCommentary(params: {
     onEvent: params.onEvent,
   });
 
-  const text = newMessages
-    .filter((message) => message.role === "assistant")
-    .flatMap((message) => message.blocks)
-    .filter((block): block is Extract<typeof block, { kind: "text" }> => block.kind === "text")
-    .map((block) => block.text)
-    .join("\n\n")
-    .trim();
+  const parts: string[] = [];
+  for (const message of newMessages) {
+    if (message.role !== "assistant") continue;
+    for (const block of message.blocks) {
+      if (block.kind === "text") parts.push(block.text);
+    }
+  }
+  const text = parts.join("\n\n").trim();
 
   if (!text) throw new Error("The model returned no commentary text.");
   return text;


### PR DESCRIPTION
Closes #59.

## What
One-click **Monthly commentary** button on the Dashboard header. It opens a modal with portfolio + month pickers, generates LP-letter-style prose through the existing AI chat agent loop, streams the draft live, and then presents it as editable markdown with **Copy** and **Export .md**.

## How
- **`src/services/commentary-service.ts`** — pre-fetches the seed data the letter needs (per the issue's latency note): portfolio KPIs + per-vintage stats (`portfolio_monthly` / `monthly_vintage_stats`), net collections by funder for the selected + prior month (`weekly_rtr_matrix`), current funder allocation, top state/industry concentration buckets, and the at-risk deals from `deal_health` (the #56 output, already folded in). Builds a purpose-built prompt with the five required sections (overview, vintage performance, collections vs. prior month, notable deals & slippage, concentration) and strict no-invented-numbers style rules, then runs it through `streamChat` — the model can still make a few `query_data` calls for deal-level detail.
- **`src/components/dashboard/commentary-modal.tsx`** — pickers (month options derived from actual collection/vintage activity, newest first), live streaming view reusing `LiveMessageView`, Preview/Edit tabs after completion, copy to clipboard, and .md export via the save dialog. Uses the default AI provider/model from settings, with the existing `ProviderSettingsModal` one click away when nothing is configured.
- No Rust changes — the existing `ai_chat_stream` command and read-only tools cover everything.

## Verification
- `npm run lint`, `npm run format:check`, `npm run build` all pass (no Rust touched, so no cargo gates).
- Not driven end-to-end in-app: generation needs a signed-in prod session plus a configured AI provider key, so please smoke-test the button once with your Anthropic key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)