### PR TITLE
feat: funder upload completeness tracker

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: verify
+description: Verify frontend changes by driving the app in a browser against the local Supabase stack — build/launch/drive recipe that avoids needing the Tauri window.
+---
+
+# Verifying Excelerate frontend changes
+
+Frontend-only changes (no Tauri `invoke()` in the changed path) can be verified
+in a plain browser: the React app runs fine under Vite, and Supabase
+auth/reads/writes work identically. Tauri APIs throw a benign
+`transformCallback` pageerror on load — ignore it.
+
+## Launch
+
+1. Local Supabase stack must be running (`supabase status`; `npm run dev:local`
+   starts it as a side effect, or `supabase start`).
+2. Get the anon key:
+   `supabase status -o json | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['ANON_KEY'])"`
+3. Start Vite only (not Tauri), in the background:
+   `VITE_SUPABASE_URL=http://127.0.0.1:54321 VITE_SUPABASE_ANON_KEY=<key> npm run dev`
+   → serves http://localhost:1420
+
+## Drive (Playwright)
+
+Playwright is not a project dep — `npm i playwright` in a scratch dir (chromium
+is already cached in `~/Library/Caches/ms-playwright`).
+
+- Login: goto `/login`, `getByLabel("Email")` → `dev@excelerate.local`,
+  `getByRole("textbox", { name: /Password/ })` → `excelerate-dev` (plain
+  `getByLabel("Password")` is ambiguous with the show-password button), submit,
+  `waitForURL(/dashboard/)`.
+- Routes: `/alder-portfolio`, `/white-rabbit-portfolio`, `/dashboard`, etc.
+  (see `src/App.tsx`).
+- HeroUI tooltips ignore instant synthetic hovers — glide the mouse in with
+  `page.mouse.move(x, y, { steps: 8 })` toward the target, then wait ~1s.
+
+## Test data
+
+Seed directly via psql (`postgresql://postgres:postgres@127.0.0.1:54322/postgres`).
+Portfolios: 1 = Alder, 2 = White Rabbit. `funders`/`portfolio_funders` are
+pre-seeded; `deals`, `funder_uploads`, `net_rtr_payments` start empty.
+Delete seeded rows afterward to leave the stack clean, or use
+`npm run db:wipe:local`.

--- a/src/components/portfolio/base-portfolio.tsx
+++ b/src/components/portfolio/base-portfolio.tsx
@@ -17,7 +17,7 @@ interface BasePortfolioProps {
   monthlyErrorStates?: Record<string, { hasError: boolean; message?: string }>;
   onExportWorkbook?: () => void;
   isExporting?: boolean;
-  /** Rendered between the date picker and the upload section (completeness tracker). */
+  /** Rendered directly below the upload section (completeness tracker). */
   uploadTracker?: React.ReactNode;
 }
 
