### PR TITLE
feat: cmd+k command palette (global search & navigation)

### DIFF
--- a/src/components/command-palette/command-palette.tsx
+++ b/src/components/command-palette/command-palette.tsx
@@ -26,12 +26,32 @@ interface PaletteEntry {
 
 const SEARCH_DEBOUNCE_MS = 200;
 const MIN_QUERY_LENGTH = 2;
+const SECTIONS: PaletteEntry["section"][] = ["Pages", "Merchants", "Deals"];
 
 /**
  * Global Cmd+K palette: jump to any page, or search merchants and deals and
  * land on Deal Lookup pre-filtered to the selection.
  */
 export function CommandPalette({ isOpen, onClose }: Props) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => !open && onClose()}
+      placement="top"
+      size="xl"
+      hideCloseButton
+      classNames={{ base: "mt-[10vh]" }}
+    >
+      <ModalContent>
+        {/* The modal unmounts its content when closed, so each open mounts
+            fresh query/results/highlight state — no reset effect needed. */}
+        <PaletteContent onClose={onClose} />
+      </ModalContent>
+    </Modal>
+  );
+}
+
+function PaletteContent({ onClose }: { onClose: () => void }) {
   const navigate = useNavigate();
   const { profile } = useAuth();
   const [query, setQuery] = useState("");
@@ -42,18 +62,8 @@ export function CommandPalette({ isOpen, onClose }: Props) {
   /** Guards against out-of-order responses from overlapping searches. */
   const requestIdRef = useRef(0);
 
-  // Start from a clean slate on every open.
-  useEffect(() => {
-    if (isOpen) {
-      setQuery("");
-      setResults(EMPTY_RESULTS);
-      setHighlighted(0);
-    }
-  }, [isOpen]);
-
   // Debounced merchant/deal search.
   useEffect(() => {
-    if (!isOpen) return;
     const trimmed = query.trim();
     if (trimmed.length < MIN_QUERY_LENGTH) {
       setResults(EMPTY_RESULTS);
@@ -76,7 +86,7 @@ export function CommandPalette({ isOpen, onClose }: Props) {
         });
     }, SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(timer);
-  }, [query, isOpen]);
+  }, [query]);
 
   const goTo = useCallback(
     (path: string, state?: { dealLookupSearch: string }) => {
@@ -89,15 +99,18 @@ export function CommandPalette({ isOpen, onClose }: Props) {
   const entries = useMemo<PaletteEntry[]>(() => {
     const pages = [...items, ...(profile?.role === "admin" ? [usersItem] : []), settingsItem];
     const needle = query.trim().toLowerCase();
-    const pageEntries: PaletteEntry[] = pages
-      .filter((p) => !needle || p.title.toLowerCase().includes(needle))
-      .map((p) => ({
-        key: `page-${p.key}`,
-        section: "Pages",
-        label: p.title,
-        icon: p.icon ?? "solar:document-linear",
-        perform: () => goTo(`/${p.key}`),
-      }));
+    const pageEntries: PaletteEntry[] = pages.flatMap((p) => {
+      if (needle && !p.title.toLowerCase().includes(needle)) return [];
+      return [
+        {
+          key: `page-${p.key}`,
+          section: "Pages" as const,
+          label: p.title,
+          icon: p.icon ?? "solar:document-linear",
+          perform: () => goTo(`/${p.key}`),
+        },
+      ];
+    });
     const merchantEntries: PaletteEntry[] = results.merchants.map((m) => ({
       key: `merchant-${m.id}`,
       section: "Merchants",
@@ -110,7 +123,7 @@ export function CommandPalette({ isOpen, onClose }: Props) {
       return [
         {
           key: `deal-${d.id}`,
-          section: "Deals",
+          section: "Deals" as const,
           label: d.funderAdvanceId ?? d.merchantName ?? "Deal",
           sublabel: d.funderAdvanceId != null ? (d.merchantName ?? undefined) : undefined,
           icon: "solar:document-text-linear",
@@ -121,123 +134,112 @@ export function CommandPalette({ isOpen, onClose }: Props) {
     return [...pageEntries, ...merchantEntries, ...dealEntries];
   }, [query, results, profile?.role, goTo]);
 
-  // Keep the highlight on a real row as the list grows/shrinks.
-  useEffect(() => {
-    setHighlighted((h) => Math.min(h, Math.max(entries.length - 1, 0)));
-  }, [entries]);
+  // Clamp at render time so the highlight stays on a real row as the list
+  // grows and shrinks, without a state-adjusting effect.
+  const activeIndex = entries.length === 0 ? 0 : Math.min(highlighted, entries.length - 1);
 
   useEffect(() => {
     listRef.current
-      ?.querySelector(`[data-entry-index="${highlighted}"]`)
+      ?.querySelector(`[data-entry-index="${activeIndex}"]`)
       ?.scrollIntoView({ block: "nearest" });
-  }, [highlighted]);
+  }, [activeIndex]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (entries.length === 0) return;
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setHighlighted((h) => (entries.length === 0 ? 0 : (h + 1) % entries.length));
+      setHighlighted((activeIndex + 1) % entries.length);
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
-      setHighlighted((h) => (entries.length === 0 ? 0 : (h - 1 + entries.length) % entries.length));
+      setHighlighted((activeIndex - 1 + entries.length) % entries.length);
     } else if (e.key === "Enter") {
       e.preventDefault();
-      entries[highlighted]?.perform();
+      entries[activeIndex]?.perform();
     }
   };
 
-  const sections: PaletteEntry["section"][] = ["Pages", "Merchants", "Deals"];
   const showEmptyHint =
     !searching && entries.length === 0 && query.trim().length >= MIN_QUERY_LENGTH;
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onOpenChange={(open) => !open && onClose()}
-      placement="top"
-      size="xl"
-      hideCloseButton
-      classNames={{ base: "mt-[10vh]" }}
-    >
-      <ModalContent>
-        <div onKeyDown={handleKeyDown}>
-          <div className="flex items-center gap-2 px-4 pt-4 pb-2 border-b border-divider">
-            <Input
-              autoFocus
-              aria-label="Search pages, merchants, and deals"
-              placeholder="Search pages, merchants, deals…"
-              size="lg"
-              variant="flat"
-              value={query}
-              onValueChange={setQuery}
-              startContent={
-                <Icon icon="solar:magnifer-linear" width={20} className="text-default-400" />
-              }
-              endContent={searching ? <Spinner size="sm" /> : <Kbd keys={["escape"]} />}
-            />
-          </div>
-          <ScrollShadow ref={listRef} className="max-h-[50vh] p-2">
-            {sections.map((section) => {
-              const sectionEntries = entries.filter((e) => e.section === section);
-              if (sectionEntries.length === 0) return null;
-              return (
-                <div key={section} className="mb-1">
-                  <p className="px-2 py-1 text-tiny font-semibold uppercase text-default-400">
-                    {section}
-                  </p>
-                  {sectionEntries.map((entry) => {
-                    const index = entries.indexOf(entry);
-                    return (
-                      <button
-                        key={entry.key}
-                        type="button"
-                        data-entry-index={index}
-                        className={`w-full flex items-center gap-3 px-3 py-2 rounded-medium text-left ${
-                          index === highlighted ? "bg-default-100" : ""
-                        }`}
-                        onMouseMove={() => setHighlighted(index)}
-                        onClick={entry.perform}
-                      >
-                        <Icon icon={entry.icon} width={18} className="text-default-500 shrink-0" />
-                        <span className="text-small truncate">{entry.label}</span>
-                        {entry.sublabel != null && (
-                          <span className="text-tiny text-default-400 truncate">
-                            {entry.sublabel}
-                          </span>
-                        )}
-                        {index === highlighted && (
-                          <Icon
-                            icon="solar:alt-arrow-right-linear"
-                            width={14}
-                            className="ml-auto text-default-400 shrink-0"
-                          />
-                        )}
-                      </button>
-                    );
-                  })}
-                </div>
-              );
-            })}
-            {showEmptyHint && (
-              <p className="px-3 py-6 text-center text-small text-default-400">
-                No matches for “{query.trim()}”
+    <div onKeyDown={handleKeyDown}>
+      <div className="flex items-center gap-2 px-4 pt-4 pb-2 border-b border-divider">
+        <Input
+          autoFocus
+          aria-label="Search pages, merchants, and deals"
+          placeholder="Search pages, merchants, deals…"
+          size="lg"
+          variant="flat"
+          value={query}
+          onValueChange={(value) => {
+            setQuery(value);
+            setHighlighted(0);
+          }}
+          startContent={
+            <Icon icon="solar:magnifer-linear" width={20} className="text-default-400" />
+          }
+          endContent={searching ? <Spinner size="sm" /> : <Kbd keys={["escape"]} />}
+        />
+      </div>
+      <ScrollShadow ref={listRef} className="max-h-[50vh] p-2">
+        {SECTIONS.map((section) => {
+          const sectionEntries = entries.filter((e) => e.section === section);
+          if (sectionEntries.length === 0) return null;
+          return (
+            <div key={section} className="mb-1">
+              <p className="px-2 py-1 text-tiny font-semibold uppercase text-default-400">
+                {section}
               </p>
-            )}
-            {entries.length === 0 && !showEmptyHint && (
-              <p className="px-3 py-6 text-center text-small text-default-400">
-                Type to search merchants and deals
-              </p>
-            )}
-          </ScrollShadow>
-          <div className="flex items-center gap-4 px-4 py-2 border-t border-divider text-tiny text-default-400">
-            <span className="flex items-center gap-1">
-              <Kbd keys={["up", "down"]} /> navigate
-            </span>
-            <span className="flex items-center gap-1">
-              <Kbd keys={["enter"]} /> open
-            </span>
-          </div>
-        </div>
-      </ModalContent>
-    </Modal>
+              {sectionEntries.map((entry) => {
+                const index = entries.indexOf(entry);
+                return (
+                  <button
+                    key={entry.key}
+                    type="button"
+                    data-entry-index={index}
+                    className={`w-full flex items-center gap-3 px-3 py-2 rounded-medium text-left ${
+                      index === activeIndex ? "bg-default-100" : ""
+                    }`}
+                    onMouseMove={() => setHighlighted(index)}
+                    onClick={entry.perform}
+                  >
+                    <Icon icon={entry.icon} width={18} className="text-default-500 shrink-0" />
+                    <span className="text-small truncate">{entry.label}</span>
+                    {entry.sublabel != null && (
+                      <span className="text-tiny text-default-400 truncate">{entry.sublabel}</span>
+                    )}
+                    {index === activeIndex && (
+                      <Icon
+                        icon="solar:alt-arrow-right-linear"
+                        width={14}
+                        className="ml-auto text-default-400 shrink-0"
+                      />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          );
+        })}
+        {showEmptyHint && (
+          <p className="px-3 py-6 text-center text-small text-default-400">
+            No matches for “{query.trim()}”
+          </p>
+        )}
+        {entries.length === 0 && !showEmptyHint && (
+          <p className="px-3 py-6 text-center text-small text-default-400">
+            Type to search merchants and deals
+          </p>
+        )}
+      </ScrollShadow>
+      <div className="flex items-center gap-4 px-4 py-2 border-t border-divider text-tiny text-default-400">
+        <span className="flex items-center gap-1">
+          <Kbd keys={["up", "down"]} /> navigate
+        </span>
+        <span className="flex items-center gap-1">
+          <Kbd keys={["enter"]} /> open
+        </span>
+      </div>
+    </div>
   );
 }

--- a/src/components/command-palette/command-palette.tsx
+++ b/src/components/command-palette/command-palette.tsx
@@ -1,0 +1,243 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Input, Kbd, Modal, ModalContent, ScrollShadow, Spinner } from "@heroui/react";
+import { Icon } from "@iconify/react";
+import { useAuth } from "@/contexts/auth-context-value";
+import { items, usersItem, settingsItem } from "@features/sidebar/sidebar-items";
+import {
+  searchPalette,
+  EMPTY_RESULTS,
+  type PaletteSearchResults,
+} from "@services/command-search-service";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface PaletteEntry {
+  key: string;
+  section: "Pages" | "Merchants" | "Deals";
+  label: string;
+  sublabel?: string;
+  icon: string;
+  perform: () => void;
+}
+
+const SEARCH_DEBOUNCE_MS = 200;
+const MIN_QUERY_LENGTH = 2;
+
+/**
+ * Global Cmd+K palette: jump to any page, or search merchants and deals and
+ * land on Deal Lookup pre-filtered to the selection.
+ */
+export function CommandPalette({ isOpen, onClose }: Props) {
+  const navigate = useNavigate();
+  const { profile } = useAuth();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<PaletteSearchResults>(EMPTY_RESULTS);
+  const [searching, setSearching] = useState(false);
+  const [highlighted, setHighlighted] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  /** Guards against out-of-order responses from overlapping searches. */
+  const requestIdRef = useRef(0);
+
+  // Start from a clean slate on every open.
+  useEffect(() => {
+    if (isOpen) {
+      setQuery("");
+      setResults(EMPTY_RESULTS);
+      setHighlighted(0);
+    }
+  }, [isOpen]);
+
+  // Debounced merchant/deal search.
+  useEffect(() => {
+    if (!isOpen) return;
+    const trimmed = query.trim();
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      setResults(EMPTY_RESULTS);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    const requestId = ++requestIdRef.current;
+    const timer = setTimeout(() => {
+      searchPalette(trimmed)
+        .then((res) => {
+          if (requestIdRef.current !== requestId) return;
+          setResults(res);
+          setSearching(false);
+        })
+        .catch(() => {
+          if (requestIdRef.current !== requestId) return;
+          setResults(EMPTY_RESULTS);
+          setSearching(false);
+        });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [query, isOpen]);
+
+  const goTo = useCallback(
+    (path: string, state?: { dealLookupSearch: string }) => {
+      onClose();
+      navigate(path, state != null ? { state } : undefined);
+    },
+    [onClose, navigate]
+  );
+
+  const entries = useMemo<PaletteEntry[]>(() => {
+    const pages = [...items, ...(profile?.role === "admin" ? [usersItem] : []), settingsItem];
+    const needle = query.trim().toLowerCase();
+    const pageEntries: PaletteEntry[] = pages
+      .filter((p) => !needle || p.title.toLowerCase().includes(needle))
+      .map((p) => ({
+        key: `page-${p.key}`,
+        section: "Pages",
+        label: p.title,
+        icon: p.icon ?? "solar:document-linear",
+        perform: () => goTo(`/${p.key}`),
+      }));
+    const merchantEntries: PaletteEntry[] = results.merchants.map((m) => ({
+      key: `merchant-${m.id}`,
+      section: "Merchants",
+      label: m.name,
+      icon: "solar:shop-2-linear",
+      perform: () => goTo("/deal-lookup", { dealLookupSearch: m.name }),
+    }));
+    const dealEntries: PaletteEntry[] = results.deals.flatMap((d) => {
+      if (!d.searchValue) return [];
+      return [
+        {
+          key: `deal-${d.id}`,
+          section: "Deals",
+          label: d.funderAdvanceId ?? d.merchantName ?? "Deal",
+          sublabel: d.funderAdvanceId != null ? (d.merchantName ?? undefined) : undefined,
+          icon: "solar:document-text-linear",
+          perform: () => goTo("/deal-lookup", { dealLookupSearch: d.searchValue }),
+        },
+      ];
+    });
+    return [...pageEntries, ...merchantEntries, ...dealEntries];
+  }, [query, results, profile?.role, goTo]);
+
+  // Keep the highlight on a real row as the list grows/shrinks.
+  useEffect(() => {
+    setHighlighted((h) => Math.min(h, Math.max(entries.length - 1, 0)));
+  }, [entries]);
+
+  useEffect(() => {
+    listRef.current
+      ?.querySelector(`[data-entry-index="${highlighted}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [highlighted]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlighted((h) => (entries.length === 0 ? 0 : (h + 1) % entries.length));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlighted((h) => (entries.length === 0 ? 0 : (h - 1 + entries.length) % entries.length));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      entries[highlighted]?.perform();
+    }
+  };
+
+  const sections: PaletteEntry["section"][] = ["Pages", "Merchants", "Deals"];
+  const showEmptyHint =
+    !searching && entries.length === 0 && query.trim().length >= MIN_QUERY_LENGTH;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => !open && onClose()}
+      placement="top"
+      size="xl"
+      hideCloseButton
+      classNames={{ base: "mt-[10vh]" }}
+    >
+      <ModalContent>
+        <div onKeyDown={handleKeyDown}>
+          <div className="flex items-center gap-2 px-4 pt-4 pb-2 border-b border-divider">
+            <Input
+              autoFocus
+              aria-label="Search pages, merchants, and deals"
+              placeholder="Search pages, merchants, deals…"
+              size="lg"
+              variant="flat"
+              value={query}
+              onValueChange={setQuery}
+              startContent={
+                <Icon icon="solar:magnifer-linear" width={20} className="text-default-400" />
+              }
+              endContent={searching ? <Spinner size="sm" /> : <Kbd keys={["escape"]} />}
+            />
+          </div>
+          <ScrollShadow ref={listRef} className="max-h-[50vh] p-2">
+            {sections.map((section) => {
+              const sectionEntries = entries.filter((e) => e.section === section);
+              if (sectionEntries.length === 0) return null;
+              return (
+                <div key={section} className="mb-1">
+                  <p className="px-2 py-1 text-tiny font-semibold uppercase text-default-400">
+                    {section}
+                  </p>
+                  {sectionEntries.map((entry) => {
+                    const index = entries.indexOf(entry);
+                    return (
+                      <button
+                        key={entry.key}
+                        type="button"
+                        data-entry-index={index}
+                        className={`w-full flex items-center gap-3 px-3 py-2 rounded-medium text-left ${
+                          index === highlighted ? "bg-default-100" : ""
+                        }`}
+                        onMouseMove={() => setHighlighted(index)}
+                        onClick={entry.perform}
+                      >
+                        <Icon icon={entry.icon} width={18} className="text-default-500 shrink-0" />
+                        <span className="text-small truncate">{entry.label}</span>
+                        {entry.sublabel != null && (
+                          <span className="text-tiny text-default-400 truncate">
+                            {entry.sublabel}
+                          </span>
+                        )}
+                        {index === highlighted && (
+                          <Icon
+                            icon="solar:alt-arrow-right-linear"
+                            width={14}
+                            className="ml-auto text-default-400 shrink-0"
+                          />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              );
+            })}
+            {showEmptyHint && (
+              <p className="px-3 py-6 text-center text-small text-default-400">
+                No matches for “{query.trim()}”
+              </p>
+            )}
+            {entries.length === 0 && !showEmptyHint && (
+              <p className="px-3 py-6 text-center text-small text-default-400">
+                Type to search merchants and deals
+              </p>
+            )}
+          </ScrollShadow>
+          <div className="flex items-center gap-4 px-4 py-2 border-t border-divider text-tiny text-default-400">
+            <span className="flex items-center gap-1">
+              <Kbd keys={["up", "down"]} /> navigate
+            </span>
+            <span className="flex items-center gap-1">
+              <Kbd keys={["enter"]} /> open
+            </span>
+          </div>
+        </div>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/hooks/use-deal-lookup.ts
+++ b/src/hooks/use-deal-lookup.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useToast } from "@/contexts/toast-context-value";
 import { formatMoney } from "@services/analytics-service";
 import {
@@ -142,6 +143,18 @@ export function useDealLookup() {
   useEffect(fetchRecords, [fetchRecords]);
   useEffect(fetchLookups, [fetchLookups]);
   useEffect(fetchUnresolved, [fetchUnresolved]);
+
+  // The command palette lands here with a search term in router state. Apply
+  // it over clean filters, then clear the state so back/refresh don't reapply.
+  const location = useLocation();
+  const navigate = useNavigate();
+  useEffect(() => {
+    const state = location.state as { dealLookupSearch?: string } | null;
+    if (state?.dealLookupSearch == null) return;
+    setFilters({ ...EMPTY_FILTERS, search: state.dealLookupSearch });
+    setActiveViewId(null);
+    navigate(location.pathname, { replace: true, state: null });
+  }, [location.state, location.pathname, navigate]);
 
   const openCreate = () => {
     setEditing(null);

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -5,7 +5,8 @@ import { items, usersItem, settingsItem } from "@features/sidebar/sidebar-items"
 import { useAuth } from "@/contexts/auth-context-value";
 import { UserMenu } from "@components/auth/user-menu";
 import ErrorBoundary from "@components/error-boundary";
-import { useEffect, useState, useRef } from "react";
+import { CommandPalette } from "@components/command-palette/command-palette";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { Icon } from "@iconify/react";
 import { useTheme } from "@/contexts/theme-context-value";
 
@@ -22,6 +23,20 @@ function Layout() {
   });
   const navigationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isNavigatingRef = useRef(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const closePalette = useCallback(() => setPaletteOpen(false), []);
+
+  // Cmd+K (Ctrl+K on Windows/Linux) toggles the command palette from anywhere.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setPaletteOpen((open) => !open);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   useEffect(() => {
     const path = location.pathname === "/" ? "/dashboard" : location.pathname;
@@ -199,6 +214,7 @@ function Layout() {
           <Outlet />
         </ErrorBoundary>
       </div>
+      <CommandPalette isOpen={paletteOpen} onClose={closePalette} />
     </div>
   );
 }

--- a/src/services/command-search-service.ts
+++ b/src/services/command-search-service.ts
@@ -1,0 +1,121 @@
+import { supabase } from "./supabase";
+
+export interface MerchantHit {
+  id: string;
+  name: string;
+}
+
+export interface DealHit {
+  id: string;
+  funderAdvanceId: string | null;
+  merchantName: string | null;
+  /** Value to seed the Deal Lookup search box with. */
+  searchValue: string;
+}
+
+export interface PaletteSearchResults {
+  merchants: MerchantHit[];
+  deals: DealHit[];
+}
+
+export const EMPTY_RESULTS: PaletteSearchResults = { merchants: [], deals: [] };
+
+const MERCHANT_LIMIT = 6;
+const DEAL_LIMIT = 8;
+
+/**
+ * Escape LIKE wildcards, and drop characters that are PostgREST `or()` syntax
+ * (commas, parens) so user input can't break the filter expression.
+ */
+function toLikePattern(query: string): string {
+  return `%${query.replace(/[,()]/g, "").replace(/[\\%_]/g, "\\$&")}%`;
+}
+
+interface DealRow {
+  id: string;
+  funder_advance_id: string | null;
+  advance_id: string | null;
+  merchant_id: string | null;
+}
+
+/**
+ * Search merchants by name and deals by advance ID or merchant name.
+ * RLS scopes both tables, so results only cover what the user can see.
+ */
+export async function searchPalette(query: string): Promise<PaletteSearchResults> {
+  const trimmed = query.trim();
+  if (!trimmed) return EMPTY_RESULTS;
+  const pattern = toLikePattern(trimmed);
+
+  const [merchantsRes, dealsByIdRes] = await Promise.all([
+    supabase
+      .from("merchants")
+      .select("id, name")
+      .eq("is_deleted", false)
+      .ilike("name", pattern)
+      .order("name")
+      .limit(MERCHANT_LIMIT),
+    supabase
+      .from("deals")
+      .select("id, funder_advance_id, advance_id, merchant_id")
+      .eq("is_deleted", false)
+      .or(`funder_advance_id.ilike.${pattern},advance_id.ilike.${pattern}`)
+      .limit(DEAL_LIMIT),
+  ]);
+
+  if (merchantsRes.error) throw new Error(merchantsRes.error.message);
+  if (dealsByIdRes.error) throw new Error(dealsByIdRes.error.message);
+
+  const merchants: MerchantHit[] = merchantsRes.data ?? [];
+  const dealRows: DealRow[] = dealsByIdRes.data ?? [];
+
+  // Deals whose merchant matched by name (so "Acme" surfaces Acme's deals too).
+  if (merchants.length > 0 && dealRows.length < DEAL_LIMIT) {
+    const { data, error } = await supabase
+      .from("deals")
+      .select("id, funder_advance_id, advance_id, merchant_id")
+      .eq("is_deleted", false)
+      .in(
+        "merchant_id",
+        merchants.map((m) => m.id)
+      )
+      .limit(DEAL_LIMIT);
+    if (error) throw new Error(error.message);
+    const seen = new Set(dealRows.map((d) => d.id));
+    for (const row of data ?? []) {
+      if (!seen.has(row.id) && dealRows.length < DEAL_LIMIT) dealRows.push(row);
+    }
+  }
+
+  // Resolve merchant names for deal hits not already covered by the name search.
+  const namesById = new Map(merchants.map((m) => [m.id, m.name]));
+  const missingIds = [
+    ...new Set(
+      dealRows.flatMap((d) =>
+        d.merchant_id != null && !namesById.has(d.merchant_id) ? [d.merchant_id] : []
+      )
+    ),
+  ];
+  if (missingIds.length > 0) {
+    const { data, error } = await supabase
+      .from("merchants")
+      .select("id, name")
+      .in("id", missingIds);
+    if (error) throw new Error(error.message);
+    for (const m of data ?? []) namesById.set(m.id, m.name);
+  }
+
+  const deals: DealHit[] = dealRows.map((d) => {
+    const merchantName = d.merchant_id != null ? (namesById.get(d.merchant_id) ?? null) : null;
+    return {
+      id: d.id,
+      funderAdvanceId: d.funder_advance_id,
+      merchantName,
+      // funder_advance_id is what Deal Lookup's free-text search matches on;
+      // fall back to the merchant name for deals without one.
+      searchValue: d.funder_advance_id ?? merchantName ?? "",
+    };
+  });
+
+  return { merchants, deals };
+}


### PR DESCRIPTION
## Summary
Implements #61 — a global Cmd+K (Ctrl+K on Windows/Linux) palette to jump to any page, merchant, or deal from anywhere in the app.

- **Pages** section lists the sidebar routes (plus Settings, and User Management for admins), filtered as you type
- **Merchants / Deals** sections search Supabase with debounced `ilike` queries (merchant name, funder/internal advance ID, and deals belonging to name-matched merchants); RLS scopes results
- Selecting a merchant or deal opens Deal Lookup pre-filtered via router state (`use-deal-lookup` seeds `filters.search` and clears the state so back/refresh don't reapply)
- Keyboard-first: ⌘K toggles, arrows navigate (wrapping), Enter opens, Esc closes

## Verification
- `npm run lint`, `format:check`, `build`, and `vitest` (64 tests) all pass
- Driven end-to-end in a browser against the local Supabase stack with Playwright: open/toggle/esc from multiple pages, page filtering + Enter navigation, merchant and advance-ID search with seeded rows, and both selection paths landing on Deal Lookup correctly pre-filtered

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)