@@ -57,9 +57,6 @@ const BasePortfolio: React.FC<BasePortfolioProps> = ({
             />
           </div>
 
-          {/* Upload Completeness Tracker */}
-          {uploadTracker}
-
           {/* Funder Upload Section */}
           {monthlyFunders?.length && (
             <div className="bg-default-50 rounded-lg p-6 border border-default-200">
@@ -77,6 +74,9 @@ const BasePortfolio: React.FC<BasePortfolioProps> = ({
               />
             </div>
           )}
+
+          {/* Upload Completeness Tracker */}
+          {uploadTracker}
 
           {/* Export Workbook Button */}
           {onExportWorkbook && (

--- a/src/components/portfolio/base-portfolio.tsx
+++ b/src/components/portfolio/base-portfolio.tsx
@@ -17,6 +17,8 @@ interface BasePortfolioProps {
   monthlyErrorStates?: Record<string, { hasError: boolean; message?: string }>;
   onExportWorkbook?: () => void;
   isExporting?: boolean;
+  /** Rendered between the date picker and the upload section (completeness tracker). */
+  uploadTracker?: React.ReactNode;
 }
 
 const BasePortfolio: React.FC<BasePortfolioProps> = ({
@@ -31,6 +33,7 @@ const BasePortfolio: React.FC<BasePortfolioProps> = ({
   monthlyErrorStates,
   onExportWorkbook,
   isExporting = false,
+  uploadTracker,
 }) => {
   return (
     <div className="min-h-screen bg-background p-6">
@@ -53,6 +56,9 @@ const BasePortfolio: React.FC<BasePortfolioProps> = ({
               onDateChange={onDateChange}
             />
           </div>
+
+          {/* Upload Completeness Tracker */}
+          {uploadTracker}
 
           {/* Funder Upload Section */}
           {monthlyFunders?.length && (

--- a/src/components/portfolio/funder-upload-section.tsx
+++ b/src/components/portfolio/funder-upload-section.tsx
@@ -59,6 +59,7 @@ const FunderUploadSection: React.FC<FunderUploadSectionProps> = ({
           funder.disabled ? (
             <div
               key={funder.name}
+              data-funder-slot={funder.name}
               className="bg-default-100 rounded-lg p-4 border border-default-200 opacity-50"
             >
               <h4 className="text-sm font-medium text-default-400 mb-3 text-center">
@@ -71,6 +72,7 @@ const FunderUploadSection: React.FC<FunderUploadSectionProps> = ({
           ) : (
             <div
               key={funder.name}
+              data-funder-slot={funder.name}
               className="bg-default-50 rounded-lg p-4 border border-default-200"
             >
               <h4 className="text-sm font-medium text-foreground mb-3 text-center">

--- a/src/components/portfolio/upload-completeness-grid.tsx
+++ b/src/components/portfolio/upload-completeness-grid.tsx
@@ -1,0 +1,179 @@
+import React, { useEffect, useState } from "react";
+import { Chip, Tooltip } from "@heroui/react";
+import { Icon } from "@iconify/react";
+import PivotSyncService, { UploadCompleteness } from "@services/pivot-sync-service";
+import { FunderData } from "./funder-upload-section";
+
+interface UploadCompletenessGridProps {
+  portfolioName: string;
+  funders: FunderData[];
+  /** Bump to refetch after an upload or delete. */
+  refreshToken: number;
+  /** Clicking a missing cell jumps to that funder's upload slot for that month. */
+  onMissingCellClick?: (funderName: string, monthKey: string) => void;
+}
+
+const monthLabel = (key: string) => {
+  const [year, month] = key.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, 1)).toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+};
+
+const formatUploadedAt = (createdAt: string) =>
+  new Date(createdAt).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+const UploadCompletenessGrid: React.FC<UploadCompletenessGridProps> = ({
+  portfolioName,
+  funders,
+  refreshToken,
+  onMissingCellClick,
+}) => {
+  const [data, setData] = useState<UploadCompleteness | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    PivotSyncService.getUploadCompleteness(portfolioName)
+      .then((result) => {
+        if (!cancelled) setData(result);
+      })
+      .catch((error) => {
+        console.error("Error loading upload completeness:", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [portfolioName, refreshToken]);
+
+  if (!data) return null;
+
+  const linked = new Set(data.linkedFunders);
+  // Page funders first (upload-slot order), then linked funders the page
+  // doesn't list — but only when they actually have uploads in the window,
+  // so slot-less funders (ACS, VSPR) don't add permanent all-missing rows.
+  const extraFunders = data.linkedFunders
+    .filter(
+      (name) =>
+        !funders.some((f) => f.name === name) &&
+        data.monthKeys.some((key) => data.uploads[`${name}|${key}`])
+    )
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => ({ name, noSlot: true }));
+  const rows = [
+    ...funders.map((f) => ({ name: f.name, disabled: f.disabled ?? false, noSlot: false })),
+    ...extraFunders.map((f) => ({ ...f, disabled: false })),
+  ];
+
+  const currentKey = data.monthKeys[data.monthKeys.length - 1];
+  const outstanding = rows.filter(
+    (row) =>
+      linked.has(row.name) &&
+      !row.disabled &&
+      !row.noSlot &&
+      !data.uploads[`${row.name}|${currentKey}`]
+  ).length;
+
+  return (
+    <div className="bg-default-50 rounded-lg p-6 border border-default-200">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold text-foreground">Upload Completeness</h2>
+        <Chip
+          size="sm"
+          variant="flat"
+          color={outstanding === 0 ? "success" : "warning"}
+          data-testid="outstanding-chip"
+        >
+          {outstanding === 0
+            ? `All reports in for ${monthLabel(currentKey)}`
+            : `${outstanding} report${outstanding === 1 ? "" : "s"} outstanding for ${monthLabel(currentKey)}`}
+        </Chip>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left font-medium text-default-500 py-2 pr-4">Funder</th>
+              {data.monthKeys.map((key) => (
+                <th key={key} className="text-center font-medium text-default-500 py-2 px-3">
+                  {monthLabel(key)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.name} className="border-t border-default-200">
+                <td className="py-2 pr-4 font-medium text-foreground whitespace-nowrap">
+                  {row.name}
+                </td>
+                {data.monthKeys.map((key) => {
+                  const upload = data.uploads[`${row.name}|${key}`];
+                  if (upload) {
+                    return (
+                      <td key={key} className="py-2 px-3 text-center">
+                        <Tooltip
+                          content={`${upload.original_filename} — uploaded ${formatUploadedAt(upload.created_at)}`}
+                        >
+                          {/* span wrapper: HeroUI Tooltip needs a ref-forwarding child */}
+                          <span className="inline-flex">
+                            <Icon
+                              icon="material-symbols:check-circle"
+                              className="w-5 h-5 text-success"
+                            />
+                          </span>
+                        </Tooltip>
+                      </td>
+                    );
+                  }
+                  if (!linked.has(row.name) || row.disabled || row.noSlot) {
+                    return (
+                      <td key={key} className="py-2 px-3 text-center">
+                        <Tooltip
+                          content={
+                            row.disabled
+                              ? "Uploads not supported yet"
+                              : row.noSlot
+                                ? "No monthly upload slot for this funder"
+                                : "Funder not linked to this portfolio"
+                          }
+                        >
+                          <span className="text-default-300">—</span>
+                        </Tooltip>
+                      </td>
+                    );
+                  }
+                  return (
+                    <td key={key} className="py-2 px-3 text-center">
+                      <Tooltip content={`Missing — click to upload for ${monthLabel(key)}`}>
+                        <button
+                          type="button"
+                          className="inline-flex items-center justify-center rounded-full hover:bg-warning-100 p-0.5 transition-colors"
+                          onClick={() => onMissingCellClick?.(row.name, key)}
+                          aria-label={`Upload ${row.name} report for ${monthLabel(key)}`}
+                        >
+                          <Icon
+                            icon="material-symbols:error-outline"
+                            className="w-5 h-5 text-warning"
+                          />
+                        </button>
+                      </Tooltip>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default UploadCompletenessGrid;

--- a/src/pages/alder-portfolio.tsx
+++ b/src/pages/alder-portfolio.tsx
@@ -245,36 +245,6 @@ function AlderPortfolio() {
 
       <WorkbookImportWizard portfolioName={PORTFOLIO} />
 
-      {/* Uploaded Files Summary */}
-      {selectedDate && funderUploads.length > 0 && (
-        <div className="max-w-6xl mx-auto mt-6 p-6 bg-default-50 rounded-lg border border-default-200">
-          <h3 className="text-xl font-semibold mb-4">
-            Uploaded Files for {selectedDate.toString()}
-          </h3>
-          <div className="space-y-2">
-            {monthlyFunderList.flatMap((funder) => {
-              if (funder.disabled) return [];
-              const uploaded = funderUploads.find(
-                (u) => uiFunderName(u.funder_name) === funder.name
-              );
-              return (
-                <div
-                  key={funder.name}
-                  className="flex items-center justify-between p-2 bg-default-100 rounded"
-                >
-                  <span className="text-sm">{funder.name}</span>
-                  {uploaded ? (
-                    <span className="text-xs text-success-600">{uploaded.original_filename}</span>
-                  ) : (
-                    <span className="text-xs text-default-400">Not uploaded</span>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
       <PivotReconciliationModal
         isOpen={cloudSync.isModalOpen}
         onOpenChange={cloudSync.setModalOpen}

--- a/src/pages/alder-portfolio.tsx
+++ b/src/pages/alder-portfolio.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
-import { DateValue } from "@internationalized/date";
+import { CalendarDate, DateValue } from "@internationalized/date";
 import BasePortfolio from "@components/portfolio/base-portfolio";
 import { getMostRecentCompletedMonth } from "@utils/report-month";
 import { FunderData } from "@components/portfolio/funder-upload-section";
+import UploadCompletenessGrid from "@components/portfolio/upload-completeness-grid";
 import PivotSyncService, { CloudUploadInfo, uiFunderName } from "@services/pivot-sync-service";
 import WorkbookExportService from "@services/workbook-export-service";
 import { toast } from "@services/toast-service";
@@ -84,10 +85,12 @@ function AlderPortfolio() {
   const [selectedDate, setSelectedDate] = useState<DateValue | null>(getMostRecentCompletedMonth);
   const [funderUploads, setFunderUploads] = useState<CloudUploadInfo[]>([]);
   const [isExporting, setIsExporting] = useState(false);
+  const [trackerRefresh, setTrackerRefresh] = useState(0);
   const { monthlyErrorStates, setFunderErrorState } = useFileErrorState();
   const cloudSync = useCloudSync();
 
   const refreshUploads = useCallback(async (reportDate: string) => {
+    setTrackerRefresh((n) => n + 1);
     try {
       const uploads = await PivotSyncService.listUploadsForDate(PORTFOLIO, reportDate);
       setFunderUploads(uploads);
@@ -185,6 +188,19 @@ function AlderPortfolio() {
     });
   };
 
+  // Grid cell click: switch to that report month, then scroll to the funder's
+  // upload slot once the page re-renders.
+  const handleMissingCellClick = (funderName: string, monthKey: string) => {
+    const [year, month] = monthKey.split("-").map(Number);
+    const monthEnd = new CalendarDate(year, month, 1).add({ months: 1 }).subtract({ days: 1 });
+    handleDateChange(monthEnd);
+    requestAnimationFrame(() => {
+      document
+        .querySelector(`[data-funder-slot="${CSS.escape(funderName)}"]`)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+  };
+
   const handleExportWorkbook = async () => {
     if (isExporting) return;
     try {
@@ -217,6 +233,14 @@ function AlderPortfolio() {
         monthlyErrorStates={monthlyErrorStates}
         onExportWorkbook={handleExportWorkbook}
         isExporting={isExporting}
+        uploadTracker={
+          <UploadCompletenessGrid
+            portfolioName={PORTFOLIO}
+            funders={monthlyFunderList}
+            refreshToken={trackerRefresh}
+            onMissingCellClick={handleMissingCellClick}
+          />
+        }
       />
 
       <WorkbookImportWizard portfolioName={PORTFOLIO} />

--- a/src/pages/white-rabbit-portfolio.tsx
+++ b/src/pages/white-rabbit-portfolio.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
-import { DateValue } from "@internationalized/date";
+import { CalendarDate, DateValue } from "@internationalized/date";
 import BasePortfolio from "@components/portfolio/base-portfolio";
 import { getMostRecentCompletedMonth } from "@utils/report-month";
 import { FunderData } from "@components/portfolio/funder-upload-section";
+import UploadCompletenessGrid from "@components/portfolio/upload-completeness-grid";
 import PivotSyncService, { CloudUploadInfo, uiFunderName } from "@services/pivot-sync-service";
 import WorkbookExportService from "@services/workbook-export-service";
 import { toast } from "@services/toast-service";
@@ -69,10 +70,12 @@ function WhiteRabbitPortfolio() {
   const [selectedDate, setSelectedDate] = useState<DateValue | null>(getMostRecentCompletedMonth);
   const [funderUploads, setFunderUploads] = useState<CloudUploadInfo[]>([]);
   const [isExporting, setIsExporting] = useState(false);
+  const [trackerRefresh, setTrackerRefresh] = useState(0);
   const { monthlyErrorStates, setFunderErrorState } = useFileErrorState();
   const cloudSync = useCloudSync();
 
   const refreshUploads = useCallback(async (reportDate: string) => {
+    setTrackerRefresh((n) => n + 1);
     try {
       const uploads = await PivotSyncService.listUploadsForDate(PORTFOLIO, reportDate);
       setFunderUploads(uploads);
@@ -170,6 +173,19 @@ function WhiteRabbitPortfolio() {
     });
   };
 
+  // Grid cell click: switch to that report month, then scroll to the funder's
+  // upload slot once the page re-renders.
+  const handleMissingCellClick = (funderName: string, monthKey: string) => {
+    const [year, month] = monthKey.split("-").map(Number);
+    const monthEnd = new CalendarDate(year, month, 1).add({ months: 1 }).subtract({ days: 1 });
+    handleDateChange(monthEnd);
+    requestAnimationFrame(() => {
+      document
+        .querySelector(`[data-funder-slot="${CSS.escape(funderName)}"]`)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+  };
+
   const handleExportWorkbook = async () => {
     if (isExporting) return;
     try {
@@ -202,6 +218,14 @@ function WhiteRabbitPortfolio() {
         monthlyErrorStates={monthlyErrorStates}
         onExportWorkbook={handleExportWorkbook}
         isExporting={isExporting}
+        uploadTracker={
+          <UploadCompletenessGrid
+            portfolioName={PORTFOLIO}
+            funders={monthlyFunderList}
+            refreshToken={trackerRefresh}
+            onMissingCellClick={handleMissingCellClick}
+          />
+        }
       />
 
       <WorkbookImportWizard portfolioName={PORTFOLIO} />

--- a/src/pages/white-rabbit-portfolio.tsx
+++ b/src/pages/white-rabbit-portfolio.tsx
@@ -230,36 +230,6 @@ function WhiteRabbitPortfolio() {
 
       <WorkbookImportWizard portfolioName={PORTFOLIO} />
 
-      {/* Uploaded Files Summary */}
-      {selectedDate && funderUploads.length > 0 && (
-        <div className="max-w-6xl mx-auto mt-6 p-6 bg-default-50 rounded-lg border border-default-200">
-          <h3 className="text-xl font-semibold mb-4">
-            Uploaded Files for {selectedDate.toString()}
-          </h3>
-          <div className="space-y-2">
-            {monthlyFunderList.flatMap((funder) => {
-              if (funder.disabled) return [];
-              const uploaded = funderUploads.find(
-                (u) => uiFunderName(u.funder_name) === funder.name
-              );
-              return (
-                <div
-                  key={funder.name}
-                  className="flex items-center justify-between p-2 bg-default-100 rounded"
-                >
-                  <span className="text-sm">{funder.name}</span>
-                  {uploaded ? (
-                    <span className="text-xs text-success-600">{uploaded.original_filename}</span>
-                  ) : (
-                    <span className="text-xs text-default-400">Not uploaded</span>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
       <PivotReconciliationModal
         isOpen={cloudSync.isModalOpen}
         onOpenChange={cloudSync.setModalOpen}

--- a/src/services/pivot-sync-service.ts
+++ b/src/services/pivot-sync-service.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { supabase } from "./supabase";
+import { getMostRecentCompletedMonth } from "@utils/report-month";
 
 /** Pivot rows + parser totals returned by the Rust `parse_funder_pivot` command. */
 export interface PivotRowData {
@@ -129,6 +130,19 @@ export interface CloudUploadInfo {
   file_size: number | null;
   storage_path: string | null;
   created_at: string;
+}
+
+/**
+ * Upload-completeness data for one portfolio: which funder files are in for
+ * each recent report month. Drives the tracker grid on the portfolio pages.
+ */
+export interface UploadCompleteness {
+  /** "YYYY-MM" keys, oldest first — recent upload history plus the current report month. */
+  monthKeys: string[];
+  /** UI labels of funders linked to the portfolio via portfolio_funders. */
+  linkedFunders: string[];
+  /** Uploads keyed by `${uiFunderName}|${monthKey}`. */
+  uploads: Record<string, CloudUploadInfo>;
 }
 
 // UI funder labels that differ from funders.name in Supabase
@@ -492,6 +506,65 @@ export class PivotSyncService {
       ...u,
       funder_name: funderNames.get(u.funder_id) ?? `Funder ${u.funder_id}`,
     }));
+  }
+
+  /**
+   * Upload completeness for the tracker grid: the last `monthCount` report
+   * months (from upload history, always including the most recent completed
+   * month), the funders linked to the portfolio, and every upload in that
+   * window keyed by funder + month.
+   */
+  static async getUploadCompleteness(
+    portfolioName: string,
+    monthCount = 6
+  ): Promise<UploadCompleteness> {
+    const portfolioId = await this.getPortfolioId(portfolioName);
+    const [funderNames, linkedRes, datesRes] = await Promise.all([
+      this.getFunderNames(),
+      supabase.from("portfolio_funders").select("funder_id").eq("portfolio_id", portfolioId),
+      supabase
+        .from("funder_uploads")
+        .select("report_date")
+        .eq("portfolio_id", portfolioId)
+        .order("report_date", { ascending: false })
+        .limit(1000),
+    ]);
+    if (linkedRes.error) {
+      throw new Error(`Failed to load portfolio funders: ${linkedRes.error.message}`);
+    }
+    if (datesRes.error) {
+      throw new Error(`Failed to load upload history: ${datesRes.error.message}`);
+    }
+
+    // Report dates are always the last day of a month, so "YYYY-MM" identifies
+    // a report period.
+    const keySet = new Set<string>([getMostRecentCompletedMonth().toString().slice(0, 7)]);
+    (datesRes.data ?? []).forEach((r) => keySet.add(r.report_date.slice(0, 7)));
+    const monthKeys = [...keySet].sort().slice(-monthCount);
+
+    const { data: uploadRows, error: uploadsError } = await supabase
+      .from("funder_uploads")
+      .select("id, funder_id, report_date, original_filename, file_size, storage_path, created_at")
+      .eq("portfolio_id", portfolioId)
+      .gte("report_date", `${monthKeys[0]}-01`)
+      .order("created_at");
+    if (uploadsError) {
+      throw new Error(`Failed to load funder uploads: ${uploadsError.message}`);
+    }
+
+    const uploads: Record<string, CloudUploadInfo> = {};
+    (uploadRows ?? []).forEach((u) => {
+      const dbName = funderNames.get(u.funder_id) ?? `Funder ${u.funder_id}`;
+      uploads[`${uiFunderName(dbName)}|${u.report_date.slice(0, 7)}`] = {
+        ...u,
+        funder_name: dbName,
+      };
+    });
+
+    const linkedFunders = (linkedRes.data ?? []).map((r) =>
+      uiFunderName(funderNames.get(r.funder_id) ?? `Funder ${r.funder_id}`)
+    );
+    return { monthKeys, linkedFunders, uploads };
   }
 
   /** Whether an upload already exists for this (portfolio, funder, date). */


### PR DESCRIPTION
Closes #60

## What

A funder × month grid on both portfolio pages (above the upload section) showing which monthly funder reports have been uploaded for each recent report month — so "BIG's June file is missing" is visible at a glance instead of discovered at reconciliation time.

- **Rows**: the page's upload-slot funders, plus any `portfolio_funders`-linked funder that has uploads in the window (e.g. ACS history) — slot-less funders with no uploads are omitted rather than shown as permanently missing
- **Columns**: up to the last 6 report months, derived from upload history and always including the most recent completed month
- **Cells**: ✅ uploaded (tooltip: filename + upload date) · ⚠️ missing (click switches the report month and scrolls to that funder's upload slot) · — not applicable (funder not linked / no parser yet / no upload slot)
- Header chip counts reports outstanding for the current report month
- Grid refetches after every upload/delete/date change via the existing `refreshUploads` path

## Implementation

- Pure read over `funder_uploads` + `portfolio_funders` — no migration
- New `PivotSyncService.getUploadCompleteness()`; new `UploadCompletenessGrid` component; `BasePortfolio` gains an `uploadTracker` slot; upload slots get a stable `data-funder-slot` anchor for the click-to-jump
- The optional sidebar count badge from the issue is not included (the header chip covers the at-a-glance count on-page)

## Verification

Driven end-to-end in a browser against the local Supabase stack (seeded `funder_uploads` rows, since wiped): grid states match the data on both portfolios, outstanding chip counts correctly, tooltips show filename + date, clicking a missing cell for an older month switches the date picker to that month and scrolls to the funder's slot. `lint`, `format:check`, and `build` pass. Also adds a project verify skill capturing the browser-verification recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